### PR TITLE
fix(appointments): block COMPLETED/NO_SHOW before the scheduled time

### DIFF
--- a/apps/server/src/appointments/appointments.service.ts
+++ b/apps/server/src/appointments/appointments.service.ts
@@ -455,6 +455,15 @@ export class AppointmentsService {
       );
     }
 
+    const requiresPastDate =
+      dto.status === AppointmentStatus.COMPLETED ||
+      dto.status === AppointmentStatus.NO_SHOW;
+    if (requiresPastDate && appointment.dateTime > new Date()) {
+      throw new BadRequestException(
+        'Só é possível marcar a consulta como realizada ou faltou após o horário agendado.',
+      );
+    }
+
     const updated = await this.prisma.appointment.update({
       where: { id: appointmentId },
       data: {


### PR DESCRIPTION
## Summary
\`PATCH /appointments/:id/status\` now rejects (400) attempts to set the status to \`COMPLETED\` or \`NO_SHOW\` while the appointment's \`dateTime\` is still in the future.

## Why
A professional was able to mark a still-upcoming appointment as Realizada or Faltou. The UI then showed inconsistent state (e.g. the patients list labeling it "Próxima consulta" while the appointment was already COMPLETED). Only past appointments should be terminable.

## Note
This PR does not retroactively fix records already in that bad state. A small migration / SQL update will be needed separately for any rows where \`status IN ('COMPLETED','NO_SHOW') AND date_time > NOW()\`.

## Test plan
- [ ] PATCH status=COMPLETED em consulta cuja dateTime ainda é no futuro → 400 com mensagem em PT-BR
- [ ] PATCH status=NO_SHOW em consulta no futuro → 400
- [ ] PATCH status=COMPLETED em consulta já no passado → 200
- [ ] PATCH status=CONFIRMED em consulta no futuro continua funcionando → 200
- [ ] PATCH status=CANCELLED em consulta no futuro continua funcionando → 200