### PR TITLE
fix(professional-patients): phone source, CPF search, UI refinements

### DIFF
--- a/apps/server/src/professional/professional.service.ts
+++ b/apps/server/src/professional/professional.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   Inject,
 } from '@nestjs/common';
+import { AppointmentStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpdateProfessionalSettingsDto } from './dto/update-setting.dto';
 import { CreateScheduleBlockDto } from './dto/schedule-block.dto';
@@ -115,37 +116,68 @@ export class ProfessionalService {
       orderBy: { dateTime: 'desc' },
       select: {
         dateTime: true,
+        status: true,
         patient: {
           select: {
             id: true,
             name: true,
             email: true,
+            cpf: true,
+            patientProfile: {
+              select: { phone: true },
+            },
           },
         },
       },
     });
 
+    const now = new Date();
     const uniquePatients = new Map<
       string,
       {
         id: string;
         name: string;
         email: string;
+        cpf: string | null;
         phone: string;
-        lastVisit: string;
+        lastVisit: string | null;
+        nextVisit: string | null;
       }
     >();
 
     for (const appt of appointments) {
-      if (!uniquePatients.has(appt.patient.id)) {
-        uniquePatients.set(appt.patient.id, {
-          id: appt.patient.id,
-          name: appt.patient.name,
-          email: appt.patient.email,
-          phone: (appt.patient as any).phone || 'Não informado',
-          lastVisit: appt.dateTime.toISOString(),
-        });
+      const existing = uniquePatients.get(appt.patient.id) ?? {
+        id: appt.patient.id,
+        name: appt.patient.name,
+        email: appt.patient.email,
+        cpf: appt.patient.cpf ?? null,
+        phone: appt.patient.patientProfile?.phone || 'Não informado',
+        lastVisit: null as string | null,
+        nextVisit: null as string | null,
+      };
+
+      const isUpcoming =
+        appt.dateTime > now &&
+        (appt.status === AppointmentStatus.PENDING ||
+          appt.status === AppointmentStatus.CONFIRMED);
+
+      if (isUpcoming) {
+        if (
+          !existing.nextVisit ||
+          new Date(existing.nextVisit) > appt.dateTime
+        ) {
+          existing.nextVisit = appt.dateTime.toISOString();
+        }
+      } else {
+        if (
+          !existing.lastVisit ||
+          new Date(existing.lastVisit) < appt.dateTime
+        ) {
+          existing.lastVisit = appt.dateTime.toISOString();
+        }
       }
+
+      uniquePatients.set(appt.patient.id, existing);
     }
 
     return Array.from(uniquePatients.values());
@@ -158,6 +190,10 @@ export class ProfessionalService {
         id: true,
         name: true,
         email: true,
+        cpf: true,
+        patientProfile: {
+          select: { phone: true },
+        },
       },
     });
 
@@ -174,7 +210,8 @@ export class ProfessionalService {
       id: patient.id,
       name: patient.name,
       email: patient.email,
-      phone: (patient as any).phone || 'Não informado',
+      cpf: patient.cpf ?? null,
+      phone: patient.patientProfile?.phone || 'Não informado',
       history: appointments.map((apt) => ({
         id: apt.id,
         dateTime: apt.dateTime,

--- a/apps/web/app/dashboard/professional/patients/components/PatientCard.tsx
+++ b/apps/web/app/dashboard/professional/patients/components/PatientCard.tsx
@@ -11,13 +11,16 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { Badge } from "@/components/ui/badge";
 import { usePatientDetail } from "@/queries/useProfessionalPatients";
+import { formatPhoneNumber } from "@/app/utils/formatPhone";
 
 export interface PatientCardData {
   id: string;
   name: string;
   email: string;
+  cpf: string | null;
   phone: string;
-  lastVisit: string;
+  lastVisit: string | null;
+  nextVisit: string | null;
   photoUrl?: string;
 }
 
@@ -41,6 +44,18 @@ const STATUS_TEXT: Record<string, string> = {
   PENDING: "Pendente",
 };
 
+function formatCpf(cpf: string | null): string {
+  if (!cpf) return "Não informado";
+  const digits = cpf.replace(/\D/g, "");
+  if (digits.length !== 11) return cpf;
+  return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9)}`;
+}
+
+function formatPhone(phone: string): string {
+  if (!phone || phone === "Não informado") return "Não informado";
+  return formatPhoneNumber(phone);
+}
+
 export function PatientCard({ patient }: PatientCardProps) {
   const [isProfileOpen, setIsProfileOpen] = useState(false);
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
@@ -51,28 +66,36 @@ export function PatientCard({ patient }: PatientCardProps) {
     isAnyModalOpen,
   );
 
-  const visitDate = new Date(patient.lastVisit);
-  const isFuture = visitDate > new Date();
-  const visitLabel = isFuture ? "Próxima Consulta" : "Última Consulta";
-  const formattedDate = visitDate.toLocaleDateString("pt-BR");
+  const nextVisitFormatted = patient.nextVisit
+    ? new Date(patient.nextVisit).toLocaleDateString("pt-BR")
+    : null;
+  const lastVisitFormatted = patient.lastVisit
+    ? new Date(patient.lastVisit).toLocaleDateString("pt-BR")
+    : null;
 
-  const renderAvatar = (name: string, photoUrl?: string) => {
+  const renderAvatar = (
+    name: string,
+    photoUrl?: string,
+    size: "sm" | "md" = "md",
+  ) => {
+    const sizePx = size === "sm" ? 40 : 48;
+    const sizeClass = size === "sm" ? "w-10 h-10" : "w-12 h-12";
     if (photoUrl) {
       return (
         <Image
           src={photoUrl}
           alt={name}
           title={`Foto de perfil de ${name}`}
-          width={48}
-          height={48}
-          className="w-12 h-12 rounded-full object-cover object-center border border-gray-200 p-1 bg-[#fafafa] shadow-sm shrink-0"
+          width={sizePx}
+          height={sizePx}
+          className={`${sizeClass} rounded-full object-cover object-center border border-gray-200 bg-[#fafafa] shrink-0`}
         />
       );
     }
     return (
       <div
         title={`Foto de perfil de ${name}`}
-        className="w-12 h-12 rounded-full font-semibold flex items-center justify-center text-[#006fee] bg-[#e6f1ff] border border-gray-200 p-1 shadow-sm shrink-0"
+        className={`${sizeClass} rounded-full font-semibold flex items-center justify-center text-blue-700 bg-blue-50 border border-blue-100 shrink-0`}
       >
         {name.charAt(0).toUpperCase()}
       </div>
@@ -81,47 +104,83 @@ export function PatientCard({ patient }: PatientCardProps) {
 
   return (
     <>
-      <div className="bg-white rounded-2xl border border-gray-200 p-5 transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_20px_rgba(0,0,0,0.05)] flex flex-col justify-between h-full">
-        <div>
-          <div className="flex gap-4 items-center mb-4">
-            {renderAvatar(patient.name, patient.photoUrl)}
-            <div className="min-w-0 flex-1">
-              <h3
-                className="font-semibold text-base text-gray-900 truncate"
-                title={patient.name}
-              >
-                {patient.name}
-              </h3>
-              <p
-                className="text-[0.85rem] text-gray-500 truncate"
-                title={patient.email}
-              >
-                {patient.email}
-              </p>
-            </div>
-          </div>
-          <div className="text-[0.9rem] text-gray-700 mb-6">
-            <p className="truncate mb-1" title={`Telefone: ${patient.phone}`}>
-              <strong>Telefone:</strong> {patient.phone}
-            </p>
-            <p className="truncate" title={`${visitLabel}: ${formattedDate}`}>
-              <strong>{visitLabel}:</strong> {formattedDate}
+      <div className="bg-white rounded-xl border border-gray-200 p-5 flex flex-col h-full">
+        <div className="flex gap-3 items-center mb-4">
+          {renderAvatar(patient.name, patient.photoUrl)}
+          <div className="min-w-0 flex-1">
+            <h3
+              className="font-semibold text-[15px] text-gray-900 truncate"
+              title={patient.name}
+            >
+              {patient.name}
+            </h3>
+            <p
+              className="text-[13px] text-gray-500 truncate"
+              title={patient.email}
+            >
+              {patient.email}
             </p>
           </div>
         </div>
+
+        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[13px] mb-5">
+          <dt className="text-gray-500">CPF</dt>
+          <dd
+            className="text-gray-800 font-medium truncate"
+            title={formatCpf(patient.cpf)}
+          >
+            {formatCpf(patient.cpf)}
+          </dd>
+          <dt className="text-gray-500">Telefone</dt>
+          <dd
+            className="text-gray-800 font-medium truncate"
+            title={formatPhone(patient.phone)}
+          >
+            {formatPhone(patient.phone)}
+          </dd>
+          {nextVisitFormatted && (
+            <>
+              <dt className="text-gray-500">Próxima consulta</dt>
+              <dd
+                className="text-gray-800 font-medium truncate"
+                title={nextVisitFormatted}
+              >
+                {nextVisitFormatted}
+              </dd>
+            </>
+          )}
+          {lastVisitFormatted && (
+            <>
+              <dt className="text-gray-500">Última consulta</dt>
+              <dd
+                className="text-gray-800 font-medium truncate"
+                title={lastVisitFormatted}
+              >
+                {lastVisitFormatted}
+              </dd>
+            </>
+          )}
+          {!nextVisitFormatted && !lastVisitFormatted && (
+            <>
+              <dt className="text-gray-500">Consultas</dt>
+              <dd className="text-gray-400 italic truncate">Nenhuma</dd>
+            </>
+          )}
+        </dl>
+
         <div className="flex gap-2 mt-auto">
           <Button
             size="sm"
             variant="outline"
-            className="flex-1 border-gray-200 text-gray-700 text-xs"
+            className="flex-1 text-xs"
             onClick={() => setIsProfileOpen(true)}
             title="Abrir perfil detalhado do paciente"
           >
-            Ver Perfil
+            Ver perfil
           </Button>
           <Button
             size="sm"
-            className="flex-1 bg-blue-600 hover:bg-blue-700 text-white text-xs"
+            className="flex-1 text-xs"
             onClick={() => setIsHistoryOpen(true)}
             title="Ver histórico de consultas deste paciente"
           >
@@ -133,7 +192,7 @@ export function PatientCard({ patient }: PatientCardProps) {
       <Dialog open={isProfileOpen} onOpenChange={setIsProfileOpen}>
         <DialogContent className="sm:max-w-106.25 rounded-2xl">
           <DialogHeader>
-            <DialogTitle>Perfil do Paciente</DialogTitle>
+            <DialogTitle>Perfil do paciente</DialogTitle>
             <DialogDescription>
               Informações detalhadas de contato e cadastro.
             </DialogDescription>
@@ -154,11 +213,19 @@ export function PatientCard({ patient }: PatientCardProps) {
                     {detailData.name}
                   </h4>
                   <span className="text-sm text-blue-600 font-medium bg-blue-50 px-2 py-0.5 rounded-md">
-                    Paciente Ativo
+                    Paciente ativo
                   </span>
                 </div>
               </div>
               <div className="bg-slate-50 border border-slate-100 rounded-xl p-4 space-y-3">
+                <div>
+                  <p className="text-xs text-gray-500 font-medium uppercase tracking-wider mb-1">
+                    CPF
+                  </p>
+                  <p className="text-sm text-gray-900">
+                    {formatCpf(detailData.cpf)}
+                  </p>
+                </div>
                 <div>
                   <p className="text-xs text-gray-500 font-medium uppercase tracking-wider mb-1">
                     E-mail
@@ -171,13 +238,13 @@ export function PatientCard({ patient }: PatientCardProps) {
                   <p className="text-xs text-gray-500 font-medium uppercase tracking-wider mb-1">
                     Telefone
                   </p>
-                  <p className="text-sm text-gray-900" title={detailData.phone}>
-                    {detailData.phone}
+                  <p className="text-sm text-gray-900">
+                    {formatPhone(detailData.phone)}
                   </p>
                 </div>
                 <div>
                   <p className="text-xs text-gray-500 font-medium uppercase tracking-wider mb-1">
-                    Total de Consultas
+                    Total de consultas
                   </p>
                   <p className="text-sm text-gray-900">
                     {detailData.history.length}
@@ -192,7 +259,7 @@ export function PatientCard({ patient }: PatientCardProps) {
       <Dialog open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>
         <DialogContent className="sm:max-w-125 rounded-2xl max-h-[80vh] overflow-hidden flex flex-col">
           <DialogHeader>
-            <DialogTitle>Histórico de Consultas</DialogTitle>
+            <DialogTitle>Histórico de consultas</DialogTitle>
             <DialogDescription>
               Acompanhamento de consultas de {patient.name}.
             </DialogDescription>

--- a/apps/web/app/dashboard/professional/patients/page.tsx
+++ b/apps/web/app/dashboard/professional/patients/page.tsx
@@ -1,65 +1,125 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
-import { SearchIcon } from "../../../utils/icons";
+import { SearchIcon, UsersIcon } from "../../../utils/icons";
 import { useProfessionalPatients } from "@/queries/useProfessionalPatients";
 import { PatientCard, PatientCardData } from "./components/PatientCard";
+
+function onlyDigits(value: string) {
+  return value.replace(/\D/g, "");
+}
 
 export default function PatientsPage() {
   const [search, setSearch] = useState("");
   const { data: patients = [], isLoading, isError } = useProfessionalPatients();
 
-  const filtered = patients.filter((p) => {
-    const term = search.toLowerCase();
-    return Object.values(p)
-      .filter((value) => typeof value === "string")
-      .some((value) => (value as string).toLowerCase().includes(term));
-  });
+  const filtered = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return patients;
+    const termDigits = onlyDigits(term);
+    return patients.filter((p) => {
+      const matchesText =
+        p.name?.toLowerCase().includes(term) ||
+        p.email?.toLowerCase().includes(term) ||
+        p.phone?.toLowerCase().includes(term);
+      const matchesCpf =
+        termDigits.length > 0 &&
+        p.cpf &&
+        onlyDigits(p.cpf).includes(termDigits);
+      return matchesText || matchesCpf;
+    });
+  }, [patients, search]);
+
+  const totalLabel =
+    patients.length === 1 ? "1 paciente" : `${patients.length} pacientes`;
 
   return (
     <section className="w-full min-h-screen mx-auto px-4 py-6 sm:px-16 sm:py-8 bg-[#f8fafc]">
       <div className="mb-6 sm:mb-8">
-        <h1 className="text-2xl sm:text-4xl font-bold text-gray-900">
+        <h1 className="text-2xl sm:text-4xl font-bold text-gray-900 tracking-tight">
           Pacientes
         </h1>
         <p className="mt-1 text-sm sm:text-base text-gray-500">
           Acompanhe o perfil e o histórico dos pacientes que você atende.
+          {!isLoading && patients.length > 0 && (
+            <span className="ml-1 text-gray-700 font-medium">
+              · {totalLabel}
+            </span>
+          )}
         </p>
       </div>
 
-      <div className="mb-6 sm:mb-8 w-full sm:max-w-100 relative">
-        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-          <SearchIcon />
-        </span>
-        <Input
-          placeholder="Buscar paciente..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          title="Digite o nome ou informação para filtrar os pacientes"
-          className="h-12 w-full px-4 rounded-lg border border-slate-300 text-sm text-slate-700 bg-white outline-none transition-all duration-200 pl-10"
-        />
-      </div>
+      <Card className="mb-6 border border-gray-200 rounded-xl bg-white">
+        <CardContent className="p-4 sm:p-5">
+          <label className="text-xs font-medium text-slate-600 mb-1.5 block">
+            Buscar por nome, e-mail, telefone ou CPF
+          </label>
+          <div className="relative">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">
+              <SearchIcon size={16} />
+            </span>
+            <Input
+              placeholder="Ex.: Maria Silva, 123.456.789-00, maria@..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              title="Digite nome, e-mail, telefone ou CPF"
+              className="h-11 pl-10"
+            />
+          </div>
+          {search && (
+            <p className="text-xs text-slate-500 mt-2">
+              {filtered.length} resultado{filtered.length === 1 ? "" : "s"} para
+              “{search}”
+            </p>
+          )}
+        </CardContent>
+      </Card>
 
       {isLoading ? (
         <div className="py-20 flex justify-center items-center">
           <Spinner size="lg" />
         </div>
       ) : isError ? (
-        <div className="py-20 text-center text-red-500 font-medium">
-          Não foi possível carregar a lista de pacientes.
-        </div>
-      ) : filtered.length === 0 ? (
-        <div className="py-20 text-center text-gray-500">
-          Nenhum paciente encontrado.
-        </div>
-      ) : (
-        <div className="grid gap-4 sm:gap-6 grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
-          {filtered.map((patient) => (
-            <div key={patient.id} title="Visualizar detalhes do paciente">
-              <PatientCard patient={patient as PatientCardData} />
+        <Card className="border border-red-200 bg-red-50 rounded-xl">
+          <CardContent className="py-10 text-center text-red-600 font-medium">
+            Não foi possível carregar a lista de pacientes.
+          </CardContent>
+        </Card>
+      ) : patients.length === 0 ? (
+        <Card className="border border-dashed border-gray-300 rounded-xl bg-white">
+          <CardContent className="py-16 text-center flex flex-col items-center gap-3">
+            <div className="w-14 h-14 rounded-full bg-blue-50 text-blue-600 flex items-center justify-center">
+              <UsersIcon size={28} />
             </div>
+            <div>
+              <p className="text-base font-semibold text-slate-800">
+                Você ainda não tem pacientes
+              </p>
+              <p className="text-sm text-slate-500 mt-1 max-w-md">
+                Assim que uma consulta for agendada com você, o paciente
+                aparecerá aqui.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      ) : filtered.length === 0 ? (
+        <Card className="border border-dashed border-gray-300 rounded-xl bg-white">
+          <CardContent className="py-12 text-center">
+            <p className="text-base font-medium text-slate-700">
+              Nenhum paciente encontrado.
+            </p>
+            <p className="text-sm text-slate-500 mt-1">
+              Tente outra busca por nome, e-mail ou CPF.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 sm:gap-5 grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(300px,1fr))]">
+          {filtered.map((patient) => (
+            <PatientCard key={patient.id} patient={patient as PatientCardData} />
           ))}
         </div>
       )}

--- a/apps/web/services/professional-service.ts
+++ b/apps/web/services/professional-service.ts
@@ -16,14 +16,17 @@ export interface PatientProfile {
   id: string;
   name: string;
   email: string;
+  cpf: string | null;
   phone: string;
-  lastVisit: string;
+  lastVisit: string | null;
+  nextVisit: string | null;
 }
 
 export interface PatientDetail {
   id: string;
   name: string;
   email: string;
+  cpf: string | null;
   phone: string;
   history: {
     id: string;


### PR DESCRIPTION
## Summary
Independent fixes and UX improvements on the professional patients list.

### Bug fixes
- **Telefone "Não informado"**: backend was reading \`(patient as any).phone\`, but \`phone\` lives on \`PatientProfile\`, not \`User\`. Now reads from \`patient.patientProfile.phone\` in both \`getPatients\` and \`getPatientDetail\`.
- **"Próxima consulta" em consulta concluída**: the card decided the label only from the date. A COMPLETED appointment scheduled in the future was being labeled "Próxima". The API now returns \`lastVisit\` and \`nextVisit\` separately (next = future + PENDING/CONFIRMED; last = everything else).

### Features
- **Busca por CPF**: API now returns \`cpf\`; the page search matches name, e-mail, telefone ou CPF (ignoring punctuation, so \`12345678900\` matches \`123.456.789-00\`).

### UI
- Removes the unintended hover-translate on the patient card
- Formats CPF (\`000.000.000-00\`) and phone via \`formatPhoneNumber\`
- Shows both "Última" and "Próxima consulta" when applicable
- Empty state with icon and a result counter beside the search

## Test plan
- [ ] Pacientes com \`patientProfile.phone\` preenchido mostram o telefone correto
- [ ] Paciente com consulta COMPLETED no futuro: card mostra "Última consulta", não "Próxima"
- [ ] Paciente com consulta CONFIRMED no futuro: card mostra "Próxima consulta"
- [ ] Buscar por nome funciona como antes
- [ ] Buscar por CPF (com ou sem pontuação) encontra o paciente
- [ ] Card sem hover translate