### PR TITLE
fix: separate patient email verification from professional pending approval

### DIFF
--- a/apps/server/src/auth/auth.service.ts
+++ b/apps/server/src/auth/auth.service.ts
@@ -56,6 +56,11 @@ export class AuthService {
     }
 
     if (!user.emailVerified) {
+      if (user.role === UserRole.PATIENT) {
+        throw new UnauthorizedException(
+          'Seu e-mail ainda não foi verificado. Verifique sua caixa de entrada.',
+        );
+      }
       throw new UnauthorizedException(
         'Sua conta ainda não foi aprovada. Aguarde a verificação do administrador.',
       );

--- a/apps/web/app/auth/login/useLoginForm.ts
+++ b/apps/web/app/auth/login/useLoginForm.ts
@@ -44,7 +44,7 @@ export function useLoginForm() {
             return;
           }
 
-          if (message.includes("e-mail ainda não foi verificado")) {
+          if (message.includes("ainda não foi verificado")) {
             toast.info(message);
             return;
           }


### PR DESCRIPTION
## Summary

- Pacientes sem e-mail verificado agora recebem a mensagem correta: _"Seu e-mail ainda não foi verificado. Verifique sua caixa de entrada."_ — sem redirecionamento para a página de aprovação pendente
- A página `/auth/pending-approval` passa a ser exibida **somente** para profissionais aguardando aprovação do administrador
- Ajuste no matcher do frontend para capturar a nova mensagem específica de paciente

## Test plan

- [ ] Cadastrar paciente → confirmar toast correto: "Cadastro realizado com sucesso! Verifique seu email..."
- [ ] Tentar logar como paciente sem verificar e-mail → deve exibir toast informativo e permanecer na tela de login (sem redirecionar para pending-approval)
- [ ] Tentar logar como profissional sem aprovação → deve exibir toast e redirecionar para `/auth/pending-approval`