### PR TITLE
fix(reports): 204 em relatório vazio + botão desabilitado no front (#114)

### DIFF
--- a/apps/server/src/patients/patients.controller.ts
+++ b/apps/server/src/patients/patients.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, Request, Res } from '@nestjs/common';
+import { Controller, Get, HttpStatus, Query, Request, Res } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -13,6 +13,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { PatientRoleGuard } from './guards/patient-role.guard';
 import { ExportAppointmentsQueryDto } from './dto/export-appointments-query.dto';
 import type { Response } from 'express';
+import type PDFKit from 'pdfkit';
 import { QuestionnaireCompletionGuard } from '../questionnaire/questionnaire-completion.guard';
 
 @ApiTags('Patients')
@@ -62,14 +63,11 @@ export class PatientsController {
       query,
     );
 
-    res.set({
-      'Content-Type': 'application/pdf',
-      'Content-Disposition':
-        'attachment; filename=relatorio-consultas-concluidas.pdf',
-    });
-
-    doc.pipe(res);
-    doc.end();
+    this.sendPdfOrNoContent(
+      res,
+      doc,
+      'relatorio-consultas-concluidas.pdf',
+    );
   }
 
   @Get('export/pending-appointments')
@@ -112,14 +110,11 @@ export class PatientsController {
       query,
     );
 
-    res.set({
-      'Content-Type': 'application/pdf',
-      'Content-Disposition':
-        'attachment; filename=relatorio-consultas-pendentes.pdf',
-    });
-
-    doc.pipe(res);
-    doc.end();
+    this.sendPdfOrNoContent(
+      res,
+      doc,
+      'relatorio-consultas-pendentes.pdf',
+    );
   }
 
   @Get('export/cancelled-appointments')
@@ -162,10 +157,26 @@ export class PatientsController {
       query,
     );
 
+    this.sendPdfOrNoContent(
+      res,
+      doc,
+      'relatorio-consultas-canceladas.pdf',
+    );
+  }
+
+  private sendPdfOrNoContent(
+    res: Response,
+    doc: PDFKit.PDFDocument | null,
+    filename: string,
+  ): void {
+    if (!doc) {
+      res.status(HttpStatus.NO_CONTENT).end();
+      return;
+    }
+
     res.set({
       'Content-Type': 'application/pdf',
-      'Content-Disposition':
-        'attachment; filename=relatorio-consultas-canceladas.pdf',
+      'Content-Disposition': `attachment; filename=${filename}`,
     });
 
     doc.pipe(res);

--- a/apps/server/src/patients/patients.service.ts
+++ b/apps/server/src/patients/patients.service.ts
@@ -35,7 +35,7 @@ export class PatientsService {
   async exportDoneAppointmentsReport(
     patientId: string,
     query: ExportAppointmentsQueryDto,
-  ): Promise<PDFDocumentType> {
+  ): Promise<PDFDocumentType | null> {
     const appointments = await this.findPatientAppointmentsByStatus(
       patientId,
       AppointmentStatus.COMPLETED,
@@ -48,7 +48,7 @@ export class PatientsService {
   async exportPendingAppointmentsReport(
     patientId: string,
     query: ExportAppointmentsQueryDto,
-  ): Promise<PDFDocumentType> {
+  ): Promise<PDFDocumentType | null> {
     const appointments = await this.findPatientAppointmentsByStatus(
       patientId,
       AppointmentStatus.PENDING,
@@ -61,7 +61,7 @@ export class PatientsService {
   async exportCancelledAppointmentsReport(
     patientId: string,
     query: ExportAppointmentsQueryDto,
-  ): Promise<PDFDocumentType> {
+  ): Promise<PDFDocumentType | null> {
     const appointments = await this.findPatientAppointmentsByStatus(
       patientId,
       AppointmentStatus.CANCELLED,

--- a/apps/server/src/reports/reports.service.ts
+++ b/apps/server/src/reports/reports.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import PDFDocument from 'pdfkit';
 import { AppointmentReportItemDto } from './dto/appointment-made.dto';
 
@@ -21,7 +21,7 @@ const MODALITY_LABELS: Record<string, string> = {
 export class ReportsService {
   generateDoneAppointmentsPdf(
     appointments: AppointmentReportItemDto[],
-  ): PDFDocumentType {
+  ): PDFDocumentType | null {
     return this.generateAppointmentsPdf(
       'Relatório de Consultas Concluídas',
       'COMPLETED',
@@ -31,7 +31,7 @@ export class ReportsService {
 
   generatePendingAppointmentsPdf(
     appointments: AppointmentReportItemDto[],
-  ): PDFDocumentType {
+  ): PDFDocumentType | null {
     return this.generateAppointmentsPdf(
       'Relatório de Consultas Pendentes',
       'PENDING',
@@ -41,7 +41,7 @@ export class ReportsService {
 
   generateCancelledAppointmentsPdf(
     appointments: AppointmentReportItemDto[],
-  ): PDFDocumentType {
+  ): PDFDocumentType | null {
     return this.generateAppointmentsPdf(
       'Relatório de Consultas Canceladas',
       'CANCELLED',
@@ -53,11 +53,9 @@ export class ReportsService {
     title: string,
     status: 'COMPLETED' | 'PENDING' | 'CANCELLED',
     appointments: AppointmentReportItemDto[],
-  ): PDFDocumentType {
+  ): PDFDocumentType | null {
     if (!appointments.length) {
-      throw new NotFoundException(
-        'Nenhum agendamento encontrado para os filtros informados',
-      );
+      return null;
     }
 
     const doc = new PDFDocument({

--- a/apps/web/app/dashboard/patient/appointments/page.tsx
+++ b/apps/web/app/dashboard/patient/appointments/page.tsx
@@ -119,6 +119,8 @@ const AppointmentsPage = () => {
     },
   );
 
+  const hasReportData = filtered.length > 0;
+
   const handleDownloadReport = async () => {
     try {
       setIsDownloadingReport(true);
@@ -203,8 +205,8 @@ const AppointmentsPage = () => {
           <Button
             size="lg"
             onClick={handleDownloadReport}
-            disabled={isDownloadingReport}
-            title={reportHint}
+            disabled={isDownloadingReport || !hasReportData}
+            title={hasReportData ? reportHint : "Nenhum dado disponível para baixar"}
           >
             {isDownloadingReport ? "Gerando relatório..." : reportButtonLabel}
           </Button>
@@ -239,8 +241,8 @@ const AppointmentsPage = () => {
           <Button
             size="default"
             onClick={handleDownloadReport}
-            disabled={isDownloadingReport}
-            title={reportHint}
+            disabled={isDownloadingReport || !hasReportData}
+            title={hasReportData ? reportHint : "Nenhum dado disponível para baixar"}
             className="w-full"
           >
             {isDownloadingReport ? "Gerando relatório..." : reportButtonLabel}


### PR DESCRIPTION
Closes #114

## Problema
Ao clicar em "Baixar Relatório" em uma aba sem registros (pendentes/realizadas/canceladas), o backend respondia **404** (`NotFoundException`) e o frontend exibia um toast de erro genérico — UX confusa e status HTTP semanticamente errado para "lista vazia".

## Solução
Defesa em duas camadas:

### Backend
- `ReportsService` deixa de lançar `NotFoundException` quando a lista está vazia e passa a retornar `null`, mantendo o serviço puro de HTTP (SRP).
- `PatientsController` centraliza o envio do PDF em um helper privado `sendPdfOrNoContent`, que responde **204 No Content** quando o doc é `null` (status correto para "ok, sem corpo"). Os 3 handlers (`done`, `pending`, `cancelled`) compartilham o helper — sem duplicação.

### Frontend
- Página `dashboard/patient/appointments` deriva `hasReportData = filtered.length > 0` e desabilita o botão (cinza) quando a aba ativa não tem registros, com `title` explicativo "Nenhum dado disponível para baixar". Vale para desktop e mobile.
- Sem novos hooks, sem novos componentes — uma derivação local reutilizada nos dois botões.

## Arquivos modificados
- `apps/server/src/reports/reports.service.ts`
- `apps/server/src/patients/patients.service.ts`
- `apps/server/src/patients/patients.controller.ts`
- `apps/web/app/dashboard/patient/appointments/page.tsx`

## Test plan
- [ ] Login como paciente e abrir `/dashboard/patient/appointments`
- [ ] Aba **Próximas** com pendentes → botão habilitado, download gera PDF normal
- [ ] Aba **Canceladas** vazia → botão **cinza/disabled** com tooltip; sem request ao backend
- [ ] `curl` direto em `GET /patients/export/cancelled-appointments` com lista vazia → resposta **204 No Content** (não mais 404)
- [ ] Aba com registros continua gerando o PDF normal (regressão da tabela)
- [ ] `npx tsc --noEmit` passa em `apps/server` e `apps/web`