### PR TITLE
fix: resolve security vulnerabilities in auth and users module

### DIFF
--- a/apps/server/src/auth/auth.controller.ts
+++ b/apps/server/src/auth/auth.controller.ts
@@ -6,9 +6,14 @@ import {
   ApiResponse,
   ApiQuery,
   ApiBody,
+  ApiBearerAuth,
 } from '@nestjs/swagger';
 
 import { AuthService } from './auth.service';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { RolesGuard } from './guards/roles-auth.guard';
+import { Roles } from './decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
 
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register-dto';
@@ -60,9 +65,15 @@ export class AuthController {
 
   @Post('register/admin')
   @Throttle({ short: { ttl: 60000, limit: 5 } })
-  @ApiOperation({ summary: 'Cadastrar administrador', description: 'Cria uma conta com perfil de administrador do sistema.' })
+  @ApiBearerAuth('access-token')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Cadastrar administrador', description: 'Cria uma conta com perfil de administrador do sistema. Requer autenticação e role ADMIN.' })
   @ApiBody({ type: RegisterAdminDto })
   @ApiResponse({ status: 201, description: 'Administrador cadastrado com sucesso.' })
+  @ApiResponse({ status: 400, description: 'Dados inválidos.' })
+  @ApiResponse({ status: 401, description: 'Não autenticado.' })
+  @ApiResponse({ status: 403, description: 'Acesso negado — somente ADMIN.' })
   @ApiResponse({ status: 409, description: 'E-mail já cadastrado.' })
   @ApiResponse({ status: 400, description: 'Dados inválidos.' })
   async registerAdmin(@Body() dto: RegisterAdminDto) {

--- a/apps/server/src/users/guards/resource-ownership.guard.ts
+++ b/apps/server/src/users/guards/resource-ownership.guard.ts
@@ -1,0 +1,30 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { UserRole } from '@prisma/client';
+
+@Injectable()
+export class ResourceOwnershipGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const { user } = request;
+    const { id } = request.params;
+
+    if (!user) {
+      return false;
+    }
+
+    if (user.role === UserRole.ADMIN) {
+      return true;
+    }
+
+    if (user.id !== id && user.userId !== id) {
+      throw new ForbiddenException('Usuario não possui permissão para editar este usuário',);
+    }
+
+    return true;
+  }
+}

--- a/apps/server/src/users/users.controller.ts
+++ b/apps/server/src/users/users.controller.ts
@@ -24,6 +24,7 @@ import { VerifyUserDto } from './dto/verify-user.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { EmailVerifiedGuard } from '../auth/guards/email-verified.guard';
 import { RolesGuard } from '../auth/guards/roles-auth.guard';
+import { ResourceOwnershipGuard } from './guards/resource-ownership.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { extname } from 'path';
@@ -36,7 +37,7 @@ import { UserRole } from '@prisma/client';
 @UseGuards(JwtAuthGuard)
 @Controller('users')
 export class UsersController {
-  constructor(private readonly usersService: UsersService) { }
+  constructor(private readonly usersService: UsersService) {}
 
   @Get('me')
   @UseGuards(EmailVerifiedGuard)
@@ -89,10 +90,12 @@ export class UsersController {
   }
 
   @Get('patients')
-  @UseGuards(EmailVerifiedGuard)
-  @ApiOperation({ summary: 'Listar todos os pacientes' })
+  @UseGuards(EmailVerifiedGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({summary: 'Listar todos os pacientes (Admin)',description:'Somente administradores podem listar todos os pacientes do sistema.' })
   @ApiResponse({ status: 200, description: 'Lista de pacientes.' })
   @ApiResponse({ status: 401, description: 'Não autenticado.' })
+  @ApiResponse({ status: 403, description: 'Acesso negado — somente ADMIN.' })
   listPatients() {
     return this.usersService.findAllPatients();
   }
@@ -111,21 +114,24 @@ export class UsersController {
   }
 
   @Patch(':id')
-  @UseGuards(EmailVerifiedGuard)
+  @UseGuards(EmailVerifiedGuard, ResourceOwnershipGuard)
   @ApiOperation({ summary: 'Atualizar dados de um usuário por ID' })
   @ApiParam({ name: 'id', description: 'ID do usuário (UUID)' })
   @ApiBody({ type: UpdateUserDto })
   @ApiResponse({ status: 200, description: 'Usuário atualizado com sucesso.' })
+  @ApiResponse({status: 403, description: 'Acesso negado — somente o próprio usuário ou ADMIN pode editar.' })
   @ApiResponse({ status: 404, description: 'Usuário não encontrado.' })
   updateUserStatus(@Param('id') id: string, @Body() dto: UpdateUserDto) {
     return this.usersService.update(id, dto);
   }
 
   @Get(':id')
-  @UseGuards(EmailVerifiedGuard)
+  @UseGuards(EmailVerifiedGuard, ResourceOwnershipGuard)
   @ApiOperation({ summary: 'Buscar usuário por ID' })
   @ApiParam({ name: 'id', description: 'ID do usuário (UUID)' })
   @ApiResponse({ status: 200, description: 'Dados do usuário.' })
+  @ApiResponse({status: 401,description: 'Não autenticado ou email não verificado.' })
+  @ApiResponse({status: 403,description: 'Acesso negado — somente o próprio usuário ou ADMIN pode visualizar.'})
   @ApiResponse({ status: 404, description: 'Usuário não encontrado.' })
   getUserbyId(@Param('id') id: string) {
     return this.usersService.findOne(id);


### PR DESCRIPTION
### Correções de Segurança — Auth e Users

### Problemas resolvidos
- **PatientRoleGuard** — corrigido para restringir endpoints de 
  exportação de PDF apenas para PATIENT
- **POST /auth/register/admin sem proteção** — adicionado JwtAuthGuard + 
  RolesGuard, apenas ADMIN pode criar novos admins
- **PATCH /users/:id sem ownership check** — criado ResourceOwnershipGuard, 
  usuário só edita seus próprios dados (ADMIN pode editar qualquer um)
- **GET /users/patients sem restrição** — restringido para ADMIN via RolesGuard
- **GET /users/:id sem restrição** — adicionado ResourceOwnershipGuard, 
  usuário só acessa seus próprios dados