### PR TITLE
feat(medical-records): paginated list and findById endpoints

### DIFF
--- a/apps/server/src/medical-records/dto/list-medical-records-query.dto.ts
+++ b/apps/server/src/medical-records/dto/list-medical-records-query.dto.ts
@@ -1,0 +1,73 @@
+import {
+  IsOptional,
+  IsUUID,
+  IsDateString,
+  IsNumber,
+  IsString,
+  Min,
+  Max,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class ListMedicalRecordsQueryDto {
+  @ApiProperty({
+    description: 'Filtrar pelo ID do paciente',
+    required: false,
+  })
+  @IsUUID('all', { message: 'patientId inválido' })
+  @IsOptional()
+  patientId?: string;
+
+  @ApiProperty({
+    description:
+      'Filtrar pelo ID do autor (médico). Pacientes ignoram esse filtro.',
+    required: false,
+  })
+  @IsUUID('all', { message: 'authorId inválido' })
+  @IsOptional()
+  authorId?: string;
+
+  @ApiProperty({
+    description:
+      'Busca textual no nome do paciente ou nos campos clínicos do prontuário',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  search?: string;
+
+  @ApiProperty({
+    example: '2024-06-01',
+    description: 'Data inicial (YYYY-MM-DD)',
+    required: false,
+  })
+  @IsDateString({}, { message: 'Data inicial inválida' })
+  @IsOptional()
+  startDate?: string;
+
+  @ApiProperty({
+    example: '2024-06-30',
+    description: 'Data final (YYYY-MM-DD)',
+    required: false,
+  })
+  @IsDateString({}, { message: 'Data final inválida' })
+  @IsOptional()
+  endDate?: string;
+
+  @ApiProperty({ example: 1, required: false })
+  @Type(() => Number)
+  @IsNumber({}, { message: 'Página deve ser um número' })
+  @Min(1, { message: 'Página deve ser no mínimo 1' })
+  @Max(1000, { message: 'Página máxima é 1000' })
+  @IsOptional()
+  page?: number = 1;
+
+  @ApiProperty({ example: 10, required: false })
+  @Type(() => Number)
+  @IsNumber({}, { message: 'Limit deve ser um número' })
+  @Min(1, { message: 'Limit deve ser no mínimo 1' })
+  @Max(100, { message: 'Limit máximo é 100 registros' })
+  @IsOptional()
+  limit?: number = 10;
+}

--- a/apps/server/src/medical-records/dto/medical-record-response.dto.ts
+++ b/apps/server/src/medical-records/dto/medical-record-response.dto.ts
@@ -6,12 +6,27 @@ export class MedicalRecordAuthorDto {
   @ApiProperty() email!: string;
 }
 
+export class MedicalRecordPatientDto {
+  @ApiProperty() id!: string;
+  @ApiProperty() name!: string;
+}
+
+export class MedicalRecordAppointmentDto {
+  @ApiProperty() id!: string;
+  @ApiProperty() dateTime!: Date;
+  @ApiProperty() modality!: string;
+}
+
 export class MedicalRecordResponseDto {
   @ApiProperty() id!: string;
   @ApiProperty() appointmentId!: string;
   @ApiProperty() patientId!: string;
   @ApiProperty({ type: MedicalRecordAuthorDto })
   author!: MedicalRecordAuthorDto;
+  @ApiProperty({ type: MedicalRecordPatientDto, required: false })
+  patient?: MedicalRecordPatientDto;
+  @ApiProperty({ type: MedicalRecordAppointmentDto, required: false })
+  appointment?: MedicalRecordAppointmentDto;
   @ApiProperty({ nullable: true }) chiefComplaint!: string | null;
   @ApiProperty({ nullable: true }) diagnosis!: string | null;
   @ApiProperty({ nullable: true }) treatmentPlan!: string | null;
@@ -27,10 +42,28 @@ export class MedicalRecordPatientResponseDto {
   @ApiProperty() patientId!: string;
   @ApiProperty({ type: MedicalRecordAuthorDto })
   author!: MedicalRecordAuthorDto;
+  @ApiProperty({ type: MedicalRecordAppointmentDto, required: false })
+  appointment?: MedicalRecordAppointmentDto;
   @ApiProperty({ nullable: true }) chiefComplaint!: string | null;
   @ApiProperty({ nullable: true }) diagnosis!: string | null;
   @ApiProperty({ nullable: true }) treatmentPlan!: string | null;
   @ApiProperty({ nullable: true }) prescriptions!: string | null;
   @ApiProperty() createdAt!: Date;
   @ApiProperty() updatedAt!: Date;
+}
+
+export class MedicalRecordListResponseDto {
+  @ApiProperty({ type: [MedicalRecordResponseDto] })
+  data!: MedicalRecordResponseDto[];
+  @ApiProperty({ example: 1 }) page!: number;
+  @ApiProperty({ example: 10 }) limit!: number;
+  @ApiProperty({ example: 0 }) total!: number;
+}
+
+export class MedicalRecordPatientListResponseDto {
+  @ApiProperty({ type: [MedicalRecordPatientResponseDto] })
+  data!: MedicalRecordPatientResponseDto[];
+  @ApiProperty({ example: 1 }) page!: number;
+  @ApiProperty({ example: 10 }) limit!: number;
+  @ApiProperty({ example: 0 }) total!: number;
 }

--- a/apps/server/src/medical-records/medical-records.controller.ts
+++ b/apps/server/src/medical-records/medical-records.controller.ts
@@ -5,6 +5,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Request,
   Res,
   UseGuards,
@@ -23,9 +24,12 @@ import type { Response } from 'express';
 import { MedicalRecordsService } from './medical-records.service';
 import { CreateMedicalRecordDto } from './dto/create-medical-record.dto';
 import { UpdateMedicalRecordDto } from './dto/update-medical-record.dto';
+import { ListMedicalRecordsQueryDto } from './dto/list-medical-records-query.dto';
 import {
   MedicalRecordResponseDto,
   MedicalRecordPatientResponseDto,
+  MedicalRecordListResponseDto,
+  MedicalRecordPatientListResponseDto,
 } from './dto/medical-record-response.dto';
 import { ProfessionalRoleGuard } from '../professional/guards/professional-role.guard';
 import { PatientRoleGuard } from '../patients/guards/patient-role.guard';
@@ -52,6 +56,39 @@ export class MedicalRecordsController {
     @Body() dto: CreateMedicalRecordDto,
   ) {
     return this.service.create(req.user.userId, dto);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: 'Listar prontuários do usuário autenticado',
+    description:
+      'Médico: lista os prontuários que ele criou. Paciente: lista os próprios prontuários (sem internalNotes).',
+  })
+  @ApiResponse({ status: 200, type: MedicalRecordListResponseDto })
+  list(
+    @Request() req: { user: { userId: string; role: UserRole } },
+    @Query() query: ListMedicalRecordsQueryDto,
+  ): Promise<
+    MedicalRecordListResponseDto | MedicalRecordPatientListResponseDto
+  > {
+    return this.service.list(req.user.userId, req.user.role, query);
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Buscar prontuário por ID',
+    description:
+      'Profissional autor recebe todos os campos. Paciente dono não recebe internalNotes (LGPD).',
+  })
+  @ApiParam({ name: 'id', description: 'ID do prontuário' })
+  @ApiResponse({ status: 200, type: MedicalRecordResponseDto })
+  @ApiResponse({ status: 403, description: 'Acesso negado.' })
+  @ApiResponse({ status: 404, description: 'Prontuário não encontrado.' })
+  findById(
+    @Request() req: { user: { userId: string; role: UserRole } },
+    @Param('id') id: string,
+  ): Promise<MedicalRecordResponseDto | MedicalRecordPatientResponseDto> {
+    return this.service.findById(id, req.user.userId, req.user.role);
   }
 
   @Get('appointment/:appointmentId')
@@ -120,6 +157,7 @@ export class MedicalRecordsController {
     doc.pipe(res);
     doc.end();
   }
+
   @Patch(':id')
   @UseGuards(ProfessionalRoleGuard)
   @ApiOperation({ summary: 'Atualizar prontuário (somente autor)' })

--- a/apps/server/src/medical-records/medical-records.service.ts
+++ b/apps/server/src/medical-records/medical-records.service.ts
@@ -8,23 +8,36 @@ import { AppointmentStatus, Prisma, UserRole } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateMedicalRecordDto } from './dto/create-medical-record.dto';
 import { UpdateMedicalRecordDto } from './dto/update-medical-record.dto';
+import { ListMedicalRecordsQueryDto } from './dto/list-medical-records-query.dto';
 import {
   MedicalRecordResponseDto,
   MedicalRecordPatientResponseDto,
+  MedicalRecordListResponseDto,
+  MedicalRecordPatientListResponseDto,
 } from './dto/medical-record-response.dto';
 import {
   MedicalRecordPdfService,
   PatientMedicalRecordPdfInput,
 } from './medical-record-pdf.service';
 
-type MedicalRecordWithAuthor = Prisma.MedicalRecordGetPayload<{
-  include: { author: true };
+type MedicalRecordWithRelations = Prisma.MedicalRecordGetPayload<{
+  include: {
+    author: true;
+    patient: true;
+    appointment: true;
+  };
 }>;
 
 const VALID_LINK_STATUSES: AppointmentStatus[] = [
   AppointmentStatus.CONFIRMED,
   AppointmentStatus.COMPLETED,
 ];
+
+const RECORD_INCLUDE = {
+  author: true,
+  patient: true,
+  appointment: true,
+} as const;
 
 @Injectable()
 export class MedicalRecordsService {
@@ -63,7 +76,7 @@ export class MedicalRecordsService {
           prescriptions: dto.prescriptions,
           internalNotes: dto.internalNotes,
         },
-        include: { author: true },
+        include: RECORD_INCLUDE,
       });
       return this.toResponseDto(record);
     } catch (error) {
@@ -93,30 +106,120 @@ export class MedicalRecordsService {
 
     const record = await this.prisma.medicalRecord.findUnique({
       where: { appointmentId },
-      include: { author: true },
+      include: RECORD_INCLUDE,
     });
 
     if (!record) {
       throw new NotFoundException('Prontuário não encontrado.');
     }
 
-    if (requesterRole === UserRole.PATIENT) {
-      if (record.patientId !== requesterId) {
-        throw new ForbiddenException('Acesso negado a este prontuário.');
-      }
-      return this.toPatientResponseDto(record);
-    }
+    return this.authorizeAndSerialize(record, requesterId, requesterRole);
+  }
 
-    const isAuthor = record.authorId === requesterId;
-    const hasLink =
-      isAuthor ||
-      (await this.hasPriorAppointment(requesterId, record.patientId));
-
-    if (!hasLink) {
+  async findById(
+    recordId: string,
+    requesterId: string,
+    requesterRole: UserRole,
+  ): Promise<MedicalRecordResponseDto | MedicalRecordPatientResponseDto> {
+    if (
+      requesterRole !== UserRole.PROFESSIONAL &&
+      requesterRole !== UserRole.PATIENT
+    ) {
       throw new ForbiddenException('Acesso negado a este prontuário.');
     }
 
-    return this.toResponseDto(record);
+    const record = await this.prisma.medicalRecord.findUnique({
+      where: { id: recordId },
+      include: RECORD_INCLUDE,
+    });
+
+    if (!record) {
+      throw new NotFoundException('Prontuário não encontrado.');
+    }
+
+    return this.authorizeAndSerialize(record, requesterId, requesterRole);
+  }
+
+  async list(
+    requesterId: string,
+    requesterRole: UserRole,
+    query: ListMedicalRecordsQueryDto,
+  ): Promise<
+    MedicalRecordListResponseDto | MedicalRecordPatientListResponseDto
+  > {
+    if (
+      requesterRole !== UserRole.PROFESSIONAL &&
+      requesterRole !== UserRole.PATIENT
+    ) {
+      throw new ForbiddenException('Acesso negado.');
+    }
+
+    const page = query.page || 1;
+    const limit = query.limit || 10;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.MedicalRecordWhereInput = {};
+
+    if (requesterRole === UserRole.PROFESSIONAL) {
+      // Médico vê apenas prontuários que ele mesmo criou
+      where.authorId = requesterId;
+      if (query.patientId) where.patientId = query.patientId;
+      if (query.authorId && query.authorId !== requesterId) {
+        // não permitir ver de outros médicos
+        throw new ForbiddenException(
+          'Não é possível listar prontuários de outros profissionais.',
+        );
+      }
+    } else {
+      // Paciente vê apenas os próprios
+      where.patientId = requesterId;
+      if (query.authorId) where.authorId = query.authorId;
+    }
+
+    if (query.startDate || query.endDate) {
+      where.createdAt = {
+        ...(query.startDate && { gte: new Date(query.startDate) }),
+        ...(query.endDate && { lte: new Date(query.endDate) }),
+      };
+    }
+
+    if (query.search) {
+      const term = query.search.trim();
+      if (term.length > 0) {
+        where.OR = [
+          { patient: { name: { contains: term, mode: 'insensitive' } } },
+          { chiefComplaint: { contains: term, mode: 'insensitive' } },
+          { diagnosis: { contains: term, mode: 'insensitive' } },
+        ];
+      }
+    }
+
+    const [records, total] = await Promise.all([
+      this.prisma.medicalRecord.findMany({
+        where,
+        include: RECORD_INCLUDE,
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.medicalRecord.count({ where }),
+    ]);
+
+    if (requesterRole === UserRole.PATIENT) {
+      return {
+        data: records.map((r) => this.toPatientResponseDto(r)),
+        page,
+        limit,
+        total,
+      };
+    }
+
+    return {
+      data: records.map((r) => this.toResponseDto(r)),
+      page,
+      limit,
+      total,
+    };
   }
 
   async findByPatient(
@@ -133,7 +236,7 @@ export class MedicalRecordsService {
 
     const records = await this.prisma.medicalRecord.findMany({
       where: { patientId },
-      include: { author: true },
+      include: RECORD_INCLUDE,
       orderBy: { createdAt: 'desc' },
     });
 
@@ -147,7 +250,7 @@ export class MedicalRecordsService {
   ): Promise<MedicalRecordResponseDto> {
     const record = await this.prisma.medicalRecord.findUnique({
       where: { id: recordId },
-      include: { author: true },
+      include: RECORD_INCLUDE,
     });
 
     if (!record) {
@@ -169,7 +272,7 @@ export class MedicalRecordsService {
         prescriptions: dto.prescriptions,
         internalNotes: dto.internalNotes,
       },
-      include: { author: true },
+      include: RECORD_INCLUDE,
     });
 
     return this.toResponseDto(updated);
@@ -234,6 +337,31 @@ export class MedicalRecordsService {
 
     return this.pdfService.generate(input);
   }
+
+  private async authorizeAndSerialize(
+    record: MedicalRecordWithRelations,
+    requesterId: string,
+    requesterRole: UserRole,
+  ): Promise<MedicalRecordResponseDto | MedicalRecordPatientResponseDto> {
+    if (requesterRole === UserRole.PATIENT) {
+      if (record.patientId !== requesterId) {
+        throw new ForbiddenException('Acesso negado a este prontuário.');
+      }
+      return this.toPatientResponseDto(record);
+    }
+
+    const isAuthor = record.authorId === requesterId;
+    const hasLink =
+      isAuthor ||
+      (await this.hasPriorAppointment(requesterId, record.patientId));
+
+    if (!hasLink) {
+      throw new ForbiddenException('Acesso negado a este prontuário.');
+    }
+
+    return this.toResponseDto(record);
+  }
+
   private async hasPriorAppointment(
     professionalId: string,
     patientId: string,
@@ -249,7 +377,7 @@ export class MedicalRecordsService {
   }
 
   private toResponseDto(
-    record: MedicalRecordWithAuthor,
+    record: MedicalRecordWithRelations,
   ): MedicalRecordResponseDto {
     return {
       id: record.id,
@@ -259,6 +387,15 @@ export class MedicalRecordsService {
         id: record.author.id,
         name: record.author.name,
         email: record.author.email,
+      },
+      patient: {
+        id: record.patient.id,
+        name: record.patient.name,
+      },
+      appointment: {
+        id: record.appointment.id,
+        dateTime: record.appointment.dateTime,
+        modality: record.appointment.modality,
       },
       chiefComplaint: record.chiefComplaint,
       diagnosis: record.diagnosis,
@@ -271,7 +408,7 @@ export class MedicalRecordsService {
   }
 
   private toPatientResponseDto(
-    record: MedicalRecordWithAuthor,
+    record: MedicalRecordWithRelations,
   ): MedicalRecordPatientResponseDto {
     return {
       id: record.id,
@@ -281,6 +418,11 @@ export class MedicalRecordsService {
         id: record.author.id,
         name: record.author.name,
         email: record.author.email,
+      },
+      appointment: {
+        id: record.appointment.id,
+        dateTime: record.appointment.dateTime,
+        modality: record.appointment.modality,
       },
       chiefComplaint: record.chiefComplaint,
       diagnosis: record.diagnosis,

--- a/apps/web/queries/useMedicalRecords.ts
+++ b/apps/web/queries/useMedicalRecords.ts
@@ -3,15 +3,45 @@ import { toast } from "sonner";
 import {
   medicalRecordsService,
   CreateMedicalRecordDto,
+  ListMedicalRecordsParams,
   UpdateMedicalRecordDto,
 } from "@/services/medical-records-service";
 
 const KEYS = {
+  list: (params: ListMedicalRecordsParams) =>
+    ["medical-records", "list", params] as const,
+  listForPatient: (params: ListMedicalRecordsParams) =>
+    ["medical-records", "list-patient", params] as const,
+  byId: (id: string) => ["medical-records", "id", id] as const,
   byAppointment: (appointmentId: string) =>
     ["medical-records", "appointment", appointmentId] as const,
   byPatient: (patientId: string) =>
     ["medical-records", "patient", patientId] as const,
 };
+
+export function useMedicalRecordsListQuery(params: ListMedicalRecordsParams) {
+  return useQuery({
+    queryKey: KEYS.list(params),
+    queryFn: () => medicalRecordsService.list(params),
+  });
+}
+
+export function useMedicalRecordsListForPatientQuery(
+  params: ListMedicalRecordsParams,
+) {
+  return useQuery({
+    queryKey: KEYS.listForPatient(params),
+    queryFn: () => medicalRecordsService.listForPatient(params),
+  });
+}
+
+export function useMedicalRecordByIdQuery(id: string | null) {
+  return useQuery({
+    queryKey: KEYS.byId(id ?? ""),
+    queryFn: () => medicalRecordsService.findById(id!),
+    enabled: Boolean(id),
+  });
+}
 
 export function useMedicalRecordByAppointmentQuery(
   appointmentId: string | null,
@@ -31,19 +61,18 @@ export function useMedicalRecordsByPatientQuery(patientId: string | null) {
   });
 }
 
+function invalidateAll(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: ["medical-records"] });
+}
+
 export function useCreateMedicalRecordMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (data: CreateMedicalRecordDto) =>
       medicalRecordsService.create(data),
-    onSuccess: (record) => {
-      queryClient.invalidateQueries({
-        queryKey: KEYS.byAppointment(record.appointmentId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: KEYS.byPatient(record.patientId),
-      });
+    onSuccess: () => {
+      invalidateAll(queryClient);
       toast.success("Prontuário criado com sucesso.");
     },
     onError: (error: Error) => {
@@ -58,13 +87,8 @@ export function useUpdateMedicalRecordMutation() {
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: UpdateMedicalRecordDto }) =>
       medicalRecordsService.update(id, data),
-    onSuccess: (record) => {
-      queryClient.invalidateQueries({
-        queryKey: KEYS.byAppointment(record.appointmentId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: KEYS.byPatient(record.patientId),
-      });
+    onSuccess: () => {
+      invalidateAll(queryClient);
       toast.success("Prontuário atualizado com sucesso.");
     },
     onError: (error: Error) => {

--- a/apps/web/services/medical-records-service.ts
+++ b/apps/web/services/medical-records-service.ts
@@ -7,11 +7,24 @@ export interface MedicalRecordAuthor {
   email: string;
 }
 
+export interface MedicalRecordPatient {
+  id: string;
+  name: string;
+}
+
+export interface MedicalRecordAppointment {
+  id: string;
+  dateTime: string;
+  modality: string;
+}
+
 export interface MedicalRecordResponse {
   id: string;
   appointmentId: string;
   patientId: string;
   author: MedicalRecordAuthor;
+  patient?: MedicalRecordPatient;
+  appointment?: MedicalRecordAppointment;
   chiefComplaint: string | null;
   diagnosis: string | null;
   treatmentPlan: string | null;
@@ -26,12 +39,20 @@ export interface MedicalRecordPatientResponse {
   appointmentId: string;
   patientId: string;
   author: MedicalRecordAuthor;
+  appointment?: MedicalRecordAppointment;
   chiefComplaint: string | null;
   diagnosis: string | null;
   treatmentPlan: string | null;
   prescriptions: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface PaginatedMedicalRecords<T> {
+  data: T[];
+  page: number;
+  limit: number;
+  total: number;
 }
 
 export interface CreateMedicalRecordDto {
@@ -47,6 +68,16 @@ export type UpdateMedicalRecordDto = Omit<
   CreateMedicalRecordDto,
   "appointmentId"
 >;
+
+export interface ListMedicalRecordsParams {
+  patientId?: string;
+  authorId?: string;
+  search?: string;
+  startDate?: string;
+  endDate?: string;
+  page?: number;
+  limit?: number;
+}
 
 function downloadBlob(blob: Blob, filename: string): void {
   const blobUrl = window.URL.createObjectURL(blob);
@@ -77,6 +108,39 @@ export const medicalRecordsService = {
       return response.data as MedicalRecordResponse;
     } catch (error) {
       extractErrorMessage(error, "Erro ao criar prontuário.");
+    }
+  },
+
+  async list(
+    params: ListMedicalRecordsParams = {},
+  ): Promise<PaginatedMedicalRecords<MedicalRecordResponse>> {
+    try {
+      const response = await api.get("/medical-records", { params });
+      return response.data as PaginatedMedicalRecords<MedicalRecordResponse>;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao listar prontuários.");
+    }
+  },
+
+  async listForPatient(
+    params: ListMedicalRecordsParams = {},
+  ): Promise<PaginatedMedicalRecords<MedicalRecordPatientResponse>> {
+    try {
+      const response = await api.get("/medical-records", { params });
+      return response.data as PaginatedMedicalRecords<MedicalRecordPatientResponse>;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao listar prontuários.");
+    }
+  },
+
+  async findById(
+    id: string,
+  ): Promise<MedicalRecordResponse | MedicalRecordPatientResponse> {
+    try {
+      const response = await api.get(`/medical-records/${id}`);
+      return response.data;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao buscar prontuário.");
     }
   },
 


### PR DESCRIPTION
## Summary
- Adds `GET /medical-records` with pagination + filters (`patientId`, `authorId`, `search`, `startDate`, `endDate`, `page`, `limit`)
- Adds `GET /medical-records/:id` returning a single record
- Both endpoints are role-aware: professionals only see records they authored; patients only their own (response omits `internalNotes`)
- Response payload now carries `patient` and `appointment` data so listings don't need extra round-trips
- Frontend service + TanStack Query hooks updated (`list`, `listForPatient`, `findById`)

## Why
The previous API only allowed fetching by `appointmentId` or `patientId`. The new flows (dedicated medical-records pages, in the following PRs) need a flat paginated listing with filters.

## Test plan
- [ ] Login as professional → `GET /medical-records?page=1&limit=10` returns only records I authored
- [ ] Login as patient → same call returns only my own records, without `internalNotes`
- [ ] `GET /medical-records?search=joao` filters by patient name / queixa / diagnóstico
- [ ] `GET /medical-records?startDate=2026-01-01&endDate=2026-12-31` filters by date range
- [ ] `GET /medical-records/:id` as the author returns full payload; as another professional returns 403
- [ ] `GET /medical-records/:id` as the owning patient omits `internalNotes`; as another patient returns 403