### PR TITLE
feat(#127): backend de prontuário médico com controle LGPD

### DIFF
--- a/apps/server/prisma/migrations/20260520123610_add_medical_records/migration.sql
+++ b/apps/server/prisma/migrations/20260520123610_add_medical_records/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "medical_records" (
+    "id" TEXT NOT NULL,
+    "appointment_id" TEXT NOT NULL,
+    "patient_id" TEXT NOT NULL,
+    "author_id" TEXT NOT NULL,
+    "chief_complaint" TEXT,
+    "diagnosis" TEXT,
+    "treatment_plan" TEXT,
+    "prescriptions" TEXT,
+    "internal_notes" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "medical_records_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "medical_records_appointment_id_key" ON "medical_records"("appointment_id");
+
+-- CreateIndex
+CREATE INDEX "medical_records_patient_id_created_at_idx" ON "medical_records"("patient_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "medical_records" ADD CONSTRAINT "medical_records_appointment_id_fkey" FOREIGN KEY ("appointment_id") REFERENCES "appointments"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "medical_records" ADD CONSTRAINT "medical_records_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "medical_records" ADD CONSTRAINT "medical_records_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -66,6 +66,9 @@ model User {
   appointmentsAsDoctor  Appointment[] @relation("DoctorAppointments")
   appointmentsAsPatient Appointment[] @relation("PatientAppointments")
 
+  medicalRecordsAsPatient MedicalRecord[] @relation("PatientMedicalRecords")
+  medicalRecordsAsAuthor  MedicalRecord[] @relation("AuthorMedicalRecords")
+
   availability       Availability[]
   emailVerifications EmailVerification[]
   passwordResets     PasswordReset[]
@@ -222,6 +225,31 @@ model Availability {
   @@map("availability")
 }
 
+model MedicalRecord {
+  id String @id @default(uuid())
+
+  appointmentId String @unique @map("appointment_id")
+  appointment   Appointment @relation(fields: [appointmentId], references: [id], onDelete: Cascade)
+
+  patientId String @map("patient_id")
+  patient   User   @relation("PatientMedicalRecords", fields: [patientId], references: [id])
+
+  authorId String @map("author_id")
+  author   User   @relation("AuthorMedicalRecords", fields: [authorId], references: [id])
+
+  chiefComplaint String? @map("chief_complaint") @db.Text
+  diagnosis      String? @db.Text
+  treatmentPlan  String? @map("treatment_plan") @db.Text
+  prescriptions  String? @db.Text
+  internalNotes  String? @map("internal_notes") @db.Text
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@index([patientId, createdAt])
+  @@map("medical_records")
+}
+
 model Appointment {
   id String @id @default(uuid())
 
@@ -247,6 +275,8 @@ model Appointment {
   googleEventId String? @map("google_event_id")
 
   createdAt DateTime @default(now()) @map("created_at")
+
+  medicalRecord MedicalRecord?
 
   @@map("appointments")
 }

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -20,6 +20,7 @@ import { AddressesModule } from './addresses/addresses.module';
 import { AdminModule } from './admin/admin.module';
 import { HealthController } from './health/health.controller';
 import { GoogleCalendarModule } from './google-calendar/google-calendar.module';
+import { MedicalRecordsModule } from './medical-records/medical-records.module';
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { GoogleCalendarModule } from './google-calendar/google-calendar.module';
     AddressesModule,
     AdminModule,
     GoogleCalendarModule,
+    MedicalRecordsModule,
   ],
   controllers: [AppController, HealthController],
   providers: [AppService, PrismaService, AdminSeederService],

--- a/apps/server/src/medical-records/dto/at-least-one-field.validator.ts
+++ b/apps/server/src/medical-records/dto/at-least-one-field.validator.ts
@@ -1,0 +1,36 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+} from 'class-validator';
+
+@ValidatorConstraint({ name: 'AtLeastOneField', async: false })
+class AtLeastOneFieldConstraint implements ValidatorConstraintInterface {
+  validate(_value: unknown, args: ValidationArguments): boolean {
+    const [fields] = args.constraints as [string[]];
+    const obj = args.object as Record<string, unknown>;
+    return fields.some((field) => {
+      const v = obj[field];
+      return v !== undefined && v !== null && v !== '';
+    });
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const [fields] = args.constraints as [string[]];
+    return `Ao menos um destes campos deve ser preenchido: ${fields.join(', ')}.`;
+  }
+}
+
+export function AtLeastOneField(fields: string[], options?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options,
+      constraints: [fields],
+      validator: AtLeastOneFieldConstraint,
+    });
+  };
+}

--- a/apps/server/src/medical-records/dto/create-medical-record.dto.ts
+++ b/apps/server/src/medical-records/dto/create-medical-record.dto.ts
@@ -1,0 +1,63 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsUUID } from 'class-validator';
+import { AtLeastOneField } from './at-least-one-field.validator';
+
+const CLINICAL_FIELDS = [
+  'chiefComplaint',
+  'diagnosis',
+  'treatmentPlan',
+  'prescriptions',
+  'internalNotes',
+];
+
+export class CreateMedicalRecordDto {
+  @ApiProperty({ example: 'uuid-consulta', description: 'ID da consulta' })
+  @IsUUID()
+  appointmentId!: string;
+
+  @ApiProperty({
+    example: 'Dor de cabeça persistente',
+    description: 'Queixa principal',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @AtLeastOneField(CLINICAL_FIELDS)
+  chiefComplaint?: string;
+
+  @ApiProperty({
+    example: 'Enxaqueca tensional',
+    description: 'Diagnóstico',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  diagnosis?: string;
+
+  @ApiProperty({
+    example: 'Repouso e analgésicos',
+    description: 'Plano terapêutico',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  treatmentPlan?: string;
+
+  @ApiProperty({
+    example: 'Dipirona 500mg',
+    description: 'Prescrições',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  prescriptions?: string;
+
+  @ApiProperty({
+    example: 'Paciente demonstra ansiedade',
+    description: 'Notas internas (não visíveis ao paciente)',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  internalNotes?: string;
+}

--- a/apps/server/src/medical-records/dto/medical-record-response.dto.ts
+++ b/apps/server/src/medical-records/dto/medical-record-response.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MedicalRecordAuthorDto {
+  @ApiProperty() id!: string;
+  @ApiProperty() name!: string;
+  @ApiProperty() email!: string;
+}
+
+export class MedicalRecordResponseDto {
+  @ApiProperty() id!: string;
+  @ApiProperty() appointmentId!: string;
+  @ApiProperty() patientId!: string;
+  @ApiProperty({ type: MedicalRecordAuthorDto })
+  author!: MedicalRecordAuthorDto;
+  @ApiProperty({ nullable: true }) chiefComplaint!: string | null;
+  @ApiProperty({ nullable: true }) diagnosis!: string | null;
+  @ApiProperty({ nullable: true }) treatmentPlan!: string | null;
+  @ApiProperty({ nullable: true }) prescriptions!: string | null;
+  @ApiProperty({ nullable: true }) internalNotes!: string | null;
+  @ApiProperty() createdAt!: Date;
+  @ApiProperty() updatedAt!: Date;
+}
+
+export class MedicalRecordPatientResponseDto {
+  @ApiProperty() id!: string;
+  @ApiProperty() appointmentId!: string;
+  @ApiProperty() patientId!: string;
+  @ApiProperty({ type: MedicalRecordAuthorDto })
+  author!: MedicalRecordAuthorDto;
+  @ApiProperty({ nullable: true }) chiefComplaint!: string | null;
+  @ApiProperty({ nullable: true }) diagnosis!: string | null;
+  @ApiProperty({ nullable: true }) treatmentPlan!: string | null;
+  @ApiProperty({ nullable: true }) prescriptions!: string | null;
+  @ApiProperty() createdAt!: Date;
+  @ApiProperty() updatedAt!: Date;
+}

--- a/apps/server/src/medical-records/dto/update-medical-record.dto.ts
+++ b/apps/server/src/medical-records/dto/update-medical-record.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+import { AtLeastOneField } from './at-least-one-field.validator';
+
+const CLINICAL_FIELDS = [
+  'chiefComplaint',
+  'diagnosis',
+  'treatmentPlan',
+  'prescriptions',
+  'internalNotes',
+];
+
+export class UpdateMedicalRecordDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @AtLeastOneField(CLINICAL_FIELDS)
+  chiefComplaint?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  diagnosis?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  treatmentPlan?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  prescriptions?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  internalNotes?: string;
+}

--- a/apps/server/src/medical-records/medical-records.controller.ts
+++ b/apps/server/src/medical-records/medical-records.controller.ts
@@ -1,0 +1,106 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+import { UserRole } from '@prisma/client';
+import { MedicalRecordsService } from './medical-records.service';
+import { CreateMedicalRecordDto } from './dto/create-medical-record.dto';
+import { UpdateMedicalRecordDto } from './dto/update-medical-record.dto';
+import {
+  MedicalRecordResponseDto,
+  MedicalRecordPatientResponseDto,
+} from './dto/medical-record-response.dto';
+import { ProfessionalRoleGuard } from '../professional/guards/professional-role.guard';
+
+@ApiTags('Medical Records')
+@ApiBearerAuth('access-token')
+@UseGuards(AuthGuard('jwt'))
+@Controller('medical-records')
+export class MedicalRecordsController {
+  constructor(private readonly service: MedicalRecordsService) {}
+
+  @Post()
+  @UseGuards(ProfessionalRoleGuard)
+  @ApiOperation({ summary: 'Criar prontuário médico para uma consulta' })
+  @ApiBody({ type: CreateMedicalRecordDto })
+  @ApiResponse({ status: 201, type: MedicalRecordResponseDto })
+  @ApiResponse({
+    status: 403,
+    description: 'Não é o profissional da consulta.',
+  })
+  @ApiResponse({ status: 404, description: 'Consulta não encontrada.' })
+  create(
+    @Request() req: { user: { userId: string } },
+    @Body() dto: CreateMedicalRecordDto,
+  ) {
+    return this.service.create(req.user.userId, dto);
+  }
+
+  @Get('appointment/:appointmentId')
+  @ApiOperation({
+    summary: 'Buscar prontuário por consulta',
+    description:
+      'Profissional com vínculo recebe todos os campos. Paciente dono não recebe internalNotes (LGPD).',
+  })
+  @ApiParam({ name: 'appointmentId', description: 'ID da consulta' })
+  @ApiResponse({ status: 200, type: MedicalRecordResponseDto })
+  @ApiResponse({ status: 403, description: 'Acesso negado.' })
+  @ApiResponse({ status: 404, description: 'Prontuário não encontrado.' })
+  findByAppointment(
+    @Request() req: { user: { userId: string; role: UserRole } },
+    @Param('appointmentId') appointmentId: string,
+  ): Promise<MedicalRecordResponseDto | MedicalRecordPatientResponseDto> {
+    return this.service.findByAppointment(
+      appointmentId,
+      req.user.userId,
+      req.user.role,
+    );
+  }
+
+  @Get('patient/:patientId')
+  @UseGuards(ProfessionalRoleGuard)
+  @ApiOperation({
+    summary: 'Listar prontuários de um paciente',
+    description: 'Requer vínculo de consulta com o paciente.',
+  })
+  @ApiParam({ name: 'patientId', description: 'ID do paciente' })
+  @ApiResponse({ status: 200, type: [MedicalRecordResponseDto] })
+  @ApiResponse({ status: 403, description: 'Sem vínculo com este paciente.' })
+  findByPatient(
+    @Request() req: { user: { userId: string } },
+    @Param('patientId') patientId: string,
+  ) {
+    return this.service.findByPatient(patientId, req.user.userId);
+  }
+
+  @Patch(':id')
+  @UseGuards(ProfessionalRoleGuard)
+  @ApiOperation({ summary: 'Atualizar prontuário (somente autor)' })
+  @ApiParam({ name: 'id', description: 'ID do prontuário' })
+  @ApiBody({ type: UpdateMedicalRecordDto })
+  @ApiResponse({ status: 200, type: MedicalRecordResponseDto })
+  @ApiResponse({ status: 403, description: 'Não é o autor do prontuário.' })
+  @ApiResponse({ status: 404, description: 'Prontuário não encontrado.' })
+  update(
+    @Request() req: { user: { userId: string } },
+    @Param('id') id: string,
+    @Body() dto: UpdateMedicalRecordDto,
+  ) {
+    return this.service.update(id, req.user.userId, dto);
+  }
+}

--- a/apps/server/src/medical-records/medical-records.module.ts
+++ b/apps/server/src/medical-records/medical-records.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { MedicalRecordsController } from './medical-records.controller';
+import { MedicalRecordsService } from './medical-records.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [MedicalRecordsController],
+  providers: [MedicalRecordsService],
+  exports: [MedicalRecordsService],
+})
+export class MedicalRecordsModule {}

--- a/apps/server/src/medical-records/medical-records.service.ts
+++ b/apps/server/src/medical-records/medical-records.service.ts
@@ -1,0 +1,227 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { AppointmentStatus, Prisma, UserRole } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateMedicalRecordDto } from './dto/create-medical-record.dto';
+import { UpdateMedicalRecordDto } from './dto/update-medical-record.dto';
+import {
+  MedicalRecordResponseDto,
+  MedicalRecordPatientResponseDto,
+} from './dto/medical-record-response.dto';
+
+type MedicalRecordWithAuthor = Prisma.MedicalRecordGetPayload<{
+  include: { author: true };
+}>;
+
+const VALID_LINK_STATUSES: AppointmentStatus[] = [
+  AppointmentStatus.CONFIRMED,
+  AppointmentStatus.COMPLETED,
+];
+
+@Injectable()
+export class MedicalRecordsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(
+    authorId: string,
+    dto: CreateMedicalRecordDto,
+  ): Promise<MedicalRecordResponseDto> {
+    const appointment = await this.prisma.appointment.findUnique({
+      where: { id: dto.appointmentId },
+    });
+
+    if (!appointment) {
+      throw new NotFoundException('Consulta não encontrada.');
+    }
+
+    if (appointment.professionalId !== authorId) {
+      throw new ForbiddenException(
+        'Apenas o profissional responsável pela consulta pode criar o prontuário.',
+      );
+    }
+
+    try {
+      const record = await this.prisma.medicalRecord.create({
+        data: {
+          appointmentId: dto.appointmentId,
+          patientId: appointment.patientId,
+          authorId,
+          chiefComplaint: dto.chiefComplaint,
+          diagnosis: dto.diagnosis,
+          treatmentPlan: dto.treatmentPlan,
+          prescriptions: dto.prescriptions,
+          internalNotes: dto.internalNotes,
+        },
+        include: { author: true },
+      });
+      return this.toResponseDto(record);
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        throw new ConflictException(
+          'Já existe um prontuário para esta consulta.',
+        );
+      }
+      throw error;
+    }
+  }
+
+  async findByAppointment(
+    appointmentId: string,
+    requesterId: string,
+    requesterRole: UserRole,
+  ): Promise<MedicalRecordResponseDto | MedicalRecordPatientResponseDto> {
+    if (
+      requesterRole !== UserRole.PROFESSIONAL &&
+      requesterRole !== UserRole.PATIENT
+    ) {
+      throw new ForbiddenException('Acesso negado a este prontuário.');
+    }
+
+    const record = await this.prisma.medicalRecord.findUnique({
+      where: { appointmentId },
+      include: { author: true },
+    });
+
+    if (!record) {
+      throw new NotFoundException('Prontuário não encontrado.');
+    }
+
+    if (requesterRole === UserRole.PATIENT) {
+      if (record.patientId !== requesterId) {
+        throw new ForbiddenException('Acesso negado a este prontuário.');
+      }
+      return this.toPatientResponseDto(record);
+    }
+
+    const isAuthor = record.authorId === requesterId;
+    const hasLink =
+      isAuthor ||
+      (await this.hasPriorAppointment(requesterId, record.patientId));
+
+    if (!hasLink) {
+      throw new ForbiddenException('Acesso negado a este prontuário.');
+    }
+
+    return this.toResponseDto(record);
+  }
+
+  async findByPatient(
+    patientId: string,
+    requesterId: string,
+  ): Promise<MedicalRecordResponseDto[]> {
+    const hasLink = await this.hasPriorAppointment(requesterId, patientId);
+
+    if (!hasLink) {
+      throw new ForbiddenException(
+        'Acesso negado: sem vínculo de consulta com este paciente.',
+      );
+    }
+
+    const records = await this.prisma.medicalRecord.findMany({
+      where: { patientId },
+      include: { author: true },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return records.map((r) => this.toResponseDto(r));
+  }
+
+  async update(
+    recordId: string,
+    requesterId: string,
+    dto: UpdateMedicalRecordDto,
+  ): Promise<MedicalRecordResponseDto> {
+    const record = await this.prisma.medicalRecord.findUnique({
+      where: { id: recordId },
+      include: { author: true },
+    });
+
+    if (!record) {
+      throw new NotFoundException('Prontuário não encontrado.');
+    }
+
+    if (record.authorId !== requesterId) {
+      throw new ForbiddenException(
+        'Apenas o autor do prontuário pode editá-lo.',
+      );
+    }
+
+    const updated = await this.prisma.medicalRecord.update({
+      where: { id: recordId },
+      data: {
+        chiefComplaint: dto.chiefComplaint,
+        diagnosis: dto.diagnosis,
+        treatmentPlan: dto.treatmentPlan,
+        prescriptions: dto.prescriptions,
+        internalNotes: dto.internalNotes,
+      },
+      include: { author: true },
+    });
+
+    return this.toResponseDto(updated);
+  }
+
+  private async hasPriorAppointment(
+    professionalId: string,
+    patientId: string,
+  ): Promise<boolean> {
+    const count = await this.prisma.appointment.count({
+      where: {
+        professionalId,
+        patientId,
+        status: { in: VALID_LINK_STATUSES },
+      },
+    });
+    return count > 0;
+  }
+
+  private toResponseDto(
+    record: MedicalRecordWithAuthor,
+  ): MedicalRecordResponseDto {
+    return {
+      id: record.id,
+      appointmentId: record.appointmentId,
+      patientId: record.patientId,
+      author: {
+        id: record.author.id,
+        name: record.author.name,
+        email: record.author.email,
+      },
+      chiefComplaint: record.chiefComplaint,
+      diagnosis: record.diagnosis,
+      treatmentPlan: record.treatmentPlan,
+      prescriptions: record.prescriptions,
+      internalNotes: record.internalNotes,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    };
+  }
+
+  private toPatientResponseDto(
+    record: MedicalRecordWithAuthor,
+  ): MedicalRecordPatientResponseDto {
+    return {
+      id: record.id,
+      appointmentId: record.appointmentId,
+      patientId: record.patientId,
+      author: {
+        id: record.author.id,
+        name: record.author.name,
+        email: record.author.email,
+      },
+      chiefComplaint: record.chiefComplaint,
+      diagnosis: record.diagnosis,
+      treatmentPlan: record.treatmentPlan,
+      prescriptions: record.prescriptions,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    };
+  }
+}


### PR DESCRIPTION
## Resumo

Implementa o backend de prontuário médico com controle de acesso LGPD para a issue #127. Foundation para as próximas issues #128 (tela do médico) e #129 (tela do paciente + PDF).

## Schema e Migration
- Modelo `MedicalRecord` com relação 1:1 a `Appointment` (FK `appointmentId` UNIQUE)
- Relações com `User` em `patient_id` (RESTRICT) e `author_id` (RESTRICT)
- `onDelete: Cascade` na consulta — prontuário não fica órfão
- Índice composto `(patient_id, created_at)` para consultas de histórico
- Migration limpa: apenas comandos relacionados ao novo modelo (sem deriva acidental)

## Endpoints
| Método | Rota | Acesso |
|--------|------|--------|
| `POST` | `/medical-records` | Profissional responsável pela consulta |
| `GET` | `/medical-records/appointment/:appointmentId` | Profissional autor/com vínculo OU paciente dono |
| `GET` | `/medical-records/patient/:patientId` | Profissional com vínculo |
| `PATCH` | `/medical-records/:id` | Somente autor |

## Controle LGPD
- `internalNotes` **nunca** retornado para `PATIENT` (DTO `MedicalRecordPatientResponseDto` separado, sem o campo)
- Caminho do paciente sempre passa por `toPatientResponseDto`
- Assert explícito de role no service: roles que não sejam `PROFESSIONAL` ou `PATIENT` são rejeitadas com 403 (defesa em profundidade contra JWT malformado)

## Robustez
- **Race condition em criação duplicada**: `P2002` capturado e mapeado para `409 Conflict`
- **Vínculo de consulta**: `hasPriorAppointment` filtra por status `CONFIRMED`/`COMPLETED` — `CANCELLED`/`NO_SHOW` não dão acesso
- **Validação "ao menos um campo"**: `@ValidatorConstraint` reaproveitável `AtLeastOneField`, aplicado em create E update
- **Tipos Prisma corretos**: sem `any` no service; usa `Prisma.MedicalRecordGetPayload<{ include: { author: true } }>`

## Plano de teste
- [ ] `POST /medical-records` 201 (profissional da consulta) / 403 (outro profissional) / 404 (consulta inexistente) / 409 (já existe)
- [ ] `POST` com body vazio → 400 com mensagem "Ao menos um destes campos..."
- [ ] `GET /appointment/:id` como autor → retorna `internalNotes`
- [ ] `GET /appointment/:id` como paciente dono → retorna sem `internalNotes`
- [ ] `GET /appointment/:id` como paciente de outra consulta → 403
- [ ] `GET /appointment/:id` como profissional sem vínculo → 403
- [ ] `GET /patient/:id` como profissional com consulta `COMPLETED` → 200
- [ ] `GET /patient/:id` como profissional com consulta `CANCELLED` apenas → 403
- [ ] `PATCH /:id` como não-autor → 403
- [ ] `PATCH /:id` com body vazio → 400

Closes #127