### PR TITLE
fix(auth): separar confirmação de e-mail da aprovação do admin (profissional)

### DIFF
--- a/apps/server/src/auth/auth.service.spec.ts
+++ b/apps/server/src/auth/auth.service.spec.ts
@@ -60,6 +60,55 @@ describe('AuthService', () => {
     expect(jwtService.sign).not.toHaveBeenCalled();
   });
 
+  it('blocks professional whose email is not yet confirmed', async () => {
+    prisma.user.findUnique.mockResolvedValue(
+      await makeUser({
+        role: UserRole.PROFESSIONAL,
+        emailVerified: false,
+        status: UserStatus.PENDING,
+        patientProfile: null,
+      }),
+    );
+
+    await expect(
+      service.login({ email: 'usuario@lifemed.com', password }),
+    ).rejects.toThrow('Seu e-mail ainda não foi verificado');
+
+    expect(jwtService.sign).not.toHaveBeenCalled();
+  });
+
+  it('blocks professional with confirmed email but pending admin approval', async () => {
+    prisma.user.findUnique.mockResolvedValue(
+      await makeUser({
+        role: UserRole.PROFESSIONAL,
+        emailVerified: true,
+        status: UserStatus.PENDING,
+        patientProfile: null,
+      }),
+    );
+
+    await expect(
+      service.login({ email: 'usuario@lifemed.com', password }),
+    ).rejects.toThrow('aguarda aprovação do administrador');
+
+    expect(jwtService.sign).not.toHaveBeenCalled();
+  });
+
+  it('lets an approved (VERIFIED) professional login', async () => {
+    prisma.user.findUnique.mockResolvedValue(
+      await makeUser({
+        role: UserRole.PROFESSIONAL,
+        emailVerified: true,
+        status: UserStatus.VERIFIED,
+        patientProfile: null,
+      }),
+    );
+
+    await expect(
+      service.login({ email: 'usuario@lifemed.com', password }),
+    ).resolves.toMatchObject({ accessToken: 'signed-token' });
+  });
+
   it('keeps verified users able to login', async () => {
     prisma.user.findUnique.mockResolvedValue(await makeUser());
 

--- a/apps/server/src/auth/auth.service.ts
+++ b/apps/server/src/auth/auth.service.ts
@@ -55,14 +55,22 @@ export class AuthService {
       );
     }
 
+    // Etapa 1 (todos): o e-mail precisa estar confirmado.
     if (!user.emailVerified) {
-      if (user.role === UserRole.PATIENT) {
-        throw new UnauthorizedException(
-          'Seu e-mail ainda não foi verificado. Verifique sua caixa de entrada.',
-        );
-      }
       throw new UnauthorizedException(
-        'Sua conta ainda não foi aprovada. Aguarde a verificação do administrador.',
+        'Seu e-mail ainda não foi verificado. Verifique sua caixa de entrada.',
+      );
+    }
+
+    // Etapa 2 (apenas profissional/gestor): a conta precisa ser aprovada por um
+    // administrador. Pacientes têm acesso assim que confirmam o e-mail.
+    if (
+      user.role !== UserRole.PATIENT &&
+      user.role !== UserRole.ADMIN &&
+      user.status !== UserStatus.VERIFIED
+    ) {
+      throw new UnauthorizedException(
+        'Seu e-mail foi confirmado, mas sua conta ainda aguarda aprovação do administrador.',
       );
     }
 
@@ -168,7 +176,7 @@ export class AuthService {
         password: passwordHash,
         name: dto.name,
         role: UserRole.PROFESSIONAL,
-        status: UserStatus.COMPLETED,
+        status: UserStatus.PENDING,
         professionalProfile: {
           create: {
             professionalLicense: dto.professionalLicense,
@@ -348,16 +356,20 @@ export class AuthService {
   async verifyEmail(token: string) {
     const user = await this.emailVerification.validateToken(token);
 
+    // Em ambos os casos a confirmação de e-mail marca emailVerified.
+    await this.prisma.user.update({
+      where: { id: user.id },
+      data: { emailVerified: true },
+    });
+
     if (user.role === UserRole.PATIENT) {
-      await this.prisma.user.update({
-        where: { id: user.id },
-        data: { emailVerified: true },
-      });
       return {
         message: 'E-mail verificado com sucesso. Você já pode fazer login.',
       };
     }
 
+    // Profissional/gestor: e-mail confirmado, mas ainda depende de aprovação
+    // do administrador (status passa a VERIFIED na aprovação).
     this.notifyAdminsOfNewUser({
       name: user.name,
       email: user.email,

--- a/apps/web/app/auth/login/useLoginForm.ts
+++ b/apps/web/app/auth/login/useLoginForm.ts
@@ -38,14 +38,17 @@ export function useLoginForm() {
           const message =
             error instanceof Error ? error.message : "Erro desconhecido.";
 
-          if (message.includes("ainda não foi aprovada")) {
+          // Etapa 2: e-mail confirmado, mas falta aprovação do administrador.
+          if (message.includes("aguarda aprovação do administrador")) {
             toast.info(message);
             router.push("/auth/pending-approval");
             return;
           }
 
+          // Etapa 1: e-mail ainda não confirmado.
           if (message.includes("ainda não foi verificado")) {
             toast.info(message);
+            router.push("/auth/verify-email-pending");
             return;
           }
 

--- a/apps/web/app/auth/pending-approval/page.tsx
+++ b/apps/web/app/auth/pending-approval/page.tsx
@@ -11,11 +11,12 @@ export default function PendingApprovalPage() {
           <Clock className="h-8 w-8 text-amber-600" />
         </div>
 
-        <h1 className="text-2xl font-semibold">Conta Pendente de Aprovacao</h1>
+        <h1 className="text-2xl font-semibold">Aguardando aprovação</h1>
 
         <p className="text-muted-foreground">
-          Sua conta foi criada com sucesso, mas ainda precisa ser aprovada por um
-          administrador. Voce recebera acesso assim que sua conta for verificada.
+          Seu e-mail já foi confirmado. Agora sua conta precisa ser aprovada por
+          um administrador antes do primeiro acesso. Você receberá um e-mail
+          assim que a aprovação for concluída.
         </p>
 
         <Link

--- a/apps/web/app/auth/register/useRegisterForm.ts
+++ b/apps/web/app/auth/register/useRegisterForm.ts
@@ -81,8 +81,11 @@ export function useRegisterForm() {
           socialLinks: professional.socialLinks,
         });
         toast.success(
-          "Sua solicitação foi enviada para a administração, aguarde. Sua resposta virá via email.",
+          "Cadastro realizado! Confirme seu e-mail para concluir a primeira etapa. Depois sua conta será analisada por um administrador.",
         );
+        form.reset(INITIAL_FORM);
+        setTimeout(() => router.push("/auth/verify-email-pending"), 1000);
+        return;
       } else {
         const patient = data as z.infer<typeof registerPatientValidation>;
         await authService.registerPatient({

--- a/apps/web/app/auth/verify-email-pending/page.tsx
+++ b/apps/web/app/auth/verify-email-pending/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { MailCheck } from "lucide-react";
+import Link from "next/link";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useResendVerificationMutation } from "../../../queries/useResendVerificationMutation";
+
+export default function VerifyEmailPendingPage() {
+  const [email, setEmail] = useState("");
+  const resendMutation = useResendVerificationMutation();
+
+  const handleResend = () => {
+    if (!email) {
+      toast.info("Informe seu e-mail para reenviar a confirmação.");
+      return;
+    }
+    resendMutation.mutate(email, {
+      onSuccess: () =>
+        toast.success("E-mail de confirmação reenviado. Verifique sua caixa de entrada."),
+      onError: (error) =>
+        toast.error(
+          error instanceof Error ? error.message : "Não foi possível reenviar o e-mail.",
+        ),
+    });
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-md text-center space-y-6">
+        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-blue-100">
+          <MailCheck className="h-8 w-8 text-blue-600" />
+        </div>
+
+        <h1 className="text-2xl font-semibold">Confirme seu e-mail</h1>
+
+        <p className="text-muted-foreground">
+          Enviamos um link de confirmação para o seu e-mail. Confirme seu e-mail
+          para continuar. Esta é a primeira etapa; depois sua conta será
+          analisada por um administrador.
+        </p>
+
+        <div className="space-y-2 text-left">
+          <Input
+            type="email"
+            placeholder="Reenviar para o e-mail..."
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Button
+            type="button"
+            className="w-full"
+            disabled={resendMutation.isPending}
+            onClick={handleResend}
+          >
+            {resendMutation.isPending ? "Reenviando..." : "Reenviar e-mail de confirmação"}
+          </Button>
+        </div>
+
+        <Link
+          href="/auth/login"
+          className="inline-block text-sm text-primary underline hover:no-underline"
+        >
+          Voltar para o login
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/admin/components/UsersTable.tsx
+++ b/apps/web/app/dashboard/admin/components/UsersTable.tsx
@@ -244,12 +244,19 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
                   >
                     <Eye />
                   </Button>
-                  {(user.status === "COMPLETED" || user.status === "BLOCKED") && (
+                  {(user.status === "PENDING" ||
+                    user.status === "COMPLETED" ||
+                    user.status === "BLOCKED") && (
                     <Button
                       size="icon"
                       variant="ghost"
+                      disabled={!user.emailVerified}
                       className="h-8 w-8 text-emerald-500 hover:text-emerald-600 hover:bg-emerald-50"
-                      title={`Verificar/Aprovar usuário ${user.name}`}
+                      title={
+                        user.emailVerified
+                          ? `Aprovar usuário ${user.name}`
+                          : `${user.name} ainda não confirmou o e-mail`
+                      }
                       onClick={() => onStatusChange(user.id, "VERIFIED")}
                     >
                       <Check />
@@ -427,12 +434,19 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
                         <Eye />
                       </Button>
 
-                      {(user.status === "COMPLETED" || user.status === "BLOCKED") && (
+                      {(user.status === "PENDING" ||
+                        user.status === "COMPLETED" ||
+                        user.status === "BLOCKED") && (
                         <Button
                           size="icon"
                           variant="ghost"
+                          disabled={!user.emailVerified}
                           className="h-8 w-8 text-emerald-500 hover:text-emerald-600 hover:bg-emerald-50"
-                          title={`Verificar/Aprovar usuário ${user.name}`}
+                          title={
+                            user.emailVerified
+                              ? `Aprovar usuário ${user.name}`
+                              : `${user.name} ainda não confirmou o e-mail`
+                          }
                           onClick={() => onStatusChange(user.id, "VERIFIED")}
                         >
                           <Check />

--- a/apps/web/components/questionnaire/VulnerabilityQuestionnaire.tsx
+++ b/apps/web/components/questionnaire/VulnerabilityQuestionnaire.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import Cookies from "js-cookie";
 import { Card, CardContent } from "../ui/card";
@@ -30,6 +31,7 @@ type AnswersState = Record<string, string>;
 
 export function VulnerabilityQuestionnaire({ mode, patientId }: Props) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [result, setResult] = useState<QuestionnaireSubmitResponse | null>(
     null,
   );
@@ -119,7 +121,11 @@ export function VulnerabilityQuestionnaire({ mode, patientId }: Props) {
 
   const handleContinue = () => {
     if (mode === "self") {
+      // Drop any stale user state so the dashboard re-fetches with the
+      // questionnaire already marked as completed, then navigate.
+      queryClient.invalidateQueries({ queryKey: ["user"] });
       router.push("/dashboard/patient");
+      router.refresh();
       return;
     }
     router.push(`/dashboard/manager/patients/${patientId}`);

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -32,7 +32,11 @@ api.interceptors.response.use(
     if (
       typeof window !== "undefined" &&
       payload?.code === "QUESTIONNAIRE_REQUIRED" &&
-      payload?.redirectTo
+      payload?.redirectTo &&
+      // Avoid bouncing the patient back to the questionnaire when they have
+      // just completed it: a residual request may still race the freshly
+      // persisted state. The completion cookie is the source of truth here.
+      Cookies.get(QUESTIONNAIRE_COMPLETED_KEY) !== "true"
     ) {
       Cookies.set(QUESTIONNAIRE_COMPLETED_KEY, "false", { expires: 1 });
       window.location.href = payload.redirectTo;


### PR DESCRIPTION
## Problema

O fluxo de aprovação do profissional estava quebrado: o campo `emailVerified` acumulava **dois significados** (confirmação de e-mail **e** aprovação do admin), e o login só checava esse campo, ignorando o `status`.

Consequências:
- A mensagem de pendência era genérica (não distinguia "confirme o e-mail" de "aguardando admin").
- O profissional **nunca** tinha `emailVerified` setado ao confirmar o e-mail.
- Mudar o status no painel admin **não liberava acesso**, porque o login não olhava o `status`.

## Solução

Separação dos dois conceitos usando campos já existentes no schema:
- `emailVerified = true` → profissional confirmou o e-mail (**etapa 1**)
- `status = VERIFIED` → admin aprovou (**etapa 2**)

### Backend (`apps/server`)
- **login**: valida as duas etapas com mensagens distintas (e-mail não confirmado vs. aguardando aprovação do admin). Paciente/admin não passam pelo gate de aprovação.
- **registerProfessional**: cria com `status: PENDING`.
- **verifyEmail**: seta `emailVerified: true` para todos os papéis.
- **+3 testes** cobrindo o fluxo de aprovação do profissional (5/5 passam).

### Frontend (`apps/web`)
- Nova tela **`/auth/verify-email-pending`** (etapa 1, com reenvio de e-mail).
- **`/auth/pending-approval`** atualizada para a etapa 2 (e-mail já confirmado).
- **login** redireciona para a tela certa conforme a etapa.
- **toast de cadastro** do profissional reflete as duas etapas.
- **painel admin**: botão Aprovar aparece em `PENDING` e fica desabilitado (com tooltip) enquanto o e-mail não foi confirmado.

## Notas
- Sem mudança de schema → nenhuma migration estrutural.
- ⚠️ Dados legados (apenas relevante fora de dev): profissionais aprovados pelo mecanismo antigo podem estar em `status: COMPLETED`. Em produção, exigiria `UPDATE ... SET status = 'VERIFIED'`. Como estamos em dev, não foi aplicado.

## Testes
- `tsc --noEmit` OK em server e web.
- `auth.service.spec.ts`: 5/5 passam.