### PR TITLE
feat(#128): tela do médico para criar e visualizar prontuário

### DIFF
--- a/apps/web/app/dashboard/professional/schedule/components/AppointmentCard.tsx
+++ b/apps/web/app/dashboard/professional/schedule/components/AppointmentCard.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { MoreVerticalIcon } from "../../../../utils/icons";
 import { ConfirmModal } from "./ConfirmModal";
+import { MedicalRecordModal } from "./MedicalRecordModal";
 
 type Appointment = {
   id: string;
@@ -18,6 +19,8 @@ type Appointment = {
   notes?: string;
   patient: { name: string };
 };
+
+const RECORD_ELIGIBLE_STATUSES = new Set(["CONFIRMED", "COMPLETED"]);
 
 const STATUS_CLASS: Record<string, string> = {
   CONFIRMED: "bg-green-100 text-green-700 hover:bg-green-100",
@@ -57,9 +60,11 @@ export function AppointmentCard({
 }: AppointmentCardProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [pendingStatus, setPendingStatus] = useState<string>("");
+  const [isRecordModalOpen, setIsRecordModalOpen] = useState(false);
 
   const initials = appointment.patient.name.charAt(0).toUpperCase();
   const statusKey = appointment.status.toLowerCase();
+  const canOpenRecord = RECORD_ELIGIBLE_STATUSES.has(appointment.status);
 
   const handleOpenModal = (status: string) => {
     setPendingStatus(status);
@@ -134,6 +139,12 @@ export function AppointmentCard({
                   <>
                     <DropdownMenuItem
                       className="cursor-pointer rounded-md focus:bg-gray-50"
+                      onClick={() => setIsRecordModalOpen(true)}
+                    >
+                      Prontuário
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="cursor-pointer rounded-md focus:bg-gray-50"
                       onClick={() => handleOpenModal("COMPLETED")}
                     >
                       Realizado
@@ -154,6 +165,12 @@ export function AppointmentCard({
                 )}
                 {appointment.status === "COMPLETED" && (
                   <>
+                    <DropdownMenuItem
+                      className="cursor-pointer rounded-md focus:bg-gray-50"
+                      onClick={() => setIsRecordModalOpen(true)}
+                    >
+                      Prontuário
+                    </DropdownMenuItem>
                     <DropdownMenuItem
                       className="cursor-pointer rounded-md focus:bg-gray-50"
                       onClick={() => handleOpenModal("NO_SHOW")}
@@ -196,6 +213,14 @@ export function AppointmentCard({
         pendingStatus={pendingStatus}
         onConfirm={handleConfirm}
       />
+      {canOpenRecord && (
+        <MedicalRecordModal
+          appointmentId={appointment.id}
+          patientName={appointment.patient.name}
+          open={isRecordModalOpen}
+          onOpenChange={setIsRecordModalOpen}
+        />
+      )}
     </>
   );
 }

--- a/apps/web/app/dashboard/professional/schedule/components/MedicalRecordModal.tsx
+++ b/apps/web/app/dashboard/professional/schedule/components/MedicalRecordModal.tsx
@@ -1,0 +1,246 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  useCreateMedicalRecordMutation,
+  useMedicalRecordByAppointmentQuery,
+  useUpdateMedicalRecordMutation,
+} from "@/queries/useMedicalRecords";
+import { useUserQuery } from "@/queries/useUserQuery";
+import { MedicalRecordResponse } from "@/services/medical-records-service";
+
+type ClinicalField = {
+  key:
+    | "chiefComplaint"
+    | "diagnosis"
+    | "treatmentPlan"
+    | "prescriptions"
+    | "internalNotes";
+  label: string;
+  placeholder: string;
+  patientHidden?: boolean;
+};
+
+const FIELDS: ClinicalField[] = [
+  {
+    key: "chiefComplaint",
+    label: "Queixa principal",
+    placeholder: "Motivo principal relatado pelo paciente...",
+  },
+  {
+    key: "diagnosis",
+    label: "Diagnóstico",
+    placeholder: "Hipóteses ou diagnóstico confirmado...",
+  },
+  {
+    key: "treatmentPlan",
+    label: "Plano terapêutico",
+    placeholder: "Plano de tratamento, condutas, orientações...",
+  },
+  {
+    key: "prescriptions",
+    label: "Prescrições",
+    placeholder: "Medicações, dosagens, exames solicitados...",
+  },
+  {
+    key: "internalNotes",
+    label: "Notas internas",
+    placeholder: "Observações privadas (não visíveis ao paciente)...",
+    patientHidden: true,
+  },
+];
+
+const EMPTY_FORM: Record<ClinicalField["key"], string> = {
+  chiefComplaint: "",
+  diagnosis: "",
+  treatmentPlan: "",
+  prescriptions: "",
+  internalNotes: "",
+};
+
+type MedicalRecordModalProps = {
+  appointmentId: string | null;
+  patientName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+function isFullRecord(
+  record: unknown,
+): record is MedicalRecordResponse {
+  return (
+    record !== null &&
+    typeof record === "object" &&
+    "internalNotes" in (record as Record<string, unknown>)
+  );
+}
+
+export function MedicalRecordModal({
+  appointmentId,
+  patientName,
+  open,
+  onOpenChange,
+}: MedicalRecordModalProps) {
+  const { data: currentUser } = useUserQuery();
+  const { data: existingRecord, isLoading } =
+    useMedicalRecordByAppointmentQuery(open ? appointmentId : null);
+  const createMutation = useCreateMedicalRecordMutation();
+  const updateMutation = useUpdateMedicalRecordMutation();
+
+  const [form, setForm] = useState(EMPTY_FORM);
+
+  const fullRecord = isFullRecord(existingRecord) ? existingRecord : null;
+
+  const isAuthor = useMemo(() => {
+    if (!fullRecord || !currentUser) return false;
+    return fullRecord.author.id === currentUser.id;
+  }, [fullRecord, currentUser]);
+
+  const isReadOnly = Boolean(fullRecord) && !isAuthor;
+
+  useEffect(() => {
+    if (!open) return;
+    if (fullRecord) {
+      setForm({
+        chiefComplaint: fullRecord.chiefComplaint ?? "",
+        diagnosis: fullRecord.diagnosis ?? "",
+        treatmentPlan: fullRecord.treatmentPlan ?? "",
+        prescriptions: fullRecord.prescriptions ?? "",
+        internalNotes: fullRecord.internalNotes ?? "",
+      });
+    } else {
+      setForm(EMPTY_FORM);
+    }
+  }, [open, fullRecord]);
+
+  const hasAnyField = Object.values(form).some((v) => v.trim().length > 0);
+  const isSaving = createMutation.isPending || updateMutation.isPending;
+
+  const handleSave = async () => {
+    if (!appointmentId || !hasAnyField) return;
+
+    const payload = {
+      chiefComplaint: form.chiefComplaint.trim() || undefined,
+      diagnosis: form.diagnosis.trim() || undefined,
+      treatmentPlan: form.treatmentPlan.trim() || undefined,
+      prescriptions: form.prescriptions.trim() || undefined,
+      internalNotes: form.internalNotes.trim() || undefined,
+    };
+
+    try {
+      if (fullRecord) {
+        await updateMutation.mutateAsync({ id: fullRecord.id, data: payload });
+      } else {
+        await createMutation.mutateAsync({ appointmentId, ...payload });
+      }
+      onOpenChange(false);
+    } catch {
+      // erros já tratados via toast nas mutations
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="sm:max-w-2xl bg-white p-0 overflow-hidden border-0 shadow-2xl rounded-2xl max-h-[90vh] flex flex-col"
+        aria-label="Modal de prontuário médico"
+      >
+        <div className="p-6 pb-4 flex-shrink-0">
+          <DialogHeader>
+            <DialogTitle className="text-xl font-semibold text-slate-900 tracking-tight">
+              Prontuário médico
+            </DialogTitle>
+            <DialogDescription className="text-sm text-slate-500 pt-1">
+              Paciente: <span className="font-medium">{patientName}</span>
+              {isReadOnly && fullRecord && (
+                <span className="block mt-1">
+                  Apenas leitura — autor: {fullRecord.author.name}
+                </span>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+        </div>
+
+        <div className="px-6 pb-4 flex-1 overflow-y-auto">
+          {isLoading ? (
+            <div className="py-10 flex justify-center">
+              <Spinner size="lg" />
+            </div>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {FIELDS.map((field) => (
+                <div key={field.key} className="flex flex-col gap-1.5">
+                  <label
+                    htmlFor={`mr-${field.key}`}
+                    className="text-sm font-medium text-slate-700"
+                  >
+                    {field.label}
+                    {field.patientHidden && (
+                      <span className="ml-2 text-[11px] font-normal text-amber-700 bg-amber-50 border border-amber-200 px-1.5 py-0.5 rounded">
+                        Não visível ao paciente
+                      </span>
+                    )}
+                  </label>
+                  <textarea
+                    id={`mr-${field.key}`}
+                    placeholder={field.placeholder}
+                    value={form[field.key]}
+                    onChange={(e) =>
+                      setForm((prev) => ({
+                        ...prev,
+                        [field.key]: e.target.value,
+                      }))
+                    }
+                    readOnly={isReadOnly}
+                    disabled={isSaving}
+                    className="w-full min-h-24 p-3 resize-y rounded-xl bg-slate-50 border border-slate-200 text-slate-700 text-[14.5px] leading-relaxed placeholder:text-slate-400 shadow-sm transition-all duration-200 focus:outline-none focus:bg-white focus:border-blue-500 focus:ring-[3px] focus:ring-blue-500/20 read-only:bg-slate-100 read-only:cursor-default"
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="bg-slate-50 border-t border-slate-100 p-4 px-6 flex justify-end gap-3 flex-shrink-0">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+            className="rounded-xl h-10 border-slate-200 text-slate-600 hover:bg-slate-100 hover:text-slate-900 px-5 font-medium"
+          >
+            {isReadOnly ? "Fechar" : "Cancelar"}
+          </Button>
+          {!isReadOnly && (
+            <Button
+              onClick={handleSave}
+              disabled={!hasAnyField || isSaving || isLoading}
+              title={
+                hasAnyField
+                  ? "Salvar prontuário"
+                  : "Preencha ao menos um campo para salvar"
+              }
+              className="rounded-xl h-10 bg-blue-600 hover:bg-blue-700 text-white shadow-sm px-6 font-medium"
+            >
+              {isSaving ? (
+                <span className="flex items-center gap-2">
+                  <Spinner size="sm" /> Salvando...
+                </span>
+              ) : fullRecord ? (
+                "Atualizar prontuário"
+              ) : (
+                "Salvar prontuário"
+              )}
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/queries/useMedicalRecords.ts
+++ b/apps/web/queries/useMedicalRecords.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  medicalRecordsService,
+  CreateMedicalRecordDto,
+  UpdateMedicalRecordDto,
+} from "@/services/medical-records-service";
+
+const KEYS = {
+  byAppointment: (appointmentId: string) =>
+    ["medical-records", "appointment", appointmentId] as const,
+  byPatient: (patientId: string) =>
+    ["medical-records", "patient", patientId] as const,
+};
+
+export function useMedicalRecordByAppointmentQuery(
+  appointmentId: string | null,
+) {
+  return useQuery({
+    queryKey: KEYS.byAppointment(appointmentId ?? ""),
+    queryFn: () => medicalRecordsService.findByAppointment(appointmentId!),
+    enabled: Boolean(appointmentId),
+  });
+}
+
+export function useMedicalRecordsByPatientQuery(patientId: string | null) {
+  return useQuery({
+    queryKey: KEYS.byPatient(patientId ?? ""),
+    queryFn: () => medicalRecordsService.findByPatient(patientId!),
+    enabled: Boolean(patientId),
+  });
+}
+
+export function useCreateMedicalRecordMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateMedicalRecordDto) =>
+      medicalRecordsService.create(data),
+    onSuccess: (record) => {
+      queryClient.invalidateQueries({
+        queryKey: KEYS.byAppointment(record.appointmentId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: KEYS.byPatient(record.patientId),
+      });
+      toast.success("Prontuário criado com sucesso.");
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Erro ao criar prontuário.");
+    },
+  });
+}
+
+export function useUpdateMedicalRecordMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateMedicalRecordDto }) =>
+      medicalRecordsService.update(id, data),
+    onSuccess: (record) => {
+      queryClient.invalidateQueries({
+        queryKey: KEYS.byAppointment(record.appointmentId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: KEYS.byPatient(record.patientId),
+      });
+      toast.success("Prontuário atualizado com sucesso.");
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Erro ao atualizar prontuário.");
+    },
+  });
+}

--- a/apps/web/services/medical-records-service.ts
+++ b/apps/web/services/medical-records-service.ts
@@ -1,0 +1,108 @@
+import { api } from "../lib/api";
+import { AxiosError } from "axios";
+
+export interface MedicalRecordAuthor {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export interface MedicalRecordResponse {
+  id: string;
+  appointmentId: string;
+  patientId: string;
+  author: MedicalRecordAuthor;
+  chiefComplaint: string | null;
+  diagnosis: string | null;
+  treatmentPlan: string | null;
+  prescriptions: string | null;
+  internalNotes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MedicalRecordPatientResponse {
+  id: string;
+  appointmentId: string;
+  patientId: string;
+  author: MedicalRecordAuthor;
+  chiefComplaint: string | null;
+  diagnosis: string | null;
+  treatmentPlan: string | null;
+  prescriptions: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateMedicalRecordDto {
+  appointmentId: string;
+  chiefComplaint?: string;
+  diagnosis?: string;
+  treatmentPlan?: string;
+  prescriptions?: string;
+  internalNotes?: string;
+}
+
+export type UpdateMedicalRecordDto = Omit<
+  CreateMedicalRecordDto,
+  "appointmentId"
+>;
+
+function extractErrorMessage(error: unknown, fallback: string): never {
+  if (error instanceof AxiosError && error.response) {
+    const message = error.response.data.message;
+    if (Array.isArray(message)) {
+      throw new Error(message.join(", "));
+    }
+    throw new Error(message || fallback);
+  }
+  throw new Error("Erro de conexão com o servidor.");
+}
+
+export const medicalRecordsService = {
+  async create(data: CreateMedicalRecordDto): Promise<MedicalRecordResponse> {
+    try {
+      const response = await api.post("/medical-records", data);
+      return response.data as MedicalRecordResponse;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao criar prontuário.");
+    }
+  },
+
+  async findByAppointment(
+    appointmentId: string,
+  ): Promise<MedicalRecordResponse | MedicalRecordPatientResponse | null> {
+    try {
+      const response = await api.get(
+        `/medical-records/appointment/${appointmentId}`,
+      );
+      return response.data;
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.status === 404) {
+        return null;
+      }
+      extractErrorMessage(error, "Erro ao buscar prontuário.");
+    }
+  },
+
+  async findByPatient(patientId: string): Promise<MedicalRecordResponse[]> {
+    try {
+      const response = await api.get(`/medical-records/patient/${patientId}`);
+      return response.data as MedicalRecordResponse[];
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao buscar prontuários do paciente.");
+    }
+  },
+
+  async update(
+    id: string,
+    data: UpdateMedicalRecordDto,
+  ): Promise<MedicalRecordResponse> {
+    try {
+      const response = await api.patch(`/medical-records/${id}`, data);
+      return response.data as MedicalRecordResponse;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao atualizar prontuário.");
+    }
+  },
+};


### PR DESCRIPTION
## Resumo

Implementa a interface do profissional para criar, visualizar e editar prontuário médico em consultas. Consome a API do PR #132 (issue #127).

**Depende de #132 ser mergeado para funcionar end-to-end.**

## Componentes
- `medical-records-service.ts`: client HTTP para `/medical-records` (POST, GET por appointment, GET por paciente, PATCH). `findByAppointment` retorna `null` em 404, distinguindo "consulta sem prontuário" de erro.
- `queries/useMedicalRecords.ts`: hooks TanStack Query com invalidação por `appointmentId` e `patientId`. Toast de sucesso/erro padronizado.
- `MedicalRecordModal.tsx`: modal com 5 campos clínicos (queixa principal, diagnóstico, plano terapêutico, prescrições, notas internas)
- `AppointmentCard.tsx`: novo item "Prontuário" no dropdown para status `CONFIRMED` e `COMPLETED` (alinhado com o `VALID_LINK_STATUSES` do backend)

## Comportamento do modal
- **Sem prontuário** → formulário em branco para criação
- **Prontuário existente, usuário é autor** → carrega valores, permite editar
- **Prontuário existente, outro profissional (com vínculo)** → somente leitura, exibe autor
- Campo `internalNotes` com label "Não visível ao paciente" em destaque âmbar
- Botão "Salvar" desabilitado até pelo menos um campo ser preenchido
- Botão muda para "Atualizar prontuário" quando editando

## Decisões de implementação
- Reuso do `useUserQuery` existente para detectar autor (compara `user.id` com `record.author.id`)
- Type guard `isFullRecord` para discriminar resposta com `internalNotes` (profissional) da resposta sem (paciente — não usado nesta tela, mas o tipo de retorno do service permite ambos)
- Modal segue padrão visual do `ConfirmModal` existente (slate/blue, rounded-2xl)

## Plano de teste
- [ ] Abrir dropdown em consulta `PENDING` → "Prontuário" não aparece
- [ ] Abrir dropdown em consulta `CONFIRMED` → "Prontuário" aparece
- [ ] Abrir dropdown em consulta `COMPLETED` → "Prontuário" aparece
- [ ] Modal sem prontuário existente: salvar com todos campos vazios é bloqueado
- [ ] Modal sem prontuário: preencher 1 campo → "Salvar prontuário" → toast sucesso
- [ ] Reabrir modal: valores carregados, botão muda para "Atualizar prontuário"
- [ ] Logar como outro profissional com vínculo: campos read-only, sem botão Salvar
- [ ] Editar como autor → toast "Prontuário atualizado com sucesso"

Closes #128