### PR TITLE
fix(#126): modal de detalhes da consulta e upload de foto do profissional

### DIFF
--- a/apps/server/src/appointments/appointments.service.ts
+++ b/apps/server/src/appointments/appointments.service.ts
@@ -269,7 +269,13 @@ export class AppointmentsService {
         where,
         include: {
           patient: true,
-          professional: true,
+          professional: {
+            include: {
+              professionalProfile: {
+                include: { specialities: true },
+              },
+            },
+          },
         },
         orderBy: { dateTime: 'asc' },
         skip,
@@ -312,7 +318,13 @@ export class AppointmentsService {
         where,
         include: {
           patient: true,
-          professional: true,
+          professional: {
+            include: {
+              professionalProfile: {
+                include: { specialities: true },
+              },
+            },
+          },
         },
         orderBy: { dateTime: 'asc' },
         skip,
@@ -654,6 +666,13 @@ export class AppointmentsService {
         id: appointment.professional.id,
         name: appointment.professional.name,
         email: appointment.professional.email,
+        specialties:
+          appointment.professional.professionalProfile?.specialities?.map(
+            (s: { name: string }) => s.name,
+          ) ?? [],
+        photoUrl:
+          appointment.professional.professionalProfile?.photoUrl ?? null,
+        bio: appointment.professional.professionalProfile?.bio ?? null,
       },
       patient: {
         id: appointment.patient.id,

--- a/apps/server/src/appointments/dto/appointment-response.dto.ts
+++ b/apps/server/src/appointments/dto/appointment-response.dto.ts
@@ -19,6 +19,30 @@ export class ProfessionalResponseDto {
     description: 'Email do profissional',
   })
   email!: string;
+
+  @ApiProperty({
+    example: ['Cardiologia'],
+    description: 'Especialidades do profissional',
+    type: [String],
+    required: false,
+  })
+  specialties?: string[];
+
+  @ApiProperty({
+    example: 'https://cdn.lifemed.com/foto.jpg',
+    description: 'URL da foto do profissional',
+    nullable: true,
+    required: false,
+  })
+  photoUrl?: string | null;
+
+  @ApiProperty({
+    example: 'Médico especialista com 10 anos de experiência.',
+    description: 'Biografia do profissional',
+    nullable: true,
+    required: false,
+  })
+  bio?: string | null;
 }
 
 export class PatientResponseDto {

--- a/apps/web/app/dashboard/patient/appointments/appointments.types.ts
+++ b/apps/web/app/dashboard/patient/appointments/appointments.types.ts
@@ -2,7 +2,11 @@ export type Appointment = {
   id: string;
   professionalId: string;
   doctorName: string;
+  doctorEmail: string;
   specialty: string;
+  specialties: string[];
+  photoUrl?: string | null;
+  bio?: string | null;
   dateTime: string;
   status: "PENDING" | "CONFIRMED" | "COMPLETED" | "CANCELLED";
   modality: "VIRTUAL" | "CLINIC" | "HOME_VISIT";

--- a/apps/web/app/dashboard/patient/appointments/components/AppointmentCard.tsx
+++ b/apps/web/app/dashboard/patient/appointments/components/AppointmentCard.tsx
@@ -16,6 +16,7 @@ type AppointmentCardProps = {
   appointment: Appointment;
   onCancel: (id: string) => void;
   onRebook: () => void;
+  onDetails: (appointment: Appointment) => void;
   isMobile?: boolean;
 };
 
@@ -23,6 +24,7 @@ export function AppointmentCard({
   appointment: appt,
   onCancel,
   onRebook,
+  onDetails,
   isMobile = false,
 }: AppointmentCardProps) {
   const { day, month, year } = formatDate(appt.dateTime);
@@ -111,6 +113,7 @@ export function AppointmentCard({
                   size="sm"
                   className="flex-1 text-xs"
                   title="Ver detalhes da consulta"
+                  onClick={() => onDetails(appt)}
                 >
                   Detalhes
                 </Button>
@@ -130,6 +133,7 @@ export function AppointmentCard({
                 size="sm"
                 className="flex-1 text-xs"
                 title="Ver detalhes da consulta finalizada"
+                onClick={() => onDetails(appt)}
               >
                 Ver Detalhes
               </Button>
@@ -227,7 +231,11 @@ export function AppointmentCard({
             )}
           {(appt.status === "CONFIRMED" || appt.status === "PENDING") && (
             <>
-              <Button size="sm" title="Ver detalhes da consulta">
+              <Button
+                size="sm"
+                title="Ver detalhes da consulta"
+                onClick={() => onDetails(appt)}
+              >
                 Detalhes
               </Button>
               <Button
@@ -241,7 +249,11 @@ export function AppointmentCard({
             </>
           )}
           {appt.status === "COMPLETED" && (
-            <Button size="sm" title="Ver detalhes da consulta finalizada">
+            <Button
+              size="sm"
+              title="Ver detalhes da consulta finalizada"
+              onClick={() => onDetails(appt)}
+            >
               Ver Detalhes
             </Button>
           )}

--- a/apps/web/app/dashboard/patient/appointments/components/AppointmentDetailsModal.tsx
+++ b/apps/web/app/dashboard/patient/appointments/components/AppointmentDetailsModal.tsx
@@ -1,0 +1,142 @@
+import Image from "next/image";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Appointment } from "../appointments.types";
+import {
+  formatDate,
+  formatTime,
+  getStatusLabel,
+  getStatusClass,
+  getModalityLabel,
+} from "../appointments.utils";
+
+type AppointmentDetailsModalProps = {
+  appointment: Appointment | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function AppointmentDetailsModal({
+  appointment: appt,
+  open,
+  onOpenChange,
+}: AppointmentDetailsModalProps) {
+  if (!appt) return null;
+
+  const { day, month, year } = formatDate(appt.dateTime);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Detalhes da Consulta</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          <div className="flex items-center gap-3">
+            {appt.photoUrl ? (
+              <Image
+                src={appt.photoUrl}
+                alt={`Foto de ${appt.doctorName}`}
+                width={56}
+                height={56}
+                className="rounded-full object-cover border border-gray-200 flex-shrink-0"
+              />
+            ) : (
+              <div
+                className="w-14 h-14 rounded-full bg-[#e8f1fd] flex items-center justify-center flex-shrink-0"
+                aria-label={`Inicial do profissional ${appt.doctorName}`}
+              >
+                <span className="text-xl font-bold text-[#006fee]">
+                  {appt.doctorName.charAt(0).toUpperCase()}
+                </span>
+              </div>
+            )}
+            <div className="min-w-0">
+              <p className="font-semibold text-gray-900 truncate">
+                {appt.doctorName}
+              </p>
+              {appt.specialties.length > 0 && (
+                <p className="text-sm text-gray-500">
+                  {appt.specialties.join(", ")}
+                </p>
+              )}
+              {appt.bio && (
+                <p className="text-xs text-gray-400 mt-0.5 line-clamp-2">
+                  {appt.bio}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="border-t border-gray-100 pt-3 grid grid-cols-2 gap-3">
+            <div>
+              <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+                Data
+              </p>
+              <p className="text-sm font-semibold text-gray-800 mt-0.5">
+                {day}/{month}/{year}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+                Horário
+              </p>
+              <p className="text-sm font-semibold text-gray-800 mt-0.5">
+                {formatTime(appt.dateTime)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+                Modalidade
+              </p>
+              <Badge className="mt-0.5 text-xs">
+                {getModalityLabel(appt.modality)}
+              </Badge>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+                Status
+              </p>
+              <Badge
+                className={`mt-0.5 text-xs ${getStatusClass(appt.status)}`}
+              >
+                {getStatusLabel(appt.status)}
+              </Badge>
+            </div>
+          </div>
+
+          {appt.notes && (
+            <div className="border-t border-gray-100 pt-3">
+              <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+                Observações
+              </p>
+              <p className="text-sm text-gray-700 mt-1 italic">{appt.notes}</p>
+            </div>
+          )}
+
+          {appt.modality === "VIRTUAL" && appt.meetLink && (
+            <div className="border-t border-gray-100 pt-3">
+              <p className="text-xs font-medium text-gray-400 uppercase tracking-wide mb-2">
+                Link da videoconsulta
+              </p>
+              <a
+                href={appt.meetLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center w-full px-4 py-2 rounded-lg text-sm font-semibold bg-[#006fee] text-white hover:bg-[#005ec8] transition-colors"
+              >
+                Entrar na videoconsulta
+              </a>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/dashboard/patient/appointments/page.tsx
+++ b/apps/web/app/dashboard/patient/appointments/page.tsx
@@ -11,6 +11,7 @@ import { Appointment, TabKey } from "./appointments.types";
 import { AppointmentTabs } from "./components/AppointmentTabs";
 import { AppointmentCard } from "./components/AppointmentCard";
 import { EmptyAppointments } from "./components/EmptyAppointments";
+import { AppointmentDetailsModal } from "./components/AppointmentDetailsModal";
 import { patientsService } from "@/services/patients-service";
 import { CancelConfirmDialog } from "./components/CancelConfirmDialog";
 import {
@@ -23,7 +24,11 @@ function mapApiToAppointment(appt: AppointmentResponse): Appointment {
     id: appt.id,
     professionalId: appt.professional.id,
     doctorName: appt.professional.name,
-    specialty: "",
+    doctorEmail: appt.professional.email,
+    specialty: appt.professional.specialties?.[0] ?? "",
+    specialties: appt.professional.specialties ?? [],
+    photoUrl: appt.professional.photoUrl,
+    bio: appt.professional.bio,
     dateTime: appt.dateTime,
     status: appt.status,
     modality: appt.modality,
@@ -57,6 +62,9 @@ const AppointmentsPage = () => {
     null,
   );
   const [isCancelling, setIsCancelling] = useState(false);
+  const [selectedAppointment, setSelectedAppointment] =
+    useState<Appointment | null>(null);
+  const [isDetailsModalOpen, setIsDetailsModalOpen] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -84,6 +92,11 @@ const AppointmentsPage = () => {
   const handleCancelClick = (id: string) => {
     setAppointmentToCancel(id);
     setIsCancelModalOpen(true);
+  };
+
+  const handleDetailsClick = (appointment: Appointment) => {
+    setSelectedAppointment(appointment);
+    setIsDetailsModalOpen(true);
   };
 
   const confirmCancel = async (reason?: string) => {
@@ -230,6 +243,7 @@ const AppointmentsPage = () => {
               appointment={appt}
               onCancel={handleCancelClick}
               onRebook={() => router.push("/dashboard/patient/search")}
+              onDetails={handleDetailsClick}
               isMobile={isMobile}
             />
           ))}
@@ -254,6 +268,11 @@ const AppointmentsPage = () => {
         onOpenChange={setIsCancelModalOpen}
         onConfirm={confirmCancel}
         isLoading={isCancelling}
+      />
+      <AppointmentDetailsModal
+        appointment={selectedAppointment}
+        open={isDetailsModalOpen}
+        onOpenChange={setIsDetailsModalOpen}
       />
     </section>
   );

--- a/apps/web/app/dashboard/professional/profile/useProfileForm.ts
+++ b/apps/web/app/dashboard/professional/profile/useProfileForm.ts
@@ -89,22 +89,29 @@ export function useProfileForm() {
   const onSubmit = async (data: ProfileSchema) => {
     try {
       setIsSaving(true);
-      await usersService.updateProfile({
-        ...data,
-        specialty: [data.primarySpecialty, data.secondarySpecialty].filter((val): val is string => Boolean(val)),
-        modality: data.modality as "VIRTUAL" | "HOME_VISIT" | "CLINIC",
-        socialLinks: {
-          linkedin: data.socialLinks.referenceLink,
-          instagram: data.socialLinks.instagram,
-          other: data.socialLinks.other,
+      await usersService.updateProfile(
+        {
+          ...data,
+          specialty: [data.primarySpecialty, data.secondarySpecialty].filter(
+            (val): val is string => Boolean(val),
+          ),
+          modality: data.modality as "VIRTUAL" | "HOME_VISIT" | "CLINIC",
+          socialLinks: {
+            linkedin: data.socialLinks.referenceLink,
+            instagram: data.socialLinks.instagram,
+            other: data.socialLinks.other,
+          },
         },
-      });
+        selectedFile ?? undefined,
+      );
       toast.success("Perfil atualizado com sucesso!");
       setIsEditing(false);
       setSelectedFile(null);
       await loadProfile();
     } catch {
-      toast.error("Não foi possível salvar as alterações do perfil. Tente novamente.");
+      toast.error(
+        "Não foi possível salvar as alterações do perfil. Tente novamente.",
+      );
     } finally {
       setIsSaving(false);
     }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -10,6 +10,15 @@ export const api = axios.create({
   },
 });
 
+// Allow FormData requests to override the default Content-Type so multipart
+// boundaries are set correctly by the browser.
+api.interceptors.request.use((config) => {
+  if (config.data instanceof FormData) {
+    delete config.headers["Content-Type"];
+  }
+  return config;
+});
+
 api.interceptors.request.use((config) => {
   if (typeof window !== "undefined") {
     const token = localStorage.getItem("auth-token");

--- a/apps/web/services/appointments-service.ts
+++ b/apps/web/services/appointments-service.ts
@@ -35,6 +35,9 @@ export interface AppointmentResponse {
     id: string;
     name: string;
     email: string;
+    specialties?: string[];
+    photoUrl?: string | null;
+    bio?: string | null;
   };
   patient: {
     id: string;

--- a/apps/web/services/users-service.ts
+++ b/apps/web/services/users-service.ts
@@ -54,9 +54,31 @@ export const usersService = {
     }
   },
 
-  async updateProfile(data: UpdateProfileDto) {
+  async updateProfile(data: UpdateProfileDto, photo?: File) {
     try {
-      const response = await api.patch("/users/me", data);
+      let body: FormData | UpdateProfileDto;
+      let headers: Record<string, string> = {};
+
+      if (photo) {
+        const formData = new FormData();
+        formData.append("photo", photo);
+        Object.entries(data).forEach(([key, value]) => {
+          if (value === undefined || value === null) return;
+          if (Array.isArray(value)) {
+            value.forEach((v) => formData.append(key, v));
+          } else if (typeof value === "object") {
+            formData.append(key, JSON.stringify(value));
+          } else {
+            formData.append(key, String(value));
+          }
+        });
+        body = formData;
+      } else {
+        body = data;
+        headers = { "Content-Type": "application/json" };
+      }
+
+      const response = await api.patch("/users/me", body, { headers });
       return response.data;
     } catch (error) {
       if (error instanceof AxiosError && error.response) {


### PR DESCRIPTION
## Resumo

Resolve a issue #126 — botão "Detalhes" sem função e especialidade ausente na listagem de consultas do paciente. Inclui também a correção do upload de foto do profissional (bug identificado durante a implementação).

### Backend
- `appointments.service.ts`: inclui `professionalProfile.specialities` no `include` das queries `listPatientAppointments` e `listProfessionalAppointments`
- `appointment-response.dto.ts`: estende `ProfessionalResponseDto` com `specialties`, `photoUrl` e `bio`
- `mapToResponseDto`: popula os novos campos a partir do `professionalProfile`

### Frontend — consultas
- `AppointmentDetailsModal.tsx` (novo): modal responsivo com foto/avatar, especialidade, data, horário, modalidade, status, observações e link de videoconsulta quando VIRTUAL
- `AppointmentCard.tsx`: prop `onDetails` adicionada e conectada a todos os botões "Detalhes"/"Ver Detalhes"
- `page.tsx`: estado `selectedAppointment` + `isDetailsModalOpen` e handler `handleDetailsClick`
- `appointments.types.ts`: campos `doctorEmail`, `specialties`, `photoUrl`, `bio` adicionados ao tipo `Appointment`
- `appointments-service.ts`: interface `AppointmentResponse` atualizada com novos campos do profissional
- `mapApiToAppointment`: remove hardcode `specialty: ""`, mapeia `specialties[0]` e demais campos reais

### Frontend — upload de foto
- `users-service.ts`: `updateProfile` agora aceita `photo?: File`; monta `FormData` com o arquivo e campos do perfil quando há foto selecionada
- `useProfileForm.ts`: passa `selectedFile` para `usersService.updateProfile` no submit
- `api.ts`: interceptor remove `Content-Type` para requisições `FormData`, permitindo que o browser defina o boundary do multipart corretamente

## Plano de teste

- [ ] `GET /appointments/my-appointments` retorna `professional.specialties`, `professional.photoUrl`, `professional.bio`
- [ ] Botão "Detalhes" abre o modal em consultas PENDING e CONFIRMED
- [ ] Botão "Ver Detalhes" abre o modal em consultas COMPLETED
- [ ] Modal exibe especialidade real (não string vazia)
- [ ] Modal exibe link de videoconsulta quando modalidade = VIRTUAL e meetLink presente
- [ ] Modal exibe avatar com inicial quando profissional não tem foto
- [ ] Editar perfil do profissional com nova foto: foto é salva e exibida após reload

Closes #126