### PR TITLE
fix(seed): resolve migration CPF falhada e corrige seed de produção

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -20,7 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "prisma": {
-    "seed": "ts-node --transpile-only prisma/seed-minimal.ts"
+    "seed": "ts-node --transpile-only prisma/seed.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/apps/server/prisma/seed.ts
+++ b/apps/server/prisma/seed.ts
@@ -58,7 +58,7 @@ async function main() {
     },
     create: {
       email: 'admin@lifemed.com',
-      cpf: '00000000000',
+      cpf: null,
       password: hashedPassword,
       name: 'Administrador do Sistema',
       role: UserRole.ADMIN,


### PR DESCRIPTION
## Problema

A migration `20260516170000_unique_cpf` falhou em produção com erro **P3009** do Prisma. O Prisma bloqueia novas migrations enquanto houver uma com status `failed`. A causa raiz: quando o campo `cpf` foi adicionado à tabela `users` (migration `20260329152318`), todos os usuários existentes receberam o valor padrão `'00000000000'`. Ao tentar criar o índice único na migration seguinte, o `CREATE UNIQUE INDEX` falhou por conta dos valores duplicados.

## Solução

A abordagem adotada é limpar o banco de produção e re-sedar do zero (dados não são críticos — sistema acadêmico/UFBA), já que a migration SQL em si está correta e funcionará perfeitamente com o banco vazio.

### Mudanças no código

- **`apps/server/package.json`** — seed padrão alterado de `seed-minimal.ts` → `seed.ts` (22 usuários com CPFs únicos e válidos para produção/staging)
- **`apps/server/prisma/seed.ts`** — CPF do admin alterado de `'00000000000'` → `null` (a migration já converte esse placeholder para NULL; deixar explícito é semanticamente correto)

## Passo manual necessário antes do merge/deploy

Executar no **Supabase Dashboard > SQL Editor** para limpar o estado corrompido:

```sql
TRUNCATE TABLE
  questionnaire_answers,
  vulnerability_questionnaires,
  schedule_blocks,
  appointments,
  availability,
  addresses,
  password_resets,
  email_verifications,
  sessions,
  professional_profiles,
  patient_profiles,
  manager_profiles,
  question_options,
  questions,
  questionnaires,
  specialties,
  users
RESTART IDENTITY CASCADE;

TRUNCATE TABLE "_prisma_migrations";
```

Após o merge, o Render executará automaticamente `prisma migrate deploy` (re-aplica todas as 23 migrations) + `prisma db seed`.

## Verificação pós-deploy

```sql
-- Todas as migrations aplicadas com sucesso (sem rolled_back_at preenchido)
SELECT migration_name, finished_at, rolled_back_at FROM _prisma_migrations ORDER BY started_at;

-- Índice único criado
SELECT indexname FROM pg_indexes WHERE tablename = 'users' AND indexname = 'users_cpf_key';

-- Sem CPFs duplicados
SELECT cpf, COUNT(*) FROM users WHERE cpf IS NOT NULL GROUP BY cpf HAVING COUNT(*) > 1;

-- Contagem esperada: ADMIN:1, MANAGER:1, PATIENT:10, PROFESSIONAL:10
SELECT role, COUNT(*) FROM users GROUP BY role ORDER BY role;
```