### PR TITLE
feat(medical-records): professional pages (list, detail, new)

### DIFF
--- a/apps/server/src/medical-records/dto/list-medical-records-query.dto.ts
+++ b/apps/server/src/medical-records/dto/list-medical-records-query.dto.ts
@@ -1,0 +1,73 @@
+import {
+  IsOptional,
+  IsUUID,
+  IsDateString,
+  IsNumber,
+  IsString,
+  Min,
+  Max,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class ListMedicalRecordsQueryDto {
+  @ApiProperty({
+    description: 'Filtrar pelo ID do paciente',
+    required: false,
+  })
+  @IsUUID('all', { message: 'patientId inválido' })
+  @IsOptional()
+  patientId?: string;
+
+  @ApiProperty({
+    description:
+      'Filtrar pelo ID do autor (médico). Pacientes ignoram esse filtro.',
+    required: false,
+  })
+  @IsUUID('all', { message: 'authorId inválido' })
+  @IsOptional()
+  authorId?: string;
+
+  @ApiProperty({
+    description:
+      'Busca textual no nome do paciente ou nos campos clínicos do prontuário',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  search?: string;
+
+  @ApiProperty({
+    example: '2024-06-01',
+    description: 'Data inicial (YYYY-MM-DD)',
+    required: false,
+  })
+  @IsDateString({}, { message: 'Data inicial inválida' })
+  @IsOptional()
+  startDate?: string;
+
+  @ApiProperty({
+    example: '2024-06-30',
+    description: 'Data final (YYYY-MM-DD)',
+    required: false,
+  })
+  @IsDateString({}, { message: 'Data final inválida' })
+  @IsOptional()
+  endDate?: string;
+
+  @ApiProperty({ example: 1, required: false })
+  @Type(() => Number)
+  @IsNumber({}, { message: 'Página deve ser um número' })
+  @Min(1, { message: 'Página deve ser no mínimo 1' })
+  @Max(1000, { message: 'Página máxima é 1000' })
+  @IsOptional()
+  page?: number = 1;
+
+  @ApiProperty({ example: 10, required: false })
+  @Type(() => Number)
+  @IsNumber({}, { message: 'Limit deve ser um número' })
+  @Min(1, { message: 'Limit deve ser no mínimo 1' })
+  @Max(100, { message: 'Limit máximo é 100 registros' })
+  @IsOptional()
+  limit?: number = 10;
+}

--- a/apps/server/src/medical-records/dto/medical-record-response.dto.ts
+++ b/apps/server/src/medical-records/dto/medical-record-response.dto.ts
@@ -6,12 +6,27 @@ export class MedicalRecordAuthorDto {
   @ApiProperty() email!: string;
 }
 
+export class MedicalRecordPatientDto {
+  @ApiProperty() id!: string;
+  @ApiProperty() name!: string;
+}
+
+export class MedicalRecordAppointmentDto {
+  @ApiProperty() id!: string;
+  @ApiProperty() dateTime!: Date;
+  @ApiProperty() modality!: string;
+}
+
 export class MedicalRecordResponseDto {
   @ApiProperty() id!: string;
   @ApiProperty() appointmentId!: string;
   @ApiProperty() patientId!: string;
   @ApiProperty({ type: MedicalRecordAuthorDto })
   author!: MedicalRecordAuthorDto;
+  @ApiProperty({ type: MedicalRecordPatientDto, required: false })
+  patient?: MedicalRecordPatientDto;
+  @ApiProperty({ type: MedicalRecordAppointmentDto, required: false })
+  appointment?: MedicalRecordAppointmentDto;
   @ApiProperty({ nullable: true }) chiefComplaint!: string | null;
   @ApiProperty({ nullable: true }) diagnosis!: string | null;
   @ApiProperty({ nullable: true }) treatmentPlan!: string | null;
@@ -27,10 +42,28 @@ export class MedicalRecordPatientResponseDto {
   @ApiProperty() patientId!: string;
   @ApiProperty({ type: MedicalRecordAuthorDto })
   author!: MedicalRecordAuthorDto;
+  @ApiProperty({ type: MedicalRecordAppointmentDto, required: false })
+  appointment?: MedicalRecordAppointmentDto;
   @ApiProperty({ nullable: true }) chiefComplaint!: string | null;
   @ApiProperty({ nullable: true }) diagnosis!: string | null;
   @ApiProperty({ nullable: true }) treatmentPlan!: string | null;
   @ApiProperty({ nullable: true }) prescriptions!: string | null;
   @ApiProperty() createdAt!: Date;
   @ApiProperty() updatedAt!: Date;
+}
+
+export class MedicalRecordListResponseDto {
+  @ApiProperty({ type: [MedicalRecordResponseDto] })
+  data!: MedicalRecordResponseDto[];
+  @ApiProperty({ example: 1 }) page!: number;
+  @ApiProperty({ example: 10 }) limit!: number;
+  @ApiProperty({ example: 0 }) total!: number;
+}
+
+export class MedicalRecordPatientListResponseDto {
+  @ApiProperty({ type: [MedicalRecordPatientResponseDto] })
+  data!: MedicalRecordPatientResponseDto[];
+  @ApiProperty({ example: 1 }) page!: number;
+  @ApiProperty({ example: 10 }) limit!: number;
+  @ApiProperty({ example: 0 }) total!: number;
 }

--- a/apps/server/src/medical-records/medical-records.controller.ts
+++ b/apps/server/src/medical-records/medical-records.controller.ts
@@ -5,6 +5,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Request,
   Res,
   UseGuards,
@@ -23,9 +24,12 @@ import type { Response } from 'express';
 import { MedicalRecordsService } from './medical-records.service';
 import { CreateMedicalRecordDto } from './dto/create-medical-record.dto';
 import { UpdateMedicalRecordDto } from './dto/update-medical-record.dto';
+import { ListMedicalRecordsQueryDto } from './dto/list-medical-records-query.dto';
 import {
   MedicalRecordResponseDto,
   MedicalRecordPatientResponseDto,
+  MedicalRecordListResponseDto,
+  MedicalRecordPatientListResponseDto,
 } from './dto/medical-record-response.dto';
 import { ProfessionalRoleGuard } from '../professional/guards/professional-role.guard';
 import { PatientRoleGuard } from '../patients/guards/patient-role.guard';
@@ -52,6 +56,39 @@ export class MedicalRecordsController {
     @Body() dto: CreateMedicalRecordDto,
   ) {
     return this.service.create(req.user.userId, dto);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: 'Listar prontuários do usuário autenticado',
+    description:
+      'Médico: lista os prontuários que ele criou. Paciente: lista os próprios prontuários (sem internalNotes).',
+  })
+  @ApiResponse({ status: 200, type: MedicalRecordListResponseDto })
+  list(
+    @Request() req: { user: { userId: string; role: UserRole } },
+    @Query() query: ListMedicalRecordsQueryDto,
+  ): Promise<
+    MedicalRecordListResponseDto | MedicalRecordPatientListResponseDto
+  > {
+    return this.service.list(req.user.userId, req.user.role, query);
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Buscar prontuário por ID',
+    description:
+      'Profissional autor recebe todos os campos. Paciente dono não recebe internalNotes (LGPD).',
+  })
+  @ApiParam({ name: 'id', description: 'ID do prontuário' })
+  @ApiResponse({ status: 200, type: MedicalRecordResponseDto })
+  @ApiResponse({ status: 403, description: 'Acesso negado.' })
+  @ApiResponse({ status: 404, description: 'Prontuário não encontrado.' })
+  findById(
+    @Request() req: { user: { userId: string; role: UserRole } },
+    @Param('id') id: string,
+  ): Promise<MedicalRecordResponseDto | MedicalRecordPatientResponseDto> {
+    return this.service.findById(id, req.user.userId, req.user.role);
   }
 
   @Get('appointment/:appointmentId')
@@ -120,6 +157,7 @@ export class MedicalRecordsController {
     doc.pipe(res);
     doc.end();
   }
+
   @Patch(':id')
   @UseGuards(ProfessionalRoleGuard)
   @ApiOperation({ summary: 'Atualizar prontuário (somente autor)' })

--- a/apps/server/src/medical-records/medical-records.service.ts
+++ b/apps/server/src/medical-records/medical-records.service.ts
@@ -8,23 +8,36 @@ import { AppointmentStatus, Prisma, UserRole } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateMedicalRecordDto } from './dto/create-medical-record.dto';
 import { UpdateMedicalRecordDto } from './dto/update-medical-record.dto';
+import { ListMedicalRecordsQueryDto } from './dto/list-medical-records-query.dto';
 import {
   MedicalRecordResponseDto,
   MedicalRecordPatientResponseDto,
+  MedicalRecordListResponseDto,
+  MedicalRecordPatientListResponseDto,
 } from './dto/medical-record-response.dto';
 import {
   MedicalRecordPdfService,
   PatientMedicalRecordPdfInput,
 } from './medical-record-pdf.service';
 
-type MedicalRecordWithAuthor = Prisma.MedicalRecordGetPayload<{
-  include: { author: true };
+type MedicalRecordWithRelations = Prisma.MedicalRecordGetPayload<{
+  include: {
+    author: true;
+    patient: true;
+    appointment: true;
+  };
 }>;
 
 const VALID_LINK_STATUSES: AppointmentStatus[] = [
   AppointmentStatus.CONFIRMED,
   AppointmentStatus.COMPLETED,
 ];
+
+const RECORD_INCLUDE = {
+  author: true,
+  patient: true,
+  appointment: true,
+} as const;
 
 @Injectable()
 export class MedicalRecordsService {
@@ -63,7 +76,7 @@ export class MedicalRecordsService {
           prescriptions: dto.prescriptions,
           internalNotes: dto.internalNotes,
         },
-        include: { author: true },
+        include: RECORD_INCLUDE,
       });
       return this.toResponseDto(record);
     } catch (error) {
@@ -93,30 +106,120 @@ export class MedicalRecordsService {
 
     const record = await this.prisma.medicalRecord.findUnique({
       where: { appointmentId },
-      include: { author: true },
+      include: RECORD_INCLUDE,
     });
 
     if (!record) {
       throw new NotFoundException('Prontuário não encontrado.');
     }
 
-    if (requesterRole === UserRole.PATIENT) {
-      if (record.patientId !== requesterId) {
-        throw new ForbiddenException('Acesso negado a este prontuário.');
-      }
-      return this.toPatientResponseDto(record);
-    }
+    return this.authorizeAndSerialize(record, requesterId, requesterRole);
+  }
 
-    const isAuthor = record.authorId === requesterId;
-    const hasLink =
-      isAuthor ||
-      (await this.hasPriorAppointment(requesterId, record.patientId));
-
-    if (!hasLink) {
+  async findById(
+    recordId: string,
+    requesterId: string,
+    requesterRole: UserRole,
+  ): Promise<MedicalRecordResponseDto | MedicalRecordPatientResponseDto> {
+    if (
+      requesterRole !== UserRole.PROFESSIONAL &&
+      requesterRole !== UserRole.PATIENT
+    ) {
       throw new ForbiddenException('Acesso negado a este prontuário.');
     }
 
-    return this.toResponseDto(record);
+    const record = await this.prisma.medicalRecord.findUnique({
+      where: { id: recordId },
+      include: RECORD_INCLUDE,
+    });
+
+    if (!record) {
+      throw new NotFoundException('Prontuário não encontrado.');
+    }
+
+    return this.authorizeAndSerialize(record, requesterId, requesterRole);
+  }
+
+  async list(
+    requesterId: string,
+    requesterRole: UserRole,
+    query: ListMedicalRecordsQueryDto,
+  ): Promise<
+    MedicalRecordListResponseDto | MedicalRecordPatientListResponseDto
+  > {
+    if (
+      requesterRole !== UserRole.PROFESSIONAL &&
+      requesterRole !== UserRole.PATIENT
+    ) {
+      throw new ForbiddenException('Acesso negado.');
+    }
+
+    const page = query.page || 1;
+    const limit = query.limit || 10;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.MedicalRecordWhereInput = {};
+
+    if (requesterRole === UserRole.PROFESSIONAL) {
+      // Médico vê apenas prontuários que ele mesmo criou
+      where.authorId = requesterId;
+      if (query.patientId) where.patientId = query.patientId;
+      if (query.authorId && query.authorId !== requesterId) {
+        // não permitir ver de outros médicos
+        throw new ForbiddenException(
+          'Não é possível listar prontuários de outros profissionais.',
+        );
+      }
+    } else {
+      // Paciente vê apenas os próprios
+      where.patientId = requesterId;
+      if (query.authorId) where.authorId = query.authorId;
+    }
+
+    if (query.startDate || query.endDate) {
+      where.createdAt = {
+        ...(query.startDate && { gte: new Date(query.startDate) }),
+        ...(query.endDate && { lte: new Date(query.endDate) }),
+      };
+    }
+
+    if (query.search) {
+      const term = query.search.trim();
+      if (term.length > 0) {
+        where.OR = [
+          { patient: { name: { contains: term, mode: 'insensitive' } } },
+          { chiefComplaint: { contains: term, mode: 'insensitive' } },
+          { diagnosis: { contains: term, mode: 'insensitive' } },
+        ];
+      }
+    }
+
+    const [records, total] = await Promise.all([
+      this.prisma.medicalRecord.findMany({
+        where,
+        include: RECORD_INCLUDE,
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.medicalRecord.count({ where }),
+    ]);
+
+    if (requesterRole === UserRole.PATIENT) {
+      return {
+        data: records.map((r) => this.toPatientResponseDto(r)),
+        page,
+        limit,
+        total,
+      };
+    }
+
+    return {
+      data: records.map((r) => this.toResponseDto(r)),
+      page,
+      limit,
+      total,
+    };
   }
 
   async findByPatient(
@@ -133,7 +236,7 @@ export class MedicalRecordsService {
 
     const records = await this.prisma.medicalRecord.findMany({
       where: { patientId },
-      include: { author: true },
+      include: RECORD_INCLUDE,
       orderBy: { createdAt: 'desc' },
     });
 
@@ -147,7 +250,7 @@ export class MedicalRecordsService {
   ): Promise<MedicalRecordResponseDto> {
     const record = await this.prisma.medicalRecord.findUnique({
       where: { id: recordId },
-      include: { author: true },
+      include: RECORD_INCLUDE,
     });
 
     if (!record) {
@@ -169,7 +272,7 @@ export class MedicalRecordsService {
         prescriptions: dto.prescriptions,
         internalNotes: dto.internalNotes,
       },
-      include: { author: true },
+      include: RECORD_INCLUDE,
     });
 
     return this.toResponseDto(updated);
@@ -234,6 +337,31 @@ export class MedicalRecordsService {
 
     return this.pdfService.generate(input);
   }
+
+  private async authorizeAndSerialize(
+    record: MedicalRecordWithRelations,
+    requesterId: string,
+    requesterRole: UserRole,
+  ): Promise<MedicalRecordResponseDto | MedicalRecordPatientResponseDto> {
+    if (requesterRole === UserRole.PATIENT) {
+      if (record.patientId !== requesterId) {
+        throw new ForbiddenException('Acesso negado a este prontuário.');
+      }
+      return this.toPatientResponseDto(record);
+    }
+
+    const isAuthor = record.authorId === requesterId;
+    const hasLink =
+      isAuthor ||
+      (await this.hasPriorAppointment(requesterId, record.patientId));
+
+    if (!hasLink) {
+      throw new ForbiddenException('Acesso negado a este prontuário.');
+    }
+
+    return this.toResponseDto(record);
+  }
+
   private async hasPriorAppointment(
     professionalId: string,
     patientId: string,
@@ -249,7 +377,7 @@ export class MedicalRecordsService {
   }
 
   private toResponseDto(
-    record: MedicalRecordWithAuthor,
+    record: MedicalRecordWithRelations,
   ): MedicalRecordResponseDto {
     return {
       id: record.id,
@@ -259,6 +387,15 @@ export class MedicalRecordsService {
         id: record.author.id,
         name: record.author.name,
         email: record.author.email,
+      },
+      patient: {
+        id: record.patient.id,
+        name: record.patient.name,
+      },
+      appointment: {
+        id: record.appointment.id,
+        dateTime: record.appointment.dateTime,
+        modality: record.appointment.modality,
       },
       chiefComplaint: record.chiefComplaint,
       diagnosis: record.diagnosis,
@@ -271,7 +408,7 @@ export class MedicalRecordsService {
   }
 
   private toPatientResponseDto(
-    record: MedicalRecordWithAuthor,
+    record: MedicalRecordWithRelations,
   ): MedicalRecordPatientResponseDto {
     return {
       id: record.id,
@@ -281,6 +418,11 @@ export class MedicalRecordsService {
         id: record.author.id,
         name: record.author.name,
         email: record.author.email,
+      },
+      appointment: {
+        id: record.appointment.id,
+        dateTime: record.appointment.dateTime,
+        modality: record.appointment.modality,
       },
       chiefComplaint: record.chiefComplaint,
       diagnosis: record.diagnosis,

--- a/apps/web/app/dashboard/professional/medical-records/[id]/page.tsx
+++ b/apps/web/app/dashboard/professional/medical-records/[id]/page.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { Badge } from "@/components/ui/badge";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import {
+  useMedicalRecordByIdQuery,
+  useUpdateMedicalRecordMutation,
+} from "@/queries/useMedicalRecords";
+import { useUserQuery } from "@/queries/useUserQuery";
+import {
+  MedicalRecordResponse,
+} from "@/services/medical-records-service";
+import { CalendarIcon } from "../../../../utils/icons";
+
+type ClinicalKey =
+  | "chiefComplaint"
+  | "diagnosis"
+  | "treatmentPlan"
+  | "prescriptions"
+  | "internalNotes";
+
+const FIELDS: {
+  key: ClinicalKey;
+  label: string;
+  placeholder: string;
+  patientHidden?: boolean;
+}[] = [
+  {
+    key: "chiefComplaint",
+    label: "Queixa principal",
+    placeholder: "Motivo principal relatado pelo paciente…",
+  },
+  {
+    key: "diagnosis",
+    label: "Diagnóstico",
+    placeholder: "Hipóteses ou diagnóstico confirmado…",
+  },
+  {
+    key: "treatmentPlan",
+    label: "Plano terapêutico",
+    placeholder: "Plano de tratamento, condutas, orientações…",
+  },
+  {
+    key: "prescriptions",
+    label: "Prescrições",
+    placeholder: "Medicações, dosagens, exames solicitados…",
+  },
+  {
+    key: "internalNotes",
+    label: "Notas internas",
+    placeholder: "Observações privadas (não visíveis ao paciente)…",
+    patientHidden: true,
+  },
+];
+
+const EMPTY: Record<ClinicalKey, string> = {
+  chiefComplaint: "",
+  diagnosis: "",
+  treatmentPlan: "",
+  prescriptions: "",
+  internalNotes: "",
+};
+
+function isFullRecord(record: unknown): record is MedicalRecordResponse {
+  return (
+    record !== null &&
+    typeof record === "object" &&
+    "internalNotes" in (record as Record<string, unknown>)
+  );
+}
+
+function formatDateTime(iso: string) {
+  return new Date(iso).toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+const MedicalRecordDetailsPage = () => {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const isMobile = useIsMobile();
+  const { data: currentUser } = useUserQuery();
+  const { data: record, isLoading } = useMedicalRecordByIdQuery(
+    params?.id ?? null,
+  );
+  const updateMutation = useUpdateMedicalRecordMutation();
+
+  const fullRecord = isFullRecord(record) ? record : null;
+  const isAuthor = useMemo(
+    () => Boolean(fullRecord && currentUser && fullRecord.author.id === currentUser.id),
+    [fullRecord, currentUser],
+  );
+
+  const [form, setForm] = useState(EMPTY);
+  const [editing, setEditing] = useState(false);
+
+  useEffect(() => {
+    if (!fullRecord) return;
+    setForm({
+      chiefComplaint: fullRecord.chiefComplaint ?? "",
+      diagnosis: fullRecord.diagnosis ?? "",
+      treatmentPlan: fullRecord.treatmentPlan ?? "",
+      prescriptions: fullRecord.prescriptions ?? "",
+      internalNotes: fullRecord.internalNotes ?? "",
+    });
+  }, [fullRecord]);
+
+  const hasAnyField = Object.values(form).some((v) => v.trim().length > 0);
+
+  const handleSave = async () => {
+    if (!fullRecord || !hasAnyField) return;
+    const payload = {
+      chiefComplaint: form.chiefComplaint.trim() || undefined,
+      diagnosis: form.diagnosis.trim() || undefined,
+      treatmentPlan: form.treatmentPlan.trim() || undefined,
+      prescriptions: form.prescriptions.trim() || undefined,
+      internalNotes: form.internalNotes.trim() || undefined,
+    };
+    try {
+      await updateMutation.mutateAsync({ id: fullRecord.id, data: payload });
+      setEditing(false);
+    } catch {
+      // erro tratado via toast
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <section className="w-full min-h-screen flex justify-center items-center bg-[#f8fafc]">
+        <Spinner size="lg" />
+      </section>
+    );
+  }
+
+  if (!record) {
+    return (
+      <section
+        className={`w-full min-h-screen bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
+      >
+        <p className="text-base text-slate-700">Prontuário não encontrado.</p>
+        <Button
+          variant="outline"
+          className="mt-4"
+          onClick={() => router.push("/dashboard/professional/medical-records")}
+        >
+          Voltar para a lista
+        </Button>
+      </section>
+    );
+  }
+
+  const isSaving = updateMutation.isPending;
+
+  return (
+    <section
+      className={`w-full min-h-screen bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
+    >
+      <div className="mb-6 flex items-center gap-3 flex-wrap">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => router.push("/dashboard/professional/medical-records")}
+          title="Voltar para a lista"
+        >
+          ← Voltar
+        </Button>
+      </div>
+
+      <Card className="border border-gray-200 rounded-xl bg-white mb-5">
+        <CardContent className="p-5 sm:p-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="flex gap-3 items-center min-w-0">
+              <div className="w-12 h-12 rounded-full bg-blue-50 border border-blue-100 text-blue-700 flex items-center justify-center font-semibold text-lg shrink-0">
+                {(fullRecord?.patient?.name ?? "P").charAt(0).toUpperCase()}
+              </div>
+              <div className="min-w-0">
+                <h1
+                  className={`font-bold text-slate-900 tracking-tight truncate ${isMobile ? "text-lg" : "text-xl"}`}
+                  title={fullRecord?.patient?.name ?? "Paciente"}
+                >
+                  {fullRecord?.patient?.name ?? "Paciente"}
+                </h1>
+                <p className="text-xs text-slate-500 mt-0.5">Prontuário</p>
+              </div>
+            </div>
+            <div className="flex gap-2 shrink-0">
+              {isAuthor && !editing && (
+                <Button onClick={() => setEditing(true)} title="Editar prontuário">
+                  Editar
+                </Button>
+              )}
+              {!isAuthor && (
+                <Badge className="bg-amber-50 text-amber-700 border border-amber-200 px-2 py-1 text-xs rounded">
+                  Somente leitura
+                </Badge>
+              )}
+            </div>
+          </div>
+
+          <div className="mt-4 pt-4 border-t border-slate-100 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+            <div className="flex items-start gap-2 text-slate-600">
+              <CalendarIcon size={16} className="mt-0.5 shrink-0" />
+              <div>
+                <p className="text-[11px] uppercase text-slate-400 tracking-wide font-medium">
+                  Consulta
+                </p>
+                <p className="text-slate-800">
+                  {fullRecord?.appointment
+                    ? formatDateTime(fullRecord.appointment.dateTime)
+                    : formatDateTime(record.createdAt)}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-2 text-slate-600">
+              <div className="w-4 h-4 mt-0.5 shrink-0 flex items-center justify-center text-[11px] font-bold text-slate-400">
+                ✎
+              </div>
+              <div>
+                <p className="text-[11px] uppercase text-slate-400 tracking-wide font-medium">
+                  Autor
+                </p>
+                <p className="text-slate-800">{record.author.name}</p>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border border-gray-200 rounded-xl bg-white">
+        <CardContent className="p-5 sm:p-6 flex flex-col gap-5">
+          {FIELDS.map((field) => {
+            const value = form[field.key];
+            const display = fullRecord?.[field.key] ?? null;
+
+            if (editing && isAuthor) {
+              return (
+                <div key={field.key} className="flex flex-col gap-1.5">
+                  <label
+                    htmlFor={`mr-${field.key}`}
+                    className="text-sm font-medium text-slate-700"
+                  >
+                    {field.label}
+                    {field.patientHidden && (
+                      <span className="ml-2 text-[11px] font-normal text-amber-700 bg-amber-50 border border-amber-200 px-1.5 py-0.5 rounded">
+                        Não visível ao paciente
+                      </span>
+                    )}
+                  </label>
+                  <textarea
+                    id={`mr-${field.key}`}
+                    placeholder={field.placeholder}
+                    value={value}
+                    onChange={(e) =>
+                      setForm((prev) => ({
+                        ...prev,
+                        [field.key]: e.target.value,
+                      }))
+                    }
+                    disabled={isSaving}
+                    className="w-full min-h-24 p-3 resize-y rounded-xl bg-slate-50 border border-slate-200 text-slate-700 text-[14.5px] leading-relaxed placeholder:text-slate-400 shadow-sm transition-all duration-200 focus:outline-none focus:bg-white focus:border-blue-500 focus:ring-[3px] focus:ring-blue-500/20"
+                  />
+                </div>
+              );
+            }
+
+            return (
+              <div key={field.key} className="flex flex-col gap-1">
+                <p className="text-xs font-medium text-slate-400 uppercase tracking-wide">
+                  {field.label}
+                  {field.patientHidden && (
+                    <span className="ml-2 normal-case font-normal text-amber-700">
+                      (não visível ao paciente)
+                    </span>
+                  )}
+                </p>
+                <p className="text-[14.5px] text-slate-700 leading-relaxed whitespace-pre-wrap">
+                  {display ?? (
+                    <span className="text-slate-300 italic">Não informado</span>
+                  )}
+                </p>
+              </div>
+            );
+          })}
+
+          {editing && isAuthor && (
+            <div className="flex justify-end gap-3 pt-3 border-t border-slate-100">
+              <Button
+                variant="outline"
+                onClick={() => setEditing(false)}
+                disabled={isSaving}
+              >
+                Cancelar
+              </Button>
+              <Button
+                onClick={handleSave}
+                disabled={!hasAnyField || isSaving}
+                title="Salvar alterações"
+              >
+                {isSaving ? (
+                  <span className="flex items-center gap-2">
+                    <Spinner size="sm" /> Salvando…
+                  </span>
+                ) : (
+                  "Salvar alterações"
+                )}
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+};
+
+export default MedicalRecordDetailsPage;

--- a/apps/web/app/dashboard/professional/medical-records/new/page.tsx
+++ b/apps/web/app/dashboard/professional/medical-records/new/page.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import {
+  useCreateMedicalRecordMutation,
+  useMedicalRecordByAppointmentQuery,
+} from "@/queries/useMedicalRecords";
+
+type ClinicalKey =
+  | "chiefComplaint"
+  | "diagnosis"
+  | "treatmentPlan"
+  | "prescriptions"
+  | "internalNotes";
+
+const FIELDS: {
+  key: ClinicalKey;
+  label: string;
+  placeholder: string;
+  patientHidden?: boolean;
+}[] = [
+  {
+    key: "chiefComplaint",
+    label: "Queixa principal",
+    placeholder: "Motivo principal relatado pelo paciente…",
+  },
+  {
+    key: "diagnosis",
+    label: "Diagnóstico",
+    placeholder: "Hipóteses ou diagnóstico confirmado…",
+  },
+  {
+    key: "treatmentPlan",
+    label: "Plano terapêutico",
+    placeholder: "Plano de tratamento, condutas, orientações…",
+  },
+  {
+    key: "prescriptions",
+    label: "Prescrições",
+    placeholder: "Medicações, dosagens, exames solicitados…",
+  },
+  {
+    key: "internalNotes",
+    label: "Notas internas",
+    placeholder: "Observações privadas (não visíveis ao paciente)…",
+    patientHidden: true,
+  },
+];
+
+const EMPTY: Record<ClinicalKey, string> = {
+  chiefComplaint: "",
+  diagnosis: "",
+  treatmentPlan: "",
+  prescriptions: "",
+  internalNotes: "",
+};
+
+const NewMedicalRecordPage = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const isMobile = useIsMobile();
+  const appointmentId = searchParams.get("appointmentId");
+  const patientName = searchParams.get("patientName") ?? "Paciente";
+
+  const { data: existing, isLoading } = useMedicalRecordByAppointmentQuery(
+    appointmentId,
+  );
+  const createMutation = useCreateMedicalRecordMutation();
+
+  const [form, setForm] = useState(EMPTY);
+
+  useEffect(() => {
+    if (existing && "id" in existing) {
+      router.replace(
+        `/dashboard/professional/medical-records/${existing.id}`,
+      );
+    }
+  }, [existing, router]);
+
+  if (!appointmentId) {
+    return (
+      <section className="w-full min-h-screen px-4 py-8 sm:px-16 bg-[#f8fafc]">
+        <p className="text-base text-slate-700">
+          Consulta não informada. Volte para a agenda e selecione uma consulta.
+        </p>
+        <Button
+          variant="outline"
+          className="mt-4"
+          onClick={() => router.push("/dashboard/professional/schedule")}
+        >
+          Ir para agenda
+        </Button>
+      </section>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <section className="w-full min-h-screen flex justify-center items-center bg-[#f8fafc]">
+        <Spinner size="lg" />
+      </section>
+    );
+  }
+
+  const hasAnyField = Object.values(form).some((v) => v.trim().length > 0);
+  const isSaving = createMutation.isPending;
+
+  const handleSave = async () => {
+    if (!hasAnyField) return;
+    const payload = {
+      appointmentId,
+      chiefComplaint: form.chiefComplaint.trim() || undefined,
+      diagnosis: form.diagnosis.trim() || undefined,
+      treatmentPlan: form.treatmentPlan.trim() || undefined,
+      prescriptions: form.prescriptions.trim() || undefined,
+      internalNotes: form.internalNotes.trim() || undefined,
+    };
+    try {
+      const created = await createMutation.mutateAsync(payload);
+      router.push(`/dashboard/professional/medical-records/${created.id}`);
+    } catch {
+      // erro tratado via toast
+    }
+  };
+
+  return (
+    <section
+      className={`w-full min-h-screen bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
+    >
+      <div className="mb-6 flex items-center gap-3 flex-wrap">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => router.back()}
+          title="Voltar"
+        >
+          ← Voltar
+        </Button>
+      </div>
+
+      <div className="mb-6">
+        <h1
+          className={`font-bold text-slate-900 tracking-tight ${isMobile ? "text-xl" : "text-2xl"}`}
+        >
+          Novo prontuário
+        </h1>
+        <p className="mt-1 text-sm text-slate-500">
+          Paciente: <span className="font-medium">{patientName}</span>
+        </p>
+      </div>
+
+      <Card className="border border-gray-200 rounded-xl bg-white">
+        <CardContent className="p-5 sm:p-6 flex flex-col gap-5">
+          {FIELDS.map((field) => (
+            <div key={field.key} className="flex flex-col gap-1.5">
+              <label
+                htmlFor={`mr-${field.key}`}
+                className="text-sm font-medium text-slate-700"
+              >
+                {field.label}
+                {field.patientHidden && (
+                  <span className="ml-2 text-[11px] font-normal text-amber-700 bg-amber-50 border border-amber-200 px-1.5 py-0.5 rounded">
+                    Não visível ao paciente
+                  </span>
+                )}
+              </label>
+              <textarea
+                id={`mr-${field.key}`}
+                placeholder={field.placeholder}
+                value={form[field.key]}
+                onChange={(e) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    [field.key]: e.target.value,
+                  }))
+                }
+                disabled={isSaving}
+                className="w-full min-h-24 p-3 resize-y rounded-xl bg-slate-50 border border-slate-200 text-slate-700 text-[14.5px] leading-relaxed placeholder:text-slate-400 shadow-sm transition-all duration-200 focus:outline-none focus:bg-white focus:border-blue-500 focus:ring-[3px] focus:ring-blue-500/20"
+              />
+            </div>
+          ))}
+
+          <div className="flex justify-end gap-3 pt-3 border-t border-slate-100">
+            <Button
+              variant="outline"
+              onClick={() => router.back()}
+              disabled={isSaving}
+            >
+              Cancelar
+            </Button>
+            <Button
+              onClick={handleSave}
+              disabled={!hasAnyField || isSaving}
+              title={
+                hasAnyField
+                  ? "Criar prontuário"
+                  : "Preencha ao menos um campo para salvar"
+              }
+            >
+              {isSaving ? (
+                <span className="flex items-center gap-2">
+                  <Spinner size="sm" /> Salvando…
+                </span>
+              ) : (
+                "Criar prontuário"
+              )}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+};
+
+export default NewMedicalRecordPage;

--- a/apps/web/app/dashboard/professional/medical-records/page.tsx
+++ b/apps/web/app/dashboard/professional/medical-records/page.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { Badge } from "@/components/ui/badge";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { useMedicalRecordsListQuery } from "@/queries/useMedicalRecords";
+import {
+  CalendarIcon,
+  SearchIcon,
+  EyeIcon,
+} from "../../../utils/icons";
+
+const PAGE_SIZE = 10;
+
+function formatDateTime(iso: string) {
+  const d = new Date(iso);
+  return d.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function truncate(text: string | null, max = 120) {
+  if (!text) return null;
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+const MedicalRecordsListPage = () => {
+  const router = useRouter();
+  const isMobile = useIsMobile();
+  const [search, setSearch] = useState("");
+  const [searchInput, setSearchInput] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [page, setPage] = useState(1);
+
+  const params = useMemo(
+    () => ({
+      page,
+      limit: PAGE_SIZE,
+      ...(search && { search }),
+      ...(startDate && { startDate }),
+      ...(endDate && { endDate }),
+    }),
+    [page, search, startDate, endDate],
+  );
+
+  const { data, isLoading, isFetching } = useMedicalRecordsListQuery(params);
+
+  const records = data?.data ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSearch(searchInput.trim());
+    setPage(1);
+  };
+
+  const handleClearFilters = () => {
+    setSearchInput("");
+    setSearch("");
+    setStartDate("");
+    setEndDate("");
+    setPage(1);
+  };
+
+  const hasFilters = Boolean(search || startDate || endDate);
+
+  return (
+    <section
+      className={`w-full min-h-screen mx-auto bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
+    >
+      <div className="mb-8">
+        <h1
+          className={`font-bold text-gray-900 tracking-tight ${isMobile ? "text-2xl" : "text-4xl"}`}
+        >
+          Prontuários
+        </h1>
+        <p
+          className={`mt-1 text-gray-500 ${isMobile ? "text-sm" : "text-base"}`}
+        >
+          Prontuários médicos criados por você. {total > 0 && `${total} no total.`}
+        </p>
+      </div>
+
+      <Card className="mb-6 border border-gray-200 rounded-xl bg-white">
+        <CardContent className="p-4 sm:p-5">
+          <form
+            onSubmit={handleSearch}
+            className="flex flex-col gap-3 sm:flex-row sm:items-end"
+          >
+            <div className="flex-1 flex flex-col gap-1">
+              <label className="text-xs font-medium text-slate-600">
+                Buscar (paciente, queixa ou diagnóstico)
+              </label>
+              <div className="relative">
+                <SearchIcon
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"
+                  size={16}
+                />
+                <Input
+                  value={searchInput}
+                  onChange={(e) => setSearchInput(e.target.value)}
+                  placeholder="Ex.: João Silva, enxaqueca…"
+                  className="pl-9"
+                />
+              </div>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-slate-600">
+                Data inicial
+              </label>
+              <Input
+                type="date"
+                value={startDate}
+                onChange={(e) => {
+                  setStartDate(e.target.value);
+                  setPage(1);
+                }}
+                className="w-full sm:w-44"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-slate-600">
+                Data final
+              </label>
+              <Input
+                type="date"
+                value={endDate}
+                onChange={(e) => {
+                  setEndDate(e.target.value);
+                  setPage(1);
+                }}
+                className="w-full sm:w-44"
+              />
+            </div>
+            <div className="flex gap-2">
+              <Button type="submit" title="Aplicar busca">
+                Buscar
+              </Button>
+              {hasFilters && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleClearFilters}
+                  title="Remover filtros"
+                >
+                  Limpar
+                </Button>
+              )}
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {isLoading ? (
+        <div className="py-16 flex justify-center">
+          <Spinner size="lg" />
+        </div>
+      ) : records.length === 0 ? (
+        <Card className="border border-dashed border-gray-300 rounded-xl bg-white">
+          <CardContent className="py-16 text-center flex flex-col items-center gap-3">
+            <div className="w-14 h-14 rounded-full bg-blue-50 text-blue-600 flex items-center justify-center">
+              <CalendarIcon size={28} />
+            </div>
+            <div>
+              <p className="text-base font-semibold text-slate-800">
+                Nenhum prontuário encontrado
+              </p>
+              <p className="text-sm text-slate-500 mt-1 max-w-md">
+                {hasFilters
+                  ? "Tente ajustar os filtros acima."
+                  : "Os prontuários que você criar a partir das consultas aparecerão aqui."}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {records.map((record) => (
+            <Card
+              key={record.id}
+              className="border border-gray-200 rounded-xl bg-white"
+            >
+              <CardContent className="p-4 sm:p-5 flex gap-4 items-center">
+                <div className="w-11 h-11 rounded-full bg-blue-50 border border-blue-100 text-blue-700 flex items-center justify-center font-semibold shrink-0">
+                  {(record.patient?.name ?? "P").charAt(0).toUpperCase()}
+                </div>
+                <div className="flex-1 min-w-0 flex flex-col gap-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-[15px] font-semibold text-slate-900 truncate">
+                      {record.patient?.name ?? "Paciente"}
+                    </h3>
+                    {record.appointment && (
+                      <Badge className="bg-slate-100 text-slate-600 px-2 py-0.5 text-[11px] rounded font-medium">
+                        {record.appointment.modality === "VIRTUAL"
+                          ? "Virtual"
+                          : "Presencial"}
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="flex items-center gap-1.5 text-xs text-slate-500">
+                    <CalendarIcon size={14} />
+                    {record.appointment
+                      ? formatDateTime(record.appointment.dateTime)
+                      : `Criado em ${formatDateTime(record.createdAt)}`}
+                  </p>
+                  {(record.diagnosis || record.chiefComplaint) && (
+                    <p className="text-sm text-slate-700 line-clamp-1 mt-0.5">
+                      <span className="text-slate-500">
+                        {record.diagnosis ? "Diagnóstico: " : "Queixa: "}
+                      </span>
+                      {truncate(record.diagnosis ?? record.chiefComplaint)}
+                    </p>
+                  )}
+                </div>
+                <Button
+                  size="sm"
+                  onClick={() =>
+                    router.push(
+                      `/dashboard/professional/medical-records/${record.id}`,
+                    )
+                  }
+                  title="Abrir prontuário"
+                  className="shrink-0"
+                >
+                  <EyeIcon size={16} /> Abrir
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="mt-6 flex items-center justify-between gap-3">
+          <p className="text-xs text-slate-500">
+            Página {page} de {totalPages}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page <= 1 || isFetching}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              title="Página anterior"
+            >
+              Anterior
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page >= totalPages || isFetching}
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              title="Próxima página"
+            >
+              Próxima
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default MedicalRecordsListPage;

--- a/apps/web/queries/useMedicalRecords.ts
+++ b/apps/web/queries/useMedicalRecords.ts
@@ -3,15 +3,45 @@ import { toast } from "sonner";
 import {
   medicalRecordsService,
   CreateMedicalRecordDto,
+  ListMedicalRecordsParams,
   UpdateMedicalRecordDto,
 } from "@/services/medical-records-service";
 
 const KEYS = {
+  list: (params: ListMedicalRecordsParams) =>
+    ["medical-records", "list", params] as const,
+  listForPatient: (params: ListMedicalRecordsParams) =>
+    ["medical-records", "list-patient", params] as const,
+  byId: (id: string) => ["medical-records", "id", id] as const,
   byAppointment: (appointmentId: string) =>
     ["medical-records", "appointment", appointmentId] as const,
   byPatient: (patientId: string) =>
     ["medical-records", "patient", patientId] as const,
 };
+
+export function useMedicalRecordsListQuery(params: ListMedicalRecordsParams) {
+  return useQuery({
+    queryKey: KEYS.list(params),
+    queryFn: () => medicalRecordsService.list(params),
+  });
+}
+
+export function useMedicalRecordsListForPatientQuery(
+  params: ListMedicalRecordsParams,
+) {
+  return useQuery({
+    queryKey: KEYS.listForPatient(params),
+    queryFn: () => medicalRecordsService.listForPatient(params),
+  });
+}
+
+export function useMedicalRecordByIdQuery(id: string | null) {
+  return useQuery({
+    queryKey: KEYS.byId(id ?? ""),
+    queryFn: () => medicalRecordsService.findById(id!),
+    enabled: Boolean(id),
+  });
+}
 
 export function useMedicalRecordByAppointmentQuery(
   appointmentId: string | null,
@@ -31,19 +61,18 @@ export function useMedicalRecordsByPatientQuery(patientId: string | null) {
   });
 }
 
+function invalidateAll(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: ["medical-records"] });
+}
+
 export function useCreateMedicalRecordMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (data: CreateMedicalRecordDto) =>
       medicalRecordsService.create(data),
-    onSuccess: (record) => {
-      queryClient.invalidateQueries({
-        queryKey: KEYS.byAppointment(record.appointmentId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: KEYS.byPatient(record.patientId),
-      });
+    onSuccess: () => {
+      invalidateAll(queryClient);
       toast.success("Prontuário criado com sucesso.");
     },
     onError: (error: Error) => {
@@ -58,13 +87,8 @@ export function useUpdateMedicalRecordMutation() {
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: UpdateMedicalRecordDto }) =>
       medicalRecordsService.update(id, data),
-    onSuccess: (record) => {
-      queryClient.invalidateQueries({
-        queryKey: KEYS.byAppointment(record.appointmentId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: KEYS.byPatient(record.patientId),
-      });
+    onSuccess: () => {
+      invalidateAll(queryClient);
       toast.success("Prontuário atualizado com sucesso.");
     },
     onError: (error: Error) => {

--- a/apps/web/services/medical-records-service.ts
+++ b/apps/web/services/medical-records-service.ts
@@ -7,11 +7,24 @@ export interface MedicalRecordAuthor {
   email: string;
 }
 
+export interface MedicalRecordPatient {
+  id: string;
+  name: string;
+}
+
+export interface MedicalRecordAppointment {
+  id: string;
+  dateTime: string;
+  modality: string;
+}
+
 export interface MedicalRecordResponse {
   id: string;
   appointmentId: string;
   patientId: string;
   author: MedicalRecordAuthor;
+  patient?: MedicalRecordPatient;
+  appointment?: MedicalRecordAppointment;
   chiefComplaint: string | null;
   diagnosis: string | null;
   treatmentPlan: string | null;
@@ -26,12 +39,20 @@ export interface MedicalRecordPatientResponse {
   appointmentId: string;
   patientId: string;
   author: MedicalRecordAuthor;
+  appointment?: MedicalRecordAppointment;
   chiefComplaint: string | null;
   diagnosis: string | null;
   treatmentPlan: string | null;
   prescriptions: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface PaginatedMedicalRecords<T> {
+  data: T[];
+  page: number;
+  limit: number;
+  total: number;
 }
 
 export interface CreateMedicalRecordDto {
@@ -47,6 +68,16 @@ export type UpdateMedicalRecordDto = Omit<
   CreateMedicalRecordDto,
   "appointmentId"
 >;
+
+export interface ListMedicalRecordsParams {
+  patientId?: string;
+  authorId?: string;
+  search?: string;
+  startDate?: string;
+  endDate?: string;
+  page?: number;
+  limit?: number;
+}
 
 function downloadBlob(blob: Blob, filename: string): void {
   const blobUrl = window.URL.createObjectURL(blob);
@@ -77,6 +108,39 @@ export const medicalRecordsService = {
       return response.data as MedicalRecordResponse;
     } catch (error) {
       extractErrorMessage(error, "Erro ao criar prontuário.");
+    }
+  },
+
+  async list(
+    params: ListMedicalRecordsParams = {},
+  ): Promise<PaginatedMedicalRecords<MedicalRecordResponse>> {
+    try {
+      const response = await api.get("/medical-records", { params });
+      return response.data as PaginatedMedicalRecords<MedicalRecordResponse>;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao listar prontuários.");
+    }
+  },
+
+  async listForPatient(
+    params: ListMedicalRecordsParams = {},
+  ): Promise<PaginatedMedicalRecords<MedicalRecordPatientResponse>> {
+    try {
+      const response = await api.get("/medical-records", { params });
+      return response.data as PaginatedMedicalRecords<MedicalRecordPatientResponse>;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao listar prontuários.");
+    }
+  },
+
+  async findById(
+    id: string,
+  ): Promise<MedicalRecordResponse | MedicalRecordPatientResponse> {
+    try {
+      const response = await api.get(`/medical-records/${id}`);
+      return response.data;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao buscar prontuário.");
     }
   },
 


### PR DESCRIPTION
## Summary
Dedicated routes for the professional medical-records flow, replacing the existing in-card modal:
- `/dashboard/professional/medical-records` — paginated list, search by patient/queixa/diagnóstico, date filter
- `/dashboard/professional/medical-records/[id]` — view + inline edit (author only)
- `/dashboard/professional/medical-records/new?appointmentId=...&patientName=...` — creation; auto-redirects to detail if a record already exists for the appointment

## Why
The previous modal made it hard to track records across appointments and didn't scale for listing/filtering. Dedicated pages give the professional a proper history view and a stable URL per record.

## Depends on
- #139 (backend list + findById endpoints)

## Test plan
- [ ] List page loads my records, paginated 10/page
- [ ] Search filters by patient name, queixa or diagnóstico
- [ ] Date filter narrows by createdAt range
- [ ] Open detail → "Editar" enabled only for the author
- [ ] Save edit invalidates queries and reflects on the list
- [ ] `/new?appointmentId=X` with an existing record redirects to that record's detail
- [ ] Creation requires at least one clinical field filled