### PR TITLE
fix(manager): corrige build do gestor e padroniza fluxo de endereço

### DIFF
--- a/apps/server/src/patients/patients.service.ts
+++ b/apps/server/src/patients/patients.service.ts
@@ -264,6 +264,7 @@ export class PatientsService {
       },
       include: {
         patientProfile: true,
+        address: true,
       },
     });
 
@@ -275,7 +276,7 @@ export class PatientsService {
       phone: updatedUser.patientProfile?.phone,
       dateOfBirth: updatedUser.patientProfile?.dateOfBirth,
       gender: updatedUser.patientProfile?.gender,
-      address: updatedUser.patientProfile?.address,
+      address: updatedUser.address,
       patientProfile: updatedUser.patientProfile,
     };
   }

--- a/apps/web/app/auth/register-manager/register-manager.validation.ts
+++ b/apps/web/app/auth/register-manager/register-manager.validation.ts
@@ -18,7 +18,6 @@ export const registerManagerSchema = z.object({
     .string()
     .min(1, 'Telefone é obrigatório')
     .regex(/^\+[1-9]\d{6,14}$/, 'Telefone deve estar no formato internacional (ex: +5571999999999)'),
-  address: z.string().max(255, 'Endereço deve ter no máximo 255 caracteres').optional().or(z.literal('')),
   bio: z.string().max(500, 'Bio deve ter no máximo 500 caracteres').optional().or(z.literal('')),
 });
 

--- a/apps/web/app/dashboard/admin/register-manager/page.tsx
+++ b/apps/web/app/dashboard/admin/register-manager/page.tsx
@@ -25,7 +25,6 @@ export default function RegisterManagerPage() {
       cpf: "",
       password: "",
       phone: "",
-      address: "",
       bio: "",
     },
   });
@@ -46,7 +45,6 @@ export default function RegisterManagerPage() {
         cpf: data.cpf.replace(/\D/g, ""),
         password: data.password,
         phone: data.phone.trim(),
-        address: data.address?.trim() || undefined,
         bio: data.bio?.trim() || undefined,
       });
 
@@ -107,22 +105,14 @@ export default function RegisterManagerPage() {
               </div>
             </div>
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <PasswordField
-                name="password"
-                label="Senha inicial"
-                register={register}
-                errors={errors}
-                showStrengthMeter
-                currentValue={watch("password")}
-              />
-
-              <div className="space-y-1.5">
-                <Label htmlFor="address">Endereço (opcional)</Label>
-                <Input id="address" placeholder="Av. Sete de Setembro, 500" {...register("address")} />
-                {errors.address && <p className="text-xs text-red-600">{errors.address.message}</p>}
-              </div>
-            </div>
+            <PasswordField
+              name="password"
+              label="Senha inicial"
+              register={register}
+              errors={errors}
+              showStrengthMeter
+              currentValue={watch("password")}
+            />
 
             <div className="space-y-1.5">
               <Label htmlFor="bio">Bio (opcional)</Label>

--- a/apps/web/app/dashboard/manager/patients/[id]/page.tsx
+++ b/apps/web/app/dashboard/manager/patients/[id]/page.tsx
@@ -51,7 +51,10 @@ export default function PatientDetailsPage() {
         dateOfBirth: patient.dateOfBirth
           ? String(patient.dateOfBirth).split("T")[0]
           : "",
-        gender: (patient.gender as string) || "",
+        gender: (patient.gender as EditPatientSchema["gender"]) || "",
+      });
+    }
+  }, [patient, reset]);
 
   const onSubmit = async (data: EditPatientSchema) => {
     try {
@@ -88,7 +91,11 @@ export default function PatientDetailsPage() {
         dateOfBirth: patient.dateOfBirth
           ? String(patient.dateOfBirth).split("T")[0]
           : "",
-        gender: (patient.gender as string) || "",
+        gender: (patient.gender as EditPatientSchema["gender"]) || "",
+      });
+    }
+    setIsEditing(false);
+  };
 
   const handleCpfChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.target.value = applyCpfMask(e.target.value);
@@ -164,7 +171,9 @@ export default function PatientDetailsPage() {
                 }
                 variant={isEditing ? "outline" : "default"}
                 title={
-                  isEditing ? "Cancelar alterações" : "Habilitar modo de edição"
+                  isEditing
+                    ? "Cancelar alterações"
+                    : "Habilitar modo de edição"
                 }
                 disabled={isSaving}
               >
@@ -173,295 +182,296 @@ export default function PatientDetailsPage() {
             </div>
 
             <form onSubmit={handleSubmit(onSubmit)}>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div className="flex flex-col gap-2">
-                  <label
-                    htmlFor="name"
-                    className="text-sm font-medium text-gray-700"
-                  >
-                    Nome Completo
-                  </label>
-                  <input
-                    id="name"
-                    {...register("name")}
-                    disabled={!isEditing}
-                    className={`w-full px-4 py-2 border border-gray-300 rounded-lg transition-colors ${
-                      isEditing ? "bg-white" : "bg-gray-50 text-gray-500"
-                    }`}
-                    title="Nome do paciente"
-                  />
-                  {errors.name && (
-                    <p className="text-xs text-red-600">
-                      {errors.name.message}
-                    </p>
-                  )}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div className="flex flex-col gap-2">
+                    <label
+                      htmlFor="name"
+                      className="text-sm font-medium text-gray-700"
+                    >
+                      Nome Completo
+                    </label>
+                    <input
+                      id="name"
+                      {...register("name")}
+                      disabled={!isEditing}
+                      className={`w-full px-4 py-2 border border-gray-300 rounded-lg transition-colors ${
+                        isEditing ? "bg-white" : "bg-gray-50 text-gray-500"
+                      }`}
+                      title="Nome do paciente"
+                    />
+                    {errors.name && (
+                      <p className="text-xs text-red-600">
+                        {errors.name.message}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="flex flex-col gap-2">
+                    <label
+                      htmlFor="cpf"
+                      className="text-sm font-medium text-gray-700"
+                    >
+                      CPF
+                    </label>
+                    <input
+                      id="cpf"
+                      {...register("cpf", {
+                        onChange: handleCpfChange,
+                      })}
+                      disabled={!isEditing}
+                      placeholder="000.000.000-00"
+                      maxLength={14}
+                      className={`w-full px-4 py-2 border border-gray-300 rounded-lg transition-colors ${
+                        isEditing ? "bg-white" : "bg-gray-50 text-gray-500"
+                      }`}
+                      title="CPF do paciente"
+                    />
+                    {errors.cpf && (
+                      <p className="text-xs text-red-600">
+                        {errors.cpf.message}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="flex flex-col gap-2">
+                    <label
+                      htmlFor="email"
+                      className="text-sm font-medium text-gray-700"
+                    >
+                      Email
+                    </label>
+                    <input
+                      id="email"
+                      type="email"
+                      {...register("email")}
+                      disabled={!isEditing}
+                      className={`w-full px-4 py-2 border border-gray-300 rounded-lg transition-colors ${
+                        isEditing ? "bg-white" : "bg-gray-50 text-gray-500"
+                      }`}
+                    />
+                    {errors.email && (
+                      <p className="text-xs text-red-600">
+                        {errors.email.message}
+                      </p>
+                    )}
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">
+                      Telefone
+                    </label>
+                    <Controller
+                      name="phone"
+                      control={control}
+                      render={({ field }) => {
+                        let safeValue = field.value
+                          ? field.value.replace(/[^\d+]/g, "")
+                          : "";
+
+                        if (safeValue && !safeValue.startsWith("+")) {
+                          safeValue = `+55${safeValue}`;
+                        }
+
+                        return (
+                          <PhoneInput
+                            id="phone"
+                            placeholder="(71) 99999-9999"
+                            international
+                            countryCallingCodeEditable={false}
+                            labels={ptBr}
+                            defaultCountry="BR"
+                            value={safeValue || undefined}
+                            onChange={(val) => field.onChange(val || "")}
+                            onBlur={field.onBlur}
+                            ref={field.ref}
+                            disabled={!isEditing}
+                            className={`w-full flex items-center border border-gray-300 rounded-lg overflow-hidden transition-colors duration-200 focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-blue-500 ${
+                              !isEditing ? "bg-gray-50" : "bg-white"
+                            } [&_.PhoneInputCountry]:max-w-[40%] [&_.PhoneInputCountry]:px-3 [&_.PhoneInputCountry]:flex [&_.PhoneInputCountry]:flex-row-reverse [&_.PhoneInputCountry]:items-center [&_.PhoneInputCountry]:justify-start [&_.PhoneInputCountry]:gap-1 [&_.PhoneInputCountry]:border-r [&_.PhoneInputCountry]:border-gray-300 [&_.PhoneInputCountrySelect]:max-w-[80%] [&_.PhoneInputCountryIcon]:w-5 [&_.PhoneInputCountryIcon]:h-[14px] [&_.PhoneInputCountryIcon]:flex [&_.PhoneInputCountryIcon]:justify-center [&_.PhoneInputCountryIcon]:items-center [&_.PhoneInputCountryIcon]:overflow-hidden [&_.PhoneInputCountryIcon_img]:w-full [&_.PhoneInputCountryIcon_img]:h-full [&_.PhoneInputCountryIcon_img]:object-cover [&_.PhoneInputInput]:h-full [&_.PhoneInputInput]:py-2 [&_.PhoneInputInput]:px-4 [&_.PhoneInputInput]:flex-1 [&_.PhoneInputInput]:border-none [&_.PhoneInputInput]:text-base [&_.PhoneInputInput]:text-gray-700 [&_.PhoneInputInput]:bg-transparent [&_.PhoneInputInput]:outline-none [&_.PhoneInputInput:disabled]:text-gray-500 [&_.PhoneInputInput:disabled]:cursor-not-allowed`}
+                          />
+                        );
+                      }}
+                    />
+                    {errors.phone && (
+                      <p className="text-xs text-red-600 mt-1">
+                        {errors.phone.message}
+                      </p>
+                    )}
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="dateOfBirth"
+                      className="block text-sm font-medium text-gray-700 mb-2"
+                    >
+                      Data de Nascimento
+                    </label>
+                    <input
+                      id="dateOfBirth"
+                      type="date"
+                      disabled={!isEditing}
+                      className={`w-full px-4 py-2 border border-gray-300 rounded-lg transition-colors ${
+                        isEditing ? "bg-white" : "bg-gray-50 text-gray-700"
+                      }`}
+                      {...register("dateOfBirth")}
+                    />
+                    {errors.dateOfBirth && (
+                      <p className="text-xs text-red-600 mt-1">
+                        {errors.dateOfBirth.message}
+                      </p>
+                    )}
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="gender"
+                      className="block text-sm font-medium text-gray-700 mb-2"
+                    >
+                      Gênero
+                    </label>
+                    <select
+                      id="gender"
+                      disabled={!isEditing}
+                      className={`w-full px-4 py-2 border border-gray-300 rounded-lg transition-colors ${
+                        isEditing ? "bg-white" : "bg-gray-50 text-gray-700"
+                      }`}
+                      {...register("gender")}
+                    >
+                      <option value="">Selecione...</option>
+                      <option value="Masculino">Masculino</option>
+                      <option value="Feminino">Feminino</option>
+                      <option value="Outro">Outro</option>
+                      <option value="Prefiro não informar">
+                        Prefiro não informar
+                      </option>
+                    </select>
+                    {errors.gender && (
+                      <p className="text-xs text-red-600 mt-1">
+                        {errors.gender.message}
+                      </p>
+                    )}
+                  </div>
                 </div>
 
-                <div className="flex flex-col gap-2">
-                  <label
-                    htmlFor="cpf"
-                    className="text-sm font-medium text-gray-700"
-                  >
-                    CPF
-                  </label>
-                  <input
-                    id="cpf"
-                    {...register("cpf", {
-                      onChange: handleCpfChange,
-                    })}
-                    disabled={!isEditing}
-                    placeholder="000.000.000-00"
-                    maxLength={14}
-                    className={`w-full px-4 py-2 border border-gray-300 rounded-lg transition-colors ${
-                      isEditing ? "bg-white" : "bg-gray-50 text-gray-500"
-                    }`}
-                    title="CPF do paciente"
-                  />
-                  {errors.cpf && (
-                    <p className="text-xs text-red-600">{errors.cpf.message}</p>
-                  )}
-                </div>
+                {isEditing && (
+                  <div className="flex gap-4 mt-6">
+                    <Button
+                      type="submit"
+                      disabled={isSaving}
+                      className="flex-1 bg-green-600 hover:bg-green-700"
+                      title="Confirmar e salvar as alterações realizadas"
+                    >
+                      {isSaving ? "Salvando..." : "Salvar Alterações"}
+                    </Button>
+                    <Button
+                      type="button"
+                      onClick={handleCancelEdit}
+                      variant="outline"
+                      className="flex-1"
+                      title="Descartar alterações e voltar para visualização"
+                    >
+                      Cancelar
+                    </Button>
+                  </div>
+                )}
+              </form>
+            </CardContent>
+          </Card>
 
-                <div className="flex flex-col gap-2">
-                  <label
-                    htmlFor="email"
-                    className="text-sm font-medium text-gray-700"
-                  >
-                    Email
-                  </label>
-                  <input
-                    id="email"
-                    type="email"
-                    {...register("email")}
-                    disabled={!isEditing}
-                    className={`w-full px-4 py-2 border border-gray-300 rounded-lg transition-colors ${
-                      isEditing ? "bg-white" : "bg-gray-50 text-gray-500"
-                    }`}
-                  />
-                  {errors.email && (
-                    <p className="text-xs text-red-600">
-                      {errors.email.message}
-                    </p>
-                  )}
-                </div>
+          <Card className="bg-white mb-4">
+            <CardContent className="p-8">
+              <AddressForm userId={patient?.id || ""} />
+            </CardContent>
+          </Card>
 
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Telefone
-                  </label>
-                  <Controller
-                    name="phone"
-                    control={control}
-                    render={({ field }) => {
-                      let safeValue = field.value
-                        ? field.value.replace(/[^\d+]/g, "")
-                        : "";
-
-                      if (safeValue && !safeValue.startsWith("+")) {
-                        safeValue = `+55${safeValue}`;
-                      }
-
-                      return (
-                        <PhoneInput
-                          id="phone"
-                          placeholder="(71) 99999-9999"
-                          international
-                          countryCallingCodeEditable={false}
-                          labels={ptBr}
-                          defaultCountry="BR"
-                          value={safeValue || undefined}
-                          onChange={(val) => field.onChange(val || "")}
-                          onBlur={field.onBlur}
-                          ref={field.ref}
-                          disabled={!isEditing}
-                          className={`w-full flex items-center border border-gray-300 rounded-lg overflow-hidden transition-colors duration-200 focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-blue-500 ${
-                            !isEditing ? "bg-gray-50" : "bg-white"
-                          } [&_.PhoneInputCountry]:max-w-[40%] [&_.PhoneInputCountry]:px-3 [&_.PhoneInputCountry]:flex [&_.PhoneInputCountry]:flex-row-reverse [&_.PhoneInputCountry]:items-center [&_.PhoneInputCountry]:justify-start [&_.PhoneInputCountry]:gap-1 [&_.PhoneInputCountry]:border-r [&_.PhoneInputCountry]:border-gray-300 [&_.PhoneInputCountrySelect]:max-w-[80%] [&_.PhoneInputCountryIcon]:w-5 [&_.PhoneInputCountryIcon]:h-[14px] [&_.PhoneInputCountryIcon]:flex [&_.PhoneInputCountryIcon]:justify-center [&_.PhoneInputCountryIcon]:items-center [&_.PhoneInputCountryIcon]:overflow-hidden [&_.PhoneInputCountryIcon_img]:w-full [&_.PhoneInputCountryIcon_img]:h-full [&_.PhoneInputCountryIcon_img]:object-cover [&_.PhoneInputInput]:h-full [&_.PhoneInputInput]:py-2 [&_.PhoneInputInput]:px-4 [&_.PhoneInputInput]:flex-1 [&_.PhoneInputInput]:border-none [&_.PhoneInputInput]:text-base [&_.PhoneInputInput]:text-gray-700 [&_.PhoneInputInput]:bg-transparent [&_.PhoneInputInput]:outline-none [&_.PhoneInputInput:disabled]:text-gray-500 [&_.PhoneInputInput:disabled]:cursor-not-allowed`}
-                        />
-                      );
-                    }}
-                  />
-                  {errors.phone && (
-                    <p className="text-xs text-red-600 mt-1">
-                      {errors.phone.message}
-                    </p>
-                  )}
-                </div>
-
-                <div>
-                  <label
-                    htmlFor="dateOfBirth"
-                    className="block text-sm font-medium text-gray-700 mb-2"
-                  >
-                    Data de Nascimento
-                  </label>
-                  <input
-                    id="dateOfBirth"
-                    type="date"
-                    disabled={!isEditing}
-                    className={`w-full px-4 py-2 border border-gray-300 rounded-lg transition-colors ${
-                      isEditing ? "bg-white" : "bg-gray-50 text-gray-700"
-                    }`}
-                    {...register("dateOfBirth")}
-                  />
-                  {errors.dateOfBirth && (
-                    <p className="text-xs text-red-600 mt-1">
-                      {errors.dateOfBirth.message}
-                    </p>
-                  )}
-                </div>
-
-                <div>
-                  <label
-                    htmlFor="gender"
-                    className="block text-sm font-medium text-gray-700 mb-2"
-                  >
-                    Gênero
-                  </label>
-                  <select
-                    id="gender"
-                    disabled={!isEditing}
-                    className={`w-full px-4 py-2 border border-gray-300 rounded-lg transition-colors ${
-                      isEditing ? "bg-white" : "bg-gray-50 text-gray-700"
-                    }`}
-                    {...register("gender")}
-                  >
-                    <option value="">Selecione...</option>
-                    <option value="Masculino">Masculino</option>
-                    <option value="Feminino">Feminino</option>
-                    <option value="Outro">Outro</option>
-                    <option value="Prefiro não informar">
-                      Prefiro não informar
-                    </option>
-                  </select>
-                  {errors.gender && (
-                    <p className="text-xs text-red-600 mt-1">
-                      {errors.gender.message}
-                    </p>
-                  )}
-                </div>
-              </div>
-
-
-              {isEditing && (
-                <div className="flex gap-4 mt-6">
-                  <Button
-                    type="submit"
-                    disabled={isSaving}
-                    className="flex-1 bg-green-600 hover:bg-green-700"
-                    title="Confirmar e salvar as alterações realizadas"
-                  >
-                    {isSaving ? "Salvando..." : "Salvar Alterações"}
-                  </Button>
-                  <Button
-                    type="button"
-                    onClick={handleCancelEdit}
-                    variant="outline"
-                    className="flex-1"
-                    title="Descartar alterações e voltar para visualização"
-                  >
-                    Cancelar
-                  </Button>
-                </div>
-              )}
-            </form>
-          </CardContent>
-        </Card>
-
-        <Card className="bg-white mb-4">
-          <CardContent className="p-8">
-            <AddressForm userId={patient?.id || ""} />
-          </CardContent>
-        </Card>
-
-        <Card className="bg-white">
-          <CardContent className="p-8">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">
-              Questionário de Vulnerabilidade
-            </h2>
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-5">
-              <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                <div className="space-y-1">
-                  <p className="text-sm text-slate-600">
-                    Status do questionário
-                  </p>
-                  <p className="font-medium text-slate-900">
-                    {patient.patientProfile?.questionnaireCompleted
-                      ? "Respondido"
-                      : "Pendente"}
-                  </p>
-                  {patient.questionnaire && (
+          <Card className="bg-white">
+            <CardContent className="p-8">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                Questionário de Vulnerabilidade
+              </h2>
+              <div className="rounded-lg border border-slate-200 bg-slate-50 p-5">
+                <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                  <div className="space-y-1">
                     <p className="text-sm text-slate-600">
-                      Pontuação: {patient.questionnaire.totalScore} |{" "}
-                      {patient.questionnaire.isVulnerable
-                        ? "Vulnerável"
-                        : "Não vulnerável"}
+                      Status do questionário
                     </p>
-                  )}
-                </div>
+                    <p className="font-medium text-slate-900">
+                      {patient.patientProfile?.questionnaireCompleted
+                        ? "Respondido"
+                        : "Pendente"}
+                    </p>
+                    {patient.questionnaire && (
+                      <p className="text-sm text-slate-600">
+                        Pontuação: {patient.questionnaire.totalScore} |{" "}
+                        {patient.questionnaire.isVulnerable
+                          ? "Vulnerável"
+                          : "Não vulnerável"}
+                      </p>
+                    )}
+                  </div>
 
-                <Link
-                  href={`/dashboard/manager/patients/${patient.id}/questionnaire`}
-                  title={
-                    patient.questionnaire
-                      ? "Editar as respostas do questionário"
-                      : "Iniciar preenchimento do questionário"
-                  }
-                >
-                  <Button
+                  <Link
+                    href={`/dashboard/manager/patients/${patient.id}/questionnaire`}
                     title={
                       patient.questionnaire
-                        ? "Editar questionário"
-                        : "Preencher questionário"
+                        ? "Editar as respostas do questionário"
+                        : "Iniciar preenchimento do questionário"
                     }
                   >
-                    {patient.questionnaire
-                      ? "Editar questionário"
-                      : "Preencher questionário"}
-                  </Button>
-                </Link>
+                    <Button
+                      title={
+                        patient.questionnaire
+                          ? "Editar questionário"
+                          : "Preencher questionário"
+                      }
+                    >
+                      {patient.questionnaire
+                        ? "Editar questionário"
+                        : "Preencher questionário"}
+                    </Button>
+                  </Link>
+                </div>
               </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card className="bg-white mt-6">
-          <CardContent className="p-8">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">
-              Informações do Sistema
-            </h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <p className="text-sm text-slate-600">ID do Paciente</p>
-                <p className="font-mono text-sm text-gray-900 break-all">
-                  {patient.id}
-                </p>
-              </div>
-              <div>
-                <p className="text-sm text-slate-600">Status</p>
-                <p className="font-medium text-gray-900">
-                  {patient.status || "Ativo"}
-                </p>
-              </div>
-              {patient.createdAt && (
+            </CardContent>
+          </Card>
+          <Card className="bg-white mt-6">
+            <CardContent className="p-8">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                Informações do Sistema
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <p className="text-sm text-slate-600">Data de Cadastro</p>
-                  <p className="font-medium text-gray-900">
-                    {new Date(patient.createdAt).toLocaleDateString("pt-BR")}
+                  <p className="text-sm text-slate-600">ID do Paciente</p>
+                  <p className="font-mono text-sm text-gray-900 break-all">
+                    {patient.id}
                   </p>
                 </div>
-              )}
-              {patient.updatedAt && (
                 <div>
-                  <p className="text-sm text-slate-600">Última Atualização</p>
+                  <p className="text-sm text-slate-600">Status</p>
                   <p className="font-medium text-gray-900">
-                    {new Date(patient.updatedAt).toLocaleDateString("pt-BR")}
+                    {patient.status || "Ativo"}
                   </p>
                 </div>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </section>
-  );
+                {patient.createdAt && (
+                  <div>
+                    <p className="text-sm text-slate-600">Data de Cadastro</p>
+                    <p className="font-medium text-gray-900">
+                      {new Date(patient.createdAt).toLocaleDateString("pt-BR")}
+                    </p>
+                  </div>
+                )}
+                {patient.updatedAt && (
+                  <div>
+                    <p className="text-sm text-slate-600">Última Atualização</p>
+                    <p className="font-medium text-gray-900">
+                      {new Date(patient.updatedAt).toLocaleDateString("pt-BR")}
+                    </p>
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    );
 }


### PR DESCRIPTION
## Resumo

Este PR resolve erros de build no fluxo do gestor causados por uma resolução de conflito mal feita em #118 e padroniza o tratamento do campo `address` no cadastro de gestor, eliminando uma inconsistência que gerava dado órfão.

## O que estava errado

1. **JSX quebrado em `apps/web/app/dashboard/manager/patients/[id]/page.tsx`**: os blocos `if (isLoading)`, `if (error)` e o `return` principal do componente estavam aninhados dentro de `handleCancelEdit`, e a função `handleCpfChange` (usada no input de CPF) havia sido removida. O build do front quebrava.
2. **`updatePatient` em `patients.service.ts` lia `address` do lugar errado**: tentava `updatedUser.patientProfile?.address`, mas `address` é uma relação no `User`, não um campo do `PatientProfile`. O type-check do server falhava.
3. **Campo `address` órfão no `RegisterManagerDto`**: o endpoint `POST /auth/register/manager` aceitava `address: string`, mas o `authService.registerManager` nunca usava esse valor — virava lixo. Pior: tinha sido marcado como obrigatório no backend enquanto o frontend mandava opcional, o que quebraria cadastros novos.

## O que foi feito

### `fix(manager): corrige página de detalhes do paciente e include de endereço no Prisma`
- Reconstrói a estrutura correta da página de detalhes do paciente (chaves, return principal no escopo certo, `handleCpfChange` restaurado, `useEffect` com dependências corretas).
- Ajusta o `include` do `updatePatient` para carregar `address: true` no nível do `User` e lê `updatedUser.address` no retorno.

### `refactor(auth): remove campo address não utilizado do cadastro de gestor`
- Remove o campo `address` do `RegisterManagerDto` (backend), da interface `RegisterManagerDto` (frontend), do schema Zod `registerManagerSchema` e do formulário de cadastro de gestor.
- Padroniza o fluxo: o gestor é criado apenas com os campos essenciais, e o endereço estruturado (CEP, rua, número, bairro, cidade, estado, complemento) passa a ser cadastrado depois via `AddressForm` / `AddressesService` — exatamente o mesmo padrão já usado para pacientes e profissionais.
- O `ValidationPipe` do projeto não usa `forbidNonWhitelisted`, então frontends antigos enviando `address` continuam funcionando (o campo é apenas ignorado), sem quebra abrupta.

## Como foi testado

Smoke test local com Postgres up e seed mínimo aplicado:

| Endpoint | Cenário | Resultado |
|---|---|---|
| `POST /auth/login` (admin) | Login admin | **200** |
| `POST /auth/login` (manager) | Login gestor | **200** |
| `POST /auth/register/manager` | Payload sem `address` (novo padrão) | **201** |
| `POST /auth/register/manager` | Payload com `address` extra (cliente antigo) | **201** (ignorado) |
| `GET /manager/patients` | Listagem | **200** |
| `PATCH /manager/patients/:id` | Update do paciente, retornando `address: null` corretamente | **200** |

Adicionalmente:
- `tsc --noEmit` passa em `apps/web` e `apps/server`.
- A documentação Scalar (`/api/docs`) é regerada automaticamente a partir dos `@ApiProperty`, então o endpoint `POST /auth/register/manager` aparece atualizado sem o campo `address`.

## Test plan

- [ ] CI verde (build do server, build do web, lint, type-check).
- [ ] Verificar manualmente o cadastro de gestor pelo dashboard admin.
- [ ] Verificar manualmente a edição de paciente pelo dashboard do gestor (form de dados + AddressForm separado).
- [ ] Abrir `/api/docs` no ambiente de preview e confirmar que `register/manager` não mostra mais `address`.