### PR TITLE
feat(mail): adiciona Resend como provider alternativo de email

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -18,3 +18,22 @@ GOOGLE_CALENDAR_CLIENT_ID=
 GOOGLE_CALENDAR_CLIENT_SECRET=
 GOOGLE_CALENDAR_REFRESH_TOKEN=
 GOOGLE_CALENDAR_ID=primary
+
+# Email
+# MAIL_PROVIDER controla qual serviço será usado para envio de email.
+# Valores aceitos: "smtp" (VPS/servidor SMTP próprio), "resend" (API Resend), "ethereal" (testes em dev).
+# Se omitido: usa "ethereal" em desenvolvimento; em produção, prefere "resend" se RESEND_API_KEY existir,
+# caso contrário cai para "smtp" se MAIL_HOST estiver definido.
+MAIL_PROVIDER=smtp
+MAIL_FROM="LifeMed <noreply@lifemed.com>"
+
+# SMTP (VPS / provedor próprio)
+MAIL_HOST=smtp.gmail.com
+MAIL_PORT=465
+MAIL_SECURE=true
+MAIL_USER=
+MAIL_PASS=
+MAIL_CONTACT=
+
+# Resend (https://resend.com)
+RESEND_API_KEY=

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -46,6 +46,7 @@
     "pdfkit": "^0.18.0",
     "prisma": "^6.19.1",
     "reflect-metadata": "^0.2.2",
+    "resend": "^6.12.3",
     "rxjs": "^7.8.1",
     "zod": "^4.3.6"
   },

--- a/apps/server/src/mail/mail.service.ts
+++ b/apps/server/src/mail/mail.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import * as nodemailer from 'nodemailer';
+
+import { createMailer, resolveProvider } from './mailers/mailer.factory';
+import { Mailer, SendEmailInput, EmailAttachment } from './mailers/mailer';
 
 import { createPasswordResetEmail } from './templates/password-reset.template';
 import { createNewUserNotificationEmail } from './templates/new-user-notification.template';
@@ -13,71 +15,23 @@ import { createAppointmentCreatedProfessionalEmail } from './templates/appointme
 import { createAppointmentCancelledEmail } from './templates/appointment-cancelled.template';
 import { createMassCancellationEmail } from './templates/mass-cancellation.template';
 
-export type EmailAttachment = {
-  filename: string;
-  content: string | Buffer;
-  contentType: string;
-};
-
-interface SendEmailInput {
-  to: string;
-  subject: string;
-  html: string;
-  cc?: string[];
-  from?: string;
-  attachments?: EmailAttachment[];
-}
+export type { EmailAttachment };
 
 @Injectable()
 export class MailService implements OnModuleInit {
   private readonly logger = new Logger(MailService.name);
-  private transporter: nodemailer.Transporter;
-  private isDevelopment = process.env.NODE_ENV === 'development';
+  private mailer: Mailer | null = null;
+  private readonly defaultFrom =
+    process.env.MAIL_FROM || 'LifeMed <onboarding@resend.dev>';
 
   async onModuleInit() {
-    if (this.isDevelopment) {
-      const testAccount = await nodemailer.createTestAccount();
-      this.transporter = nodemailer.createTransport({
-        host: 'smtp.ethereal.email',
-        port: 587,
-        secure: false,
-        auth: { user: testAccount.user, pass: testAccount.pass },
-      });
-      this.logger.log(
-        'Transporter de email configurado (modo desenvolvimento)',
-      );
-    } else {
-      this.transporter = nodemailer.createTransport({
-        host: process.env.MAIL_HOST,
-        port: Number(process.env.MAIL_PORT),
-        secure: process.env.MAIL_SECURE === 'true',
-        auth: {
-          user: process.env.MAIL_USER,
-          pass: process.env.MAIL_PASS,
-        },
-      });
-      this.logger.log('Transporter de email configurado (modo produção)');
-    }
+    this.mailer = await createMailer(resolveProvider(), this.defaultFrom);
   }
 
   async sendEmail(input: SendEmailInput): Promise<void> {
+    if (!this.mailer) throw new Error('Mailer não inicializado');
     try {
-      const info = await this.transporter.sendMail({
-        from: input.from || '"Life Med" <noreply@lifemed.com>',
-        to: input.to,
-        cc: input.cc,
-        subject: input.subject,
-        html: input.html,
-        attachments: input.attachments,
-      });
-
-      if (this.isDevelopment) {
-        this.logger.log(
-          `Email de teste enviado: ${nodemailer.getTestMessageUrl(info)}`,
-        );
-      } else {
-        this.logger.log(`Email enviado: ${info.messageId}`);
-      }
+      await this.mailer.send(input);
     } catch (error) {
       this.logger.error(
         `Falha ao enviar email para ${input.to}: ${(error as Error).message}`,

--- a/apps/server/src/mail/mailers/ethereal.mailer.ts
+++ b/apps/server/src/mail/mailers/ethereal.mailer.ts
@@ -1,0 +1,38 @@
+import { Logger } from '@nestjs/common';
+import * as nodemailer from 'nodemailer';
+
+import { Mailer, SendEmailInput } from './mailer';
+
+export class EtherealMailer implements Mailer {
+  private readonly logger = new Logger(EtherealMailer.name);
+
+  constructor(
+    private readonly transporter: nodemailer.Transporter,
+    private readonly defaultFrom: string,
+  ) {}
+
+  static async create(defaultFrom: string): Promise<EtherealMailer> {
+    const account = await nodemailer.createTestAccount();
+    const transporter = nodemailer.createTransport({
+      host: 'smtp.ethereal.email',
+      port: 587,
+      secure: false,
+      auth: { user: account.user, pass: account.pass },
+    });
+    return new EtherealMailer(transporter, defaultFrom);
+  }
+
+  async send(input: SendEmailInput): Promise<void> {
+    const info = await this.transporter.sendMail({
+      from: input.from || this.defaultFrom,
+      to: input.to,
+      cc: input.cc,
+      subject: input.subject,
+      html: input.html,
+      attachments: input.attachments,
+    });
+    this.logger.log(
+      `Email de teste enviado: ${nodemailer.getTestMessageUrl(info)}`,
+    );
+  }
+}

--- a/apps/server/src/mail/mailers/mailer.factory.ts
+++ b/apps/server/src/mail/mailers/mailer.factory.ts
@@ -1,0 +1,48 @@
+import { Logger } from '@nestjs/common';
+import * as nodemailer from 'nodemailer';
+
+import { EtherealMailer } from './ethereal.mailer';
+import { Mailer, MAIL_PROVIDERS, MailProvider } from './mailer';
+import { ResendMailer } from './resend.mailer';
+import { SmtpMailer } from './smtp.mailer';
+
+const logger = new Logger('MailerFactory');
+
+export function resolveProvider(): MailProvider {
+  const explicit = process.env.MAIL_PROVIDER?.toLowerCase();
+  if ((MAIL_PROVIDERS as readonly string[]).includes(explicit ?? '')) {
+    return explicit as MailProvider;
+  }
+  if (process.env.NODE_ENV === 'development') return 'ethereal';
+  if (process.env.RESEND_API_KEY) return 'resend';
+  if (process.env.MAIL_HOST) return 'smtp';
+  return 'ethereal';
+}
+
+export async function createMailer(
+  provider: MailProvider,
+  defaultFrom: string,
+): Promise<Mailer> {
+  logger.log(`Mail provider: ${provider}`);
+
+  if (provider === 'resend') {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) throw new Error('RESEND_API_KEY não configurada');
+    return new ResendMailer(apiKey, defaultFrom);
+  }
+
+  if (provider === 'smtp') {
+    const transporter = nodemailer.createTransport({
+      host: process.env.MAIL_HOST,
+      port: Number(process.env.MAIL_PORT),
+      secure: process.env.MAIL_SECURE === 'true',
+      auth: { user: process.env.MAIL_USER, pass: process.env.MAIL_PASS },
+      connectionTimeout: 10_000,
+      greetingTimeout: 10_000,
+      socketTimeout: 15_000,
+    });
+    return new SmtpMailer(transporter, defaultFrom);
+  }
+
+  return EtherealMailer.create(defaultFrom);
+}

--- a/apps/server/src/mail/mailers/mailer.ts
+++ b/apps/server/src/mail/mailers/mailer.ts
@@ -1,0 +1,21 @@
+export type EmailAttachment = {
+  filename: string;
+  content: string | Buffer;
+  contentType: string;
+};
+
+export interface SendEmailInput {
+  to: string;
+  subject: string;
+  html: string;
+  cc?: string[];
+  from?: string;
+  attachments?: EmailAttachment[];
+}
+
+export interface Mailer {
+  send(input: SendEmailInput): Promise<void>;
+}
+
+export const MAIL_PROVIDERS = ['resend', 'smtp', 'ethereal'] as const;
+export type MailProvider = (typeof MAIL_PROVIDERS)[number];

--- a/apps/server/src/mail/mailers/resend.mailer.ts
+++ b/apps/server/src/mail/mailers/resend.mailer.ts
@@ -1,0 +1,32 @@
+import { Logger } from '@nestjs/common';
+import { Resend } from 'resend';
+
+import { Mailer, SendEmailInput } from './mailer';
+
+export class ResendMailer implements Mailer {
+  private readonly logger = new Logger(ResendMailer.name);
+  private readonly client: Resend;
+
+  constructor(
+    apiKey: string,
+    private readonly defaultFrom: string,
+  ) {
+    this.client = new Resend(apiKey);
+  }
+
+  async send(input: SendEmailInput): Promise<void> {
+    const result = await this.client.emails.send({
+      from: input.from || this.defaultFrom,
+      to: input.to,
+      cc: input.cc,
+      subject: input.subject,
+      html: input.html,
+      attachments: input.attachments?.map((a) => ({
+        filename: a.filename,
+        content: a.content,
+      })),
+    });
+    if (result.error) throw new Error(result.error.message);
+    this.logger.log(`Email enviado via Resend: ${result.data?.id}`);
+  }
+}

--- a/apps/server/src/mail/mailers/smtp.mailer.ts
+++ b/apps/server/src/mail/mailers/smtp.mailer.ts
@@ -1,0 +1,25 @@
+import { Logger } from '@nestjs/common';
+import * as nodemailer from 'nodemailer';
+
+import { Mailer, SendEmailInput } from './mailer';
+
+export class SmtpMailer implements Mailer {
+  private readonly logger = new Logger(SmtpMailer.name);
+
+  constructor(
+    private readonly transporter: nodemailer.Transporter,
+    private readonly defaultFrom: string,
+  ) {}
+
+  async send(input: SendEmailInput): Promise<void> {
+    const info = await this.transporter.sendMail({
+      from: input.from || this.defaultFrom,
+      to: input.to,
+      cc: input.cc,
+      subject: input.subject,
+      html: input.html,
+      attachments: input.attachments,
+    });
+    this.logger.log(`Email enviado via SMTP: ${info.messageId}`);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "pdfkit": "^0.18.0",
         "prisma": "^6.19.1",
         "reflect-metadata": "^0.2.2",
+        "resend": "^6.12.3",
         "rxjs": "^7.8.1",
         "zod": "^4.3.6"
       },
@@ -6389,6 +6390,12 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -12260,6 +12267,12 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -19662,6 +19675,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -20769,6 +20788,27 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
@@ -22182,6 +22222,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -22621,6 +22671,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/swagger-ui-dist": {


### PR DESCRIPTION
## Summary

- Adiciona o **Resend** como opcao de envio de email, selecionavel via env `MAIL_PROVIDER`.
- Mantem o envio SMTP/VPS existente intacto como padrao — nenhum consumidor do `MailService` precisou mudar.
- Refatora o `MailService` para o padrao Strategy: cada canal (Resend, SMTP, Ethereal) vira uma classe pequena implementando a interface `Mailer`. O `MailService` deixa de conhecer detalhes de cada provider e passa a apenas orquestrar templates.

## Por que

O `MailService` antigo tinha tres caminhos de inicializacao e dois ramos completos no `sendEmail`, com try/catch duplicado e CC alta. Separar em classes (`ResendMailer`, `SmtpMailer`, `EtherealMailer` + `mailer.factory`) reduz a complexidade ciclomatica, isola o SDK do Resend e facilita adicionar novos providers no futuro.

## Como funciona

`MAIL_PROVIDER` controla o canal:

- `smtp` — envia via SMTP (VPS/Gmail/etc), usando `MAIL_HOST/PORT/USER/PASS`.
- `resend` — envia via API Resend, usando `RESEND_API_KEY` e `MAIL_FROM`.
- `ethereal` — conta de teste em dev.

Sem `MAIL_PROVIDER` definido, mantem o fallback antigo: `ethereal` em dev; em prod prefere `resend` se `RESEND_API_KEY` existir, senao cai para `smtp` se `MAIL_HOST` existir.

## Arquivos

- `apps/server/src/mail/mailers/mailer.ts` — interface `Mailer`, tipos `SendEmailInput`, `EmailAttachment`, `MailProvider`.
- `apps/server/src/mail/mailers/{resend,smtp,ethereal}.mailer.ts` — implementacoes.
- `apps/server/src/mail/mailers/mailer.factory.ts` — `resolveProvider()` + `createMailer()`.
- `apps/server/src/mail/mail.service.ts` — enxugado; `sendEmail` virou um delegate de ~8 linhas.
- `apps/server/.env.example` — documenta as novas envs.
- `apps/server/package.json` — adiciona `resend`.

## Test plan

- [x] `tsc --noEmit` passa.
- [x] Server sobe localmente com `MAIL_PROVIDER=resend` e loga `Mail provider: resend`.
- [x] `POST /auth/register` cria conta e envia email de verificacao via Resend (id retornado pela API).
- [ ] Validar SMTP em ambiente que ainda usa Gmail (`MAIL_PROVIDER=smtp`) — sem mudanca esperada.
- [ ] Configurar `RESEND_API_KEY`, `MAIL_PROVIDER=resend` e `MAIL_FROM` no Render para o ambiente de deploy.

## Notas para deploy

Em producao no Render, adicionar nas env vars do servico `server`:

- `MAIL_PROVIDER=resend`
- `RESEND_API_KEY=re_...` (nova chave; a usada em teste local sera revogada)
- `MAIL_FROM="LifeMed <noreply@dominio-verificado>"`

Manter `MAIL_HOST/PORT/USER/PASS` permite alternar de volta para SMTP apenas trocando `MAIL_PROVIDER=smtp`.