### PR TITLE
feat(medical-records): patient pages (list, detail)

### DIFF
--- a/apps/server/src/medical-records/dto/list-medical-records-query.dto.ts
+++ b/apps/server/src/medical-records/dto/list-medical-records-query.dto.ts
@@ -1,0 +1,73 @@
+import {
+  IsOptional,
+  IsUUID,
+  IsDateString,
+  IsNumber,
+  IsString,
+  Min,
+  Max,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class ListMedicalRecordsQueryDto {
+  @ApiProperty({
+    description: 'Filtrar pelo ID do paciente',
+    required: false,
+  })
+  @IsUUID('all', { message: 'patientId inválido' })
+  @IsOptional()
+  patientId?: string;
+
+  @ApiProperty({
+    description:
+      'Filtrar pelo ID do autor (médico). Pacientes ignoram esse filtro.',
+    required: false,
+  })
+  @IsUUID('all', { message: 'authorId inválido' })
+  @IsOptional()
+  authorId?: string;
+
+  @ApiProperty({
+    description:
+      'Busca textual no nome do paciente ou nos campos clínicos do prontuário',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  search?: string;
+
+  @ApiProperty({
+    example: '2024-06-01',
+    description: 'Data inicial (YYYY-MM-DD)',
+    required: false,
+  })
+  @IsDateString({}, { message: 'Data inicial inválida' })
+  @IsOptional()
+  startDate?: string;
+
+  @ApiProperty({
+    example: '2024-06-30',
+    description: 'Data final (YYYY-MM-DD)',
+    required: false,
+  })
+  @IsDateString({}, { message: 'Data final inválida' })
+  @IsOptional()
+  endDate?: string;
+
+  @ApiProperty({ example: 1, required: false })
+  @Type(() => Number)
+  @IsNumber({}, { message: 'Página deve ser um número' })
+  @Min(1, { message: 'Página deve ser no mínimo 1' })
+  @Max(1000, { message: 'Página máxima é 1000' })
+  @IsOptional()
+  page?: number = 1;
+
+  @ApiProperty({ example: 10, required: false })
+  @Type(() => Number)
+  @IsNumber({}, { message: 'Limit deve ser um número' })
+  @Min(1, { message: 'Limit deve ser no mínimo 1' })
+  @Max(100, { message: 'Limit máximo é 100 registros' })
+  @IsOptional()
+  limit?: number = 10;
+}

--- a/apps/server/src/medical-records/dto/medical-record-response.dto.ts
+++ b/apps/server/src/medical-records/dto/medical-record-response.dto.ts
@@ -6,12 +6,27 @@ export class MedicalRecordAuthorDto {
   @ApiProperty() email!: string;
 }
 
+export class MedicalRecordPatientDto {
+  @ApiProperty() id!: string;
+  @ApiProperty() name!: string;
+}
+
+export class MedicalRecordAppointmentDto {
+  @ApiProperty() id!: string;
+  @ApiProperty() dateTime!: Date;
+  @ApiProperty() modality!: string;
+}
+
 export class MedicalRecordResponseDto {
   @ApiProperty() id!: string;
   @ApiProperty() appointmentId!: string;
   @ApiProperty() patientId!: string;
   @ApiProperty({ type: MedicalRecordAuthorDto })
   author!: MedicalRecordAuthorDto;
+  @ApiProperty({ type: MedicalRecordPatientDto, required: false })
+  patient?: MedicalRecordPatientDto;
+  @ApiProperty({ type: MedicalRecordAppointmentDto, required: false })
+  appointment?: MedicalRecordAppointmentDto;
   @ApiProperty({ nullable: true }) chiefComplaint!: string | null;
   @ApiProperty({ nullable: true }) diagnosis!: string | null;
   @ApiProperty({ nullable: true }) treatmentPlan!: string | null;
@@ -27,10 +42,28 @@ export class MedicalRecordPatientResponseDto {
   @ApiProperty() patientId!: string;
   @ApiProperty({ type: MedicalRecordAuthorDto })
   author!: MedicalRecordAuthorDto;
+  @ApiProperty({ type: MedicalRecordAppointmentDto, required: false })
+  appointment?: MedicalRecordAppointmentDto;
   @ApiProperty({ nullable: true }) chiefComplaint!: string | null;
   @ApiProperty({ nullable: true }) diagnosis!: string | null;
   @ApiProperty({ nullable: true }) treatmentPlan!: string | null;
   @ApiProperty({ nullable: true }) prescriptions!: string | null;
   @ApiProperty() createdAt!: Date;
   @ApiProperty() updatedAt!: Date;
+}
+
+export class MedicalRecordListResponseDto {
+  @ApiProperty({ type: [MedicalRecordResponseDto] })
+  data!: MedicalRecordResponseDto[];
+  @ApiProperty({ example: 1 }) page!: number;
+  @ApiProperty({ example: 10 }) limit!: number;
+  @ApiProperty({ example: 0 }) total!: number;
+}
+
+export class MedicalRecordPatientListResponseDto {
+  @ApiProperty({ type: [MedicalRecordPatientResponseDto] })
+  data!: MedicalRecordPatientResponseDto[];
+  @ApiProperty({ example: 1 }) page!: number;
+  @ApiProperty({ example: 10 }) limit!: number;
+  @ApiProperty({ example: 0 }) total!: number;
 }

--- a/apps/server/src/medical-records/medical-records.controller.ts
+++ b/apps/server/src/medical-records/medical-records.controller.ts
@@ -5,6 +5,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Request,
   Res,
   UseGuards,
@@ -23,9 +24,12 @@ import type { Response } from 'express';
 import { MedicalRecordsService } from './medical-records.service';
 import { CreateMedicalRecordDto } from './dto/create-medical-record.dto';
 import { UpdateMedicalRecordDto } from './dto/update-medical-record.dto';
+import { ListMedicalRecordsQueryDto } from './dto/list-medical-records-query.dto';
 import {
   MedicalRecordResponseDto,
   MedicalRecordPatientResponseDto,
+  MedicalRecordListResponseDto,
+  MedicalRecordPatientListResponseDto,
 } from './dto/medical-record-response.dto';
 import { ProfessionalRoleGuard } from '../professional/guards/professional-role.guard';
 import { PatientRoleGuard } from '../patients/guards/patient-role.guard';
@@ -52,6 +56,39 @@ export class MedicalRecordsController {
     @Body() dto: CreateMedicalRecordDto,
   ) {
     return this.service.create(req.user.userId, dto);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: 'Listar prontuários do usuário autenticado',
+    description:
+      'Médico: lista os prontuários que ele criou. Paciente: lista os próprios prontuários (sem internalNotes).',
+  })
+  @ApiResponse({ status: 200, type: MedicalRecordListResponseDto })
+  list(
+    @Request() req: { user: { userId: string; role: UserRole } },
+    @Query() query: ListMedicalRecordsQueryDto,
+  ): Promise<
+    MedicalRecordListResponseDto | MedicalRecordPatientListResponseDto
+  > {
+    return this.service.list(req.user.userId, req.user.role, query);
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Buscar prontuário por ID',
+    description:
+      'Profissional autor recebe todos os campos. Paciente dono não recebe internalNotes (LGPD).',
+  })
+  @ApiParam({ name: 'id', description: 'ID do prontuário' })
+  @ApiResponse({ status: 200, type: MedicalRecordResponseDto })
+  @ApiResponse({ status: 403, description: 'Acesso negado.' })
+  @ApiResponse({ status: 404, description: 'Prontuário não encontrado.' })
+  findById(
+    @Request() req: { user: { userId: string; role: UserRole } },
+    @Param('id') id: string,
+  ): Promise<MedicalRecordResponseDto | MedicalRecordPatientResponseDto> {
+    return this.service.findById(id, req.user.userId, req.user.role);
   }
 
   @Get('appointment/:appointmentId')
@@ -120,6 +157,7 @@ export class MedicalRecordsController {
     doc.pipe(res);
     doc.end();
   }
+
   @Patch(':id')
   @UseGuards(ProfessionalRoleGuard)
   @ApiOperation({ summary: 'Atualizar prontuário (somente autor)' })

--- a/apps/server/src/medical-records/medical-records.service.ts
+++ b/apps/server/src/medical-records/medical-records.service.ts
@@ -8,23 +8,36 @@ import { AppointmentStatus, Prisma, UserRole } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateMedicalRecordDto } from './dto/create-medical-record.dto';
 import { UpdateMedicalRecordDto } from './dto/update-medical-record.dto';
+import { ListMedicalRecordsQueryDto } from './dto/list-medical-records-query.dto';
 import {
   MedicalRecordResponseDto,
   MedicalRecordPatientResponseDto,
+  MedicalRecordListResponseDto,
+  MedicalRecordPatientListResponseDto,
 } from './dto/medical-record-response.dto';
 import {
   MedicalRecordPdfService,
   PatientMedicalRecordPdfInput,
 } from './medical-record-pdf.service';
 
-type MedicalRecordWithAuthor = Prisma.MedicalRecordGetPayload<{
-  include: { author: true };
+type MedicalRecordWithRelations = Prisma.MedicalRecordGetPayload<{
+  include: {
+    author: true;
+    patient: true;
+    appointment: true;
+  };
 }>;
 
 const VALID_LINK_STATUSES: AppointmentStatus[] = [
   AppointmentStatus.CONFIRMED,
   AppointmentStatus.COMPLETED,
 ];
+
+const RECORD_INCLUDE = {
+  author: true,
+  patient: true,
+  appointment: true,
+} as const;
 
 @Injectable()
 export class MedicalRecordsService {
@@ -63,7 +76,7 @@ export class MedicalRecordsService {
           prescriptions: dto.prescriptions,
           internalNotes: dto.internalNotes,
         },
-        include: { author: true },
+        include: RECORD_INCLUDE,
       });
       return this.toResponseDto(record);
     } catch (error) {
@@ -93,30 +106,120 @@ export class MedicalRecordsService {
 
     const record = await this.prisma.medicalRecord.findUnique({
       where: { appointmentId },
-      include: { author: true },
+      include: RECORD_INCLUDE,
     });
 
     if (!record) {
       throw new NotFoundException('Prontuário não encontrado.');
     }
 
-    if (requesterRole === UserRole.PATIENT) {
-      if (record.patientId !== requesterId) {
-        throw new ForbiddenException('Acesso negado a este prontuário.');
-      }
-      return this.toPatientResponseDto(record);
-    }
+    return this.authorizeAndSerialize(record, requesterId, requesterRole);
+  }
 
-    const isAuthor = record.authorId === requesterId;
-    const hasLink =
-      isAuthor ||
-      (await this.hasPriorAppointment(requesterId, record.patientId));
-
-    if (!hasLink) {
+  async findById(
+    recordId: string,
+    requesterId: string,
+    requesterRole: UserRole,
+  ): Promise<MedicalRecordResponseDto | MedicalRecordPatientResponseDto> {
+    if (
+      requesterRole !== UserRole.PROFESSIONAL &&
+      requesterRole !== UserRole.PATIENT
+    ) {
       throw new ForbiddenException('Acesso negado a este prontuário.');
     }
 
-    return this.toResponseDto(record);
+    const record = await this.prisma.medicalRecord.findUnique({
+      where: { id: recordId },
+      include: RECORD_INCLUDE,
+    });
+
+    if (!record) {
+      throw new NotFoundException('Prontuário não encontrado.');
+    }
+
+    return this.authorizeAndSerialize(record, requesterId, requesterRole);
+  }
+
+  async list(
+    requesterId: string,
+    requesterRole: UserRole,
+    query: ListMedicalRecordsQueryDto,
+  ): Promise<
+    MedicalRecordListResponseDto | MedicalRecordPatientListResponseDto
+  > {
+    if (
+      requesterRole !== UserRole.PROFESSIONAL &&
+      requesterRole !== UserRole.PATIENT
+    ) {
+      throw new ForbiddenException('Acesso negado.');
+    }
+
+    const page = query.page || 1;
+    const limit = query.limit || 10;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.MedicalRecordWhereInput = {};
+
+    if (requesterRole === UserRole.PROFESSIONAL) {
+      // Médico vê apenas prontuários que ele mesmo criou
+      where.authorId = requesterId;
+      if (query.patientId) where.patientId = query.patientId;
+      if (query.authorId && query.authorId !== requesterId) {
+        // não permitir ver de outros médicos
+        throw new ForbiddenException(
+          'Não é possível listar prontuários de outros profissionais.',
+        );
+      }
+    } else {
+      // Paciente vê apenas os próprios
+      where.patientId = requesterId;
+      if (query.authorId) where.authorId = query.authorId;
+    }
+
+    if (query.startDate || query.endDate) {
+      where.createdAt = {
+        ...(query.startDate && { gte: new Date(query.startDate) }),
+        ...(query.endDate && { lte: new Date(query.endDate) }),
+      };
+    }
+
+    if (query.search) {
+      const term = query.search.trim();
+      if (term.length > 0) {
+        where.OR = [
+          { patient: { name: { contains: term, mode: 'insensitive' } } },
+          { chiefComplaint: { contains: term, mode: 'insensitive' } },
+          { diagnosis: { contains: term, mode: 'insensitive' } },
+        ];
+      }
+    }
+
+    const [records, total] = await Promise.all([
+      this.prisma.medicalRecord.findMany({
+        where,
+        include: RECORD_INCLUDE,
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.medicalRecord.count({ where }),
+    ]);
+
+    if (requesterRole === UserRole.PATIENT) {
+      return {
+        data: records.map((r) => this.toPatientResponseDto(r)),
+        page,
+        limit,
+        total,
+      };
+    }
+
+    return {
+      data: records.map((r) => this.toResponseDto(r)),
+      page,
+      limit,
+      total,
+    };
   }
 
   async findByPatient(
@@ -133,7 +236,7 @@ export class MedicalRecordsService {
 
     const records = await this.prisma.medicalRecord.findMany({
       where: { patientId },
-      include: { author: true },
+      include: RECORD_INCLUDE,
       orderBy: { createdAt: 'desc' },
     });
 
@@ -147,7 +250,7 @@ export class MedicalRecordsService {
   ): Promise<MedicalRecordResponseDto> {
     const record = await this.prisma.medicalRecord.findUnique({
       where: { id: recordId },
-      include: { author: true },
+      include: RECORD_INCLUDE,
     });
 
     if (!record) {
@@ -169,7 +272,7 @@ export class MedicalRecordsService {
         prescriptions: dto.prescriptions,
         internalNotes: dto.internalNotes,
       },
-      include: { author: true },
+      include: RECORD_INCLUDE,
     });
 
     return this.toResponseDto(updated);
@@ -234,6 +337,31 @@ export class MedicalRecordsService {
 
     return this.pdfService.generate(input);
   }
+
+  private async authorizeAndSerialize(
+    record: MedicalRecordWithRelations,
+    requesterId: string,
+    requesterRole: UserRole,
+  ): Promise<MedicalRecordResponseDto | MedicalRecordPatientResponseDto> {
+    if (requesterRole === UserRole.PATIENT) {
+      if (record.patientId !== requesterId) {
+        throw new ForbiddenException('Acesso negado a este prontuário.');
+      }
+      return this.toPatientResponseDto(record);
+    }
+
+    const isAuthor = record.authorId === requesterId;
+    const hasLink =
+      isAuthor ||
+      (await this.hasPriorAppointment(requesterId, record.patientId));
+
+    if (!hasLink) {
+      throw new ForbiddenException('Acesso negado a este prontuário.');
+    }
+
+    return this.toResponseDto(record);
+  }
+
   private async hasPriorAppointment(
     professionalId: string,
     patientId: string,
@@ -249,7 +377,7 @@ export class MedicalRecordsService {
   }
 
   private toResponseDto(
-    record: MedicalRecordWithAuthor,
+    record: MedicalRecordWithRelations,
   ): MedicalRecordResponseDto {
     return {
       id: record.id,
@@ -259,6 +387,15 @@ export class MedicalRecordsService {
         id: record.author.id,
         name: record.author.name,
         email: record.author.email,
+      },
+      patient: {
+        id: record.patient.id,
+        name: record.patient.name,
+      },
+      appointment: {
+        id: record.appointment.id,
+        dateTime: record.appointment.dateTime,
+        modality: record.appointment.modality,
       },
       chiefComplaint: record.chiefComplaint,
       diagnosis: record.diagnosis,
@@ -271,7 +408,7 @@ export class MedicalRecordsService {
   }
 
   private toPatientResponseDto(
-    record: MedicalRecordWithAuthor,
+    record: MedicalRecordWithRelations,
   ): MedicalRecordPatientResponseDto {
     return {
       id: record.id,
@@ -281,6 +418,11 @@ export class MedicalRecordsService {
         id: record.author.id,
         name: record.author.name,
         email: record.author.email,
+      },
+      appointment: {
+        id: record.appointment.id,
+        dateTime: record.appointment.dateTime,
+        modality: record.appointment.modality,
       },
       chiefComplaint: record.chiefComplaint,
       diagnosis: record.diagnosis,

--- a/apps/web/app/dashboard/patient/medical-records/[id]/page.tsx
+++ b/apps/web/app/dashboard/patient/medical-records/[id]/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { useMedicalRecordByIdQuery } from "@/queries/useMedicalRecords";
+import { medicalRecordsService } from "@/services/medical-records-service";
+import { CalendarIcon } from "../../../../utils/icons";
+
+const FIELDS = [
+  { key: "chiefComplaint", label: "Queixa principal" },
+  { key: "diagnosis", label: "Diagnóstico" },
+  { key: "treatmentPlan", label: "Plano terapêutico" },
+  { key: "prescriptions", label: "Prescrições" },
+] as const;
+
+function formatDateTime(iso: string) {
+  return new Date(iso).toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+const PatientMedicalRecordDetailsPage = () => {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const isMobile = useIsMobile();
+  const { data: record, isLoading } = useMedicalRecordByIdQuery(
+    params?.id ?? null,
+  );
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  if (isLoading) {
+    return (
+      <section className="w-full min-h-screen flex justify-center items-center bg-[#f8fafc]">
+        <Spinner size="lg" />
+      </section>
+    );
+  }
+
+  if (!record) {
+    return (
+      <section
+        className={`w-full min-h-screen bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
+      >
+        <p className="text-base text-slate-700">Prontuário não encontrado.</p>
+        <Button
+          variant="outline"
+          className="mt-4"
+          onClick={() => router.push("/dashboard/patient/medical-records")}
+        >
+          Voltar para a lista
+        </Button>
+      </section>
+    );
+  }
+
+  const handleDownloadPdf = async () => {
+    try {
+      setIsDownloading(true);
+      await medicalRecordsService.downloadPdf(record.appointmentId);
+      toast.success("PDF do prontuário baixado com sucesso.");
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : "Erro ao baixar PDF.";
+      toast.error(msg);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <section
+      className={`w-full min-h-screen bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
+    >
+      <div className="mb-6 flex items-center gap-3 flex-wrap">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => router.push("/dashboard/patient/medical-records")}
+          title="Voltar para a lista"
+        >
+          ← Voltar
+        </Button>
+      </div>
+
+      <Card className="border border-gray-200 rounded-xl bg-white mb-5">
+        <CardContent className="p-5 sm:p-6 flex flex-col gap-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h1
+                className={`font-bold text-slate-900 tracking-tight ${isMobile ? "text-xl" : "text-2xl"}`}
+              >
+                Prontuário da consulta
+              </h1>
+              <p className="mt-1 text-sm text-slate-500 flex items-center gap-1.5 flex-wrap">
+                <CalendarIcon size={14} />
+                {record.appointment
+                  ? formatDateTime(record.appointment.dateTime)
+                  : formatDateTime(record.createdAt)}
+                <span className="text-slate-300">•</span>
+                Atendido por{" "}
+                <span className="font-medium">{record.author.name}</span>
+              </p>
+            </div>
+            <Button
+              onClick={handleDownloadPdf}
+              disabled={isDownloading}
+              title="Baixar prontuário em PDF (sem notas internas)"
+            >
+              {isDownloading ? (
+                <span className="flex items-center gap-2">
+                  <Spinner size="sm" /> Gerando PDF…
+                </span>
+              ) : (
+                "Exportar PDF"
+              )}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border border-gray-200 rounded-xl bg-white">
+        <CardContent className="p-5 sm:p-6 flex flex-col gap-5">
+          {FIELDS.map((field) => {
+            const value = record[field.key];
+            return (
+              <div key={field.key} className="flex flex-col gap-1">
+                <p className="text-xs font-medium text-slate-400 uppercase tracking-wide">
+                  {field.label}
+                </p>
+                <p className="text-[14.5px] text-slate-700 leading-relaxed whitespace-pre-wrap">
+                  {value ?? (
+                    <span className="text-slate-300 italic">
+                      Não informado
+                    </span>
+                  )}
+                </p>
+              </div>
+            );
+          })}
+          <p className="text-xs text-slate-400 italic border-t border-slate-100 pt-3 mt-2">
+            Notas internas do profissional não são exibidas neste documento
+            conforme política de privacidade.
+          </p>
+        </CardContent>
+      </Card>
+    </section>
+  );
+};
+
+export default PatientMedicalRecordDetailsPage;

--- a/apps/web/app/dashboard/patient/medical-records/page.tsx
+++ b/apps/web/app/dashboard/patient/medical-records/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { Badge } from "@/components/ui/badge";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { useMedicalRecordsListForPatientQuery } from "@/queries/useMedicalRecords";
+import { CalendarIcon, EyeIcon, SearchIcon } from "../../../utils/icons";
+
+const PAGE_SIZE = 10;
+
+function formatDateTime(iso: string) {
+  return new Date(iso).toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function truncate(text: string | null, max = 120) {
+  if (!text) return null;
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+const PatientMedicalRecordsPage = () => {
+  const router = useRouter();
+  const isMobile = useIsMobile();
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  const params = useMemo(
+    () => ({
+      page,
+      limit: PAGE_SIZE,
+      ...(search && { search }),
+    }),
+    [page, search],
+  );
+
+  const { data, isLoading, isFetching } =
+    useMedicalRecordsListForPatientQuery(params);
+
+  const records = data?.data ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSearch(searchInput.trim());
+    setPage(1);
+  };
+
+  const hasFilters = Boolean(search);
+
+  return (
+    <section
+      className={`w-full min-h-screen mx-auto bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
+    >
+      <div className="mb-8">
+        <h1
+          className={`font-bold text-gray-900 tracking-tight ${isMobile ? "text-2xl" : "text-4xl"}`}
+        >
+          Meus Prontuários
+        </h1>
+        <p
+          className={`mt-1 text-gray-500 ${isMobile ? "text-sm" : "text-base"}`}
+        >
+          Histórico dos prontuários das suas consultas.
+          {total > 0 && ` ${total} no total.`}
+        </p>
+      </div>
+
+      <Card className="mb-6 border border-gray-200 rounded-xl bg-white">
+        <CardContent className="p-4 sm:p-5">
+          <form
+            onSubmit={handleSearch}
+            className="flex flex-col gap-3 sm:flex-row sm:items-end"
+          >
+            <div className="flex-1 flex flex-col gap-1">
+              <label className="text-xs font-medium text-slate-600">
+                Buscar (médico, queixa ou diagnóstico)
+              </label>
+              <div className="relative">
+                <SearchIcon
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"
+                  size={16}
+                />
+                <Input
+                  value={searchInput}
+                  onChange={(e) => setSearchInput(e.target.value)}
+                  placeholder="Ex.: Dr. Ana, gripe…"
+                  className="pl-9"
+                />
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Button type="submit">Buscar</Button>
+              {hasFilters && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setSearchInput("");
+                    setSearch("");
+                    setPage(1);
+                  }}
+                >
+                  Limpar
+                </Button>
+              )}
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {isLoading ? (
+        <div className="py-16 flex justify-center">
+          <Spinner size="lg" />
+        </div>
+      ) : records.length === 0 ? (
+        <Card className="border border-dashed border-gray-300 rounded-xl bg-white">
+          <CardContent className="py-16 text-center flex flex-col items-center gap-3">
+            <div className="w-14 h-14 rounded-full bg-blue-50 text-blue-600 flex items-center justify-center">
+              <CalendarIcon size={28} />
+            </div>
+            <div>
+              <p className="text-base font-semibold text-slate-800">
+                Nenhum prontuário encontrado
+              </p>
+              <p className="text-sm text-slate-500 mt-1 max-w-md">
+                {hasFilters
+                  ? "Tente ajustar a busca."
+                  : "Quando um médico criar um prontuário em alguma consulta sua, ele aparecerá aqui."}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {records.map((record) => (
+            <Card
+              key={record.id}
+              className="border border-gray-200 rounded-xl bg-white"
+            >
+              <CardContent className="p-4 sm:p-5 flex gap-4 items-center">
+                <div className="w-11 h-11 rounded-full bg-blue-50 border border-blue-100 text-blue-700 flex items-center justify-center font-semibold shrink-0">
+                  {record.author.name.charAt(0).toUpperCase()}
+                </div>
+                <div className="flex-1 min-w-0 flex flex-col gap-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-[15px] font-semibold text-slate-900 truncate">
+                      {record.author.name}
+                    </h3>
+                    {record.appointment && (
+                      <Badge className="bg-slate-100 text-slate-600 px-2 py-0.5 text-[11px] rounded font-medium">
+                        {record.appointment.modality === "VIRTUAL"
+                          ? "Virtual"
+                          : "Presencial"}
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="flex items-center gap-1.5 text-xs text-slate-500">
+                    <CalendarIcon size={14} />
+                    {record.appointment
+                      ? formatDateTime(record.appointment.dateTime)
+                      : `Emitido em ${formatDateTime(record.createdAt)}`}
+                  </p>
+                  {(record.diagnosis || record.chiefComplaint) && (
+                    <p className="text-sm text-slate-700 line-clamp-1 mt-0.5">
+                      <span className="text-slate-500">
+                        {record.diagnosis ? "Diagnóstico: " : "Queixa: "}
+                      </span>
+                      {truncate(record.diagnosis ?? record.chiefComplaint)}
+                    </p>
+                  )}
+                </div>
+                <Button
+                  size="sm"
+                  onClick={() =>
+                    router.push(`/dashboard/patient/medical-records/${record.id}`)
+                  }
+                  title="Abrir prontuário"
+                  className="shrink-0"
+                >
+                  <EyeIcon size={16} /> Abrir
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="mt-6 flex items-center justify-between gap-3">
+          <p className="text-xs text-slate-500">
+            Página {page} de {totalPages}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page <= 1 || isFetching}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+            >
+              Anterior
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page >= totalPages || isFetching}
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            >
+              Próxima
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default PatientMedicalRecordsPage;

--- a/apps/web/queries/useMedicalRecords.ts
+++ b/apps/web/queries/useMedicalRecords.ts
@@ -3,15 +3,45 @@ import { toast } from "sonner";
 import {
   medicalRecordsService,
   CreateMedicalRecordDto,
+  ListMedicalRecordsParams,
   UpdateMedicalRecordDto,
 } from "@/services/medical-records-service";
 
 const KEYS = {
+  list: (params: ListMedicalRecordsParams) =>
+    ["medical-records", "list", params] as const,
+  listForPatient: (params: ListMedicalRecordsParams) =>
+    ["medical-records", "list-patient", params] as const,
+  byId: (id: string) => ["medical-records", "id", id] as const,
   byAppointment: (appointmentId: string) =>
     ["medical-records", "appointment", appointmentId] as const,
   byPatient: (patientId: string) =>
     ["medical-records", "patient", patientId] as const,
 };
+
+export function useMedicalRecordsListQuery(params: ListMedicalRecordsParams) {
+  return useQuery({
+    queryKey: KEYS.list(params),
+    queryFn: () => medicalRecordsService.list(params),
+  });
+}
+
+export function useMedicalRecordsListForPatientQuery(
+  params: ListMedicalRecordsParams,
+) {
+  return useQuery({
+    queryKey: KEYS.listForPatient(params),
+    queryFn: () => medicalRecordsService.listForPatient(params),
+  });
+}
+
+export function useMedicalRecordByIdQuery(id: string | null) {
+  return useQuery({
+    queryKey: KEYS.byId(id ?? ""),
+    queryFn: () => medicalRecordsService.findById(id!),
+    enabled: Boolean(id),
+  });
+}
 
 export function useMedicalRecordByAppointmentQuery(
   appointmentId: string | null,
@@ -31,19 +61,18 @@ export function useMedicalRecordsByPatientQuery(patientId: string | null) {
   });
 }
 
+function invalidateAll(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: ["medical-records"] });
+}
+
 export function useCreateMedicalRecordMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (data: CreateMedicalRecordDto) =>
       medicalRecordsService.create(data),
-    onSuccess: (record) => {
-      queryClient.invalidateQueries({
-        queryKey: KEYS.byAppointment(record.appointmentId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: KEYS.byPatient(record.patientId),
-      });
+    onSuccess: () => {
+      invalidateAll(queryClient);
       toast.success("Prontuário criado com sucesso.");
     },
     onError: (error: Error) => {
@@ -58,13 +87,8 @@ export function useUpdateMedicalRecordMutation() {
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: UpdateMedicalRecordDto }) =>
       medicalRecordsService.update(id, data),
-    onSuccess: (record) => {
-      queryClient.invalidateQueries({
-        queryKey: KEYS.byAppointment(record.appointmentId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: KEYS.byPatient(record.patientId),
-      });
+    onSuccess: () => {
+      invalidateAll(queryClient);
       toast.success("Prontuário atualizado com sucesso.");
     },
     onError: (error: Error) => {

--- a/apps/web/services/medical-records-service.ts
+++ b/apps/web/services/medical-records-service.ts
@@ -7,11 +7,24 @@ export interface MedicalRecordAuthor {
   email: string;
 }
 
+export interface MedicalRecordPatient {
+  id: string;
+  name: string;
+}
+
+export interface MedicalRecordAppointment {
+  id: string;
+  dateTime: string;
+  modality: string;
+}
+
 export interface MedicalRecordResponse {
   id: string;
   appointmentId: string;
   patientId: string;
   author: MedicalRecordAuthor;
+  patient?: MedicalRecordPatient;
+  appointment?: MedicalRecordAppointment;
   chiefComplaint: string | null;
   diagnosis: string | null;
   treatmentPlan: string | null;
@@ -26,12 +39,20 @@ export interface MedicalRecordPatientResponse {
   appointmentId: string;
   patientId: string;
   author: MedicalRecordAuthor;
+  appointment?: MedicalRecordAppointment;
   chiefComplaint: string | null;
   diagnosis: string | null;
   treatmentPlan: string | null;
   prescriptions: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface PaginatedMedicalRecords<T> {
+  data: T[];
+  page: number;
+  limit: number;
+  total: number;
 }
 
 export interface CreateMedicalRecordDto {
@@ -47,6 +68,16 @@ export type UpdateMedicalRecordDto = Omit<
   CreateMedicalRecordDto,
   "appointmentId"
 >;
+
+export interface ListMedicalRecordsParams {
+  patientId?: string;
+  authorId?: string;
+  search?: string;
+  startDate?: string;
+  endDate?: string;
+  page?: number;
+  limit?: number;
+}
 
 function downloadBlob(blob: Blob, filename: string): void {
   const blobUrl = window.URL.createObjectURL(blob);
@@ -77,6 +108,39 @@ export const medicalRecordsService = {
       return response.data as MedicalRecordResponse;
     } catch (error) {
       extractErrorMessage(error, "Erro ao criar prontuário.");
+    }
+  },
+
+  async list(
+    params: ListMedicalRecordsParams = {},
+  ): Promise<PaginatedMedicalRecords<MedicalRecordResponse>> {
+    try {
+      const response = await api.get("/medical-records", { params });
+      return response.data as PaginatedMedicalRecords<MedicalRecordResponse>;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao listar prontuários.");
+    }
+  },
+
+  async listForPatient(
+    params: ListMedicalRecordsParams = {},
+  ): Promise<PaginatedMedicalRecords<MedicalRecordPatientResponse>> {
+    try {
+      const response = await api.get("/medical-records", { params });
+      return response.data as PaginatedMedicalRecords<MedicalRecordPatientResponse>;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao listar prontuários.");
+    }
+  },
+
+  async findById(
+    id: string,
+  ): Promise<MedicalRecordResponse | MedicalRecordPatientResponse> {
+    try {
+      const response = await api.get(`/medical-records/${id}`);
+      return response.data;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao buscar prontuário.");
     }
   },
 


### PR DESCRIPTION
## Summary
Dedicated patient routes for accessing their own medical records, replacing the appointment-card view modal:
- `/dashboard/patient/medical-records` — paginated list, search by médico/queixa/diagnóstico
- `/dashboard/patient/medical-records/[id]` — read-only view + "Exportar PDF" action

`internalNotes` is omitted by the backend for patients (LGPD), so the UI doesn't render it.

## Why
Patients had no way to browse their records outside an individual completed-appointment modal. A dedicated history page makes records findable independent of the appointment list.

## Depends on
- #139 (backend list + findById endpoints)

## Test plan
- [ ] List loads only my records, paginated 10/page
- [ ] Search filters by médico name / queixa / diagnóstico
- [ ] Detail page hides internalNotes (LGPD)
- [ ] "Exportar PDF" downloads the record PDF without internal notes
- [ ] Trying to access another patient's record id returns 403