### PR TITLE
fix(questionnaire): impede paciente de ficar preso após concluir o questionário

### DIFF
--- a/apps/web/components/questionnaire/VulnerabilityQuestionnaire.tsx
+++ b/apps/web/components/questionnaire/VulnerabilityQuestionnaire.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import Cookies from "js-cookie";
 import { Card, CardContent } from "../ui/card";
@@ -30,6 +31,7 @@ type AnswersState = Record<string, string>;
 
 export function VulnerabilityQuestionnaire({ mode, patientId }: Props) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [result, setResult] = useState<QuestionnaireSubmitResponse | null>(
     null,
   );
@@ -119,7 +121,11 @@ export function VulnerabilityQuestionnaire({ mode, patientId }: Props) {
 
   const handleContinue = () => {
     if (mode === "self") {
+      // Drop any stale user state so the dashboard re-fetches with the
+      // questionnaire already marked as completed, then navigate.
+      queryClient.invalidateQueries({ queryKey: ["user"] });
       router.push("/dashboard/patient");
+      router.refresh();
       return;
     }
     router.push(`/dashboard/manager/patients/${patientId}`);

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -32,7 +32,11 @@ api.interceptors.response.use(
     if (
       typeof window !== "undefined" &&
       payload?.code === "QUESTIONNAIRE_REQUIRED" &&
-      payload?.redirectTo
+      payload?.redirectTo &&
+      // Avoid bouncing the patient back to the questionnaire when they have
+      // just completed it: a residual request may still race the freshly
+      // persisted state. The completion cookie is the source of truth here.
+      Cookies.get(QUESTIONNAIRE_COMPLETED_KEY) !== "true"
     ) {
       Cookies.set(QUESTIONNAIRE_COMPLETED_KEY, "false", { expires: 1 });
       window.location.href = payload.redirectTo;


### PR DESCRIPTION
## Problema

Ao preencher o questionário e tentar navegar, o paciente ficava **preso no questionário** — só conseguia sair dando F5.

## Causa raiz

Condição de corrida agravada por um redirect "hard":

1. Paciente envia o questionário (`POST /questionnaire`, na whitelist do `QuestionnaireCompletionGuard`) — o backend persiste `questionnaireCompleted=true`.
2. Clica "Ir para o painel" → `router.push("/dashboard/patient")` (navegação SPA, **sem reload**).
3. O dashboard dispara `GET /appointments/my-appointments`, que **não está na whitelist** do guard.
4. Se esse GET pega estado obsoleto (cache do React Query / corrida de propagação), o backend retorna `403 QUESTIONNAIRE_REQUIRED`.
5. O interceptor do Axios fazia `window.location.href` de volta ao questionário **e regravava o cookie de conclusão para `"false"`**, prendendo o usuário.
6. F5 "resolvia" porque o reload completo refazia tudo já consistente.

## Correção (frontend)

- **`apps/web/lib/api.ts`**: o interceptor só redireciona (e reseta o cookie) quando o cookie de conclusão **não** for `"true"`, tratando-o como fonte de verdade logo após a conclusão.
- **`apps/web/components/questionnaire/VulnerabilityQuestionnaire.tsx`**: ao continuar, invalida o cache `["user"]` e chama `router.refresh()` antes do `router.push`, garantindo que o dashboard re-busque com o questionário já marcado como concluído.

## Validação

- ✅ `tsc --noEmit` (web) sem erros
- ✅ ESLint limpo nos arquivos alterados
- ✅ Jest unit (backend): 8/8
- ⚠️ `test:e2e` (backend) falha por config de path pré-existente (`Cannot find module 'src/prisma/prisma.service'`), não relacionada a esta mudança (100% frontend). Não há e2e de navegador no projeto.

## Teste manual sugerido

Preencher o questionário → "Ir para o painel" → navegar entre telas sem precisar de F5.