### PR TITLE
refactor(ui): nova sidebar shadcn colapsável com nav role-aware

### DIFF
--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import { AppSidebar } from "../ui/dashboard/sidebar";
 import { MobileNav } from "../ui/dashboard/mobile-navbar";
 import { Spinner } from "@/components/ui/spinner";
-import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
+import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { LifeMedLogo } from "../ui/life-med-logo";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -46,10 +46,22 @@ const DashboardLayout = ({
   const defaultOpen = role !== "ADMIN";
 
   return (
-    <SidebarProvider defaultOpen={defaultOpen}>
+    <SidebarProvider
+      defaultOpen={defaultOpen}
+      style={
+        {
+          "--sidebar-width": "13rem",
+          "--sidebar-width-icon": "3rem",
+        } as React.CSSProperties
+      }
+    >
       <AppSidebar role={role} />
 
-      <SidebarInset className="flex flex-col flex-1 min-w-0 overflow-hidden relative">
+      <div className="flex flex-col flex-1 min-w-0 overflow-hidden relative bg-slate-50">
+        <header className="hidden md:flex h-14 shrink-0 items-center gap-2 px-4">
+          <SidebarTrigger />
+        </header>
+
         <header className="flex md:hidden h-14 shrink-0 items-center justify-between border-b border-gray-200 bg-white px-4">
           <Link href={`/dashboard/${role.toLowerCase()}`}>
             <LifeMedLogo height={24} width={65} />
@@ -61,12 +73,12 @@ const DashboardLayout = ({
           )}
         </header>
 
-        <main className="flex-1 overflow-y-auto p-4 md:p-8 pb-24 md:pb-8 bg-slate-50">
+        <main className="flex-1 overflow-y-auto pb-24 md:pb-0">
           {children}
         </main>
 
         <MobileNav role={role} />
-      </SidebarInset>
+      </div>
     </SidebarProvider>
   );
 };

--- a/apps/web/app/ui/dashboard/mobile-navbar/index.tsx
+++ b/apps/web/app/ui/dashboard/mobile-navbar/index.tsx
@@ -2,90 +2,15 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import {
-  Home,
-  Calendar,
-  Users,
-  FileText,
-  User,
-  Search,
-  CalendarDays,
-  CalendarPlus,
-  LogOut,
-} from "lucide-react";
+import { LogOut } from "lucide-react";
 import { authService } from "../../../../services/auth-service";
+import { getNavItems } from "../nav-items";
 
 export function MobileNav({ role }: { role: string }) {
   const pathname = usePathname();
   const router = useRouter();
 
-  const getNavItems = () => {
-    switch (role) {
-      case "ADMIN":
-        return [];
-      case "PROFESSIONAL":
-        return [
-          { name: "Início", href: "/dashboard/professional", icon: Home },
-          {
-            name: "Agenda",
-            href: "/dashboard/professional/schedule",
-            icon: Calendar,
-          },
-          {
-            name: "Pacientes",
-            href: "/dashboard/professional/patients",
-            icon: Users,
-          },
-          {
-            name: "Prontuários",
-            href: "/dashboard/professional/medical-records",
-            icon: FileText,
-          },
-          {
-            name: "Perfil",
-            href: "/dashboard/professional/profile",
-            icon: User,
-          },
-        ];
-      case "MANAGER":
-        return [
-          { name: "Início", href: "/dashboard/manager", icon: Home },
-          {
-            name: "Pacientes",
-            href: "/dashboard/manager/patients",
-            icon: Users,
-          },
-          {
-            name: "Consultas",
-            href: "/dashboard/manager/appointments",
-            icon: CalendarDays,
-          },
-          {
-            name: "Agendar",
-            href: "/dashboard/manager/appointments/new",
-            icon: CalendarPlus,
-          },
-        ];
-      default:
-        return [
-          { name: "Início", href: "/dashboard/patient", icon: Home },
-          { name: "Buscar", href: "/dashboard/patient/search", icon: Search },
-          {
-            name: "Consultas",
-            href: "/dashboard/patient/appointments",
-            icon: Calendar,
-          },
-          {
-            name: "Prontuários",
-            href: "/dashboard/patient/medical-records",
-            icon: FileText,
-          },
-          { name: "Perfil", href: "/dashboard/patient/profile", icon: User },
-        ];
-    }
-  };
-
-  const navItems = getNavItems();
+  const navItems = getNavItems(role);
 
   const handleLogout = () => {
     authService.logout();

--- a/apps/web/app/ui/dashboard/nav-items.ts
+++ b/apps/web/app/ui/dashboard/nav-items.ts
@@ -1,0 +1,108 @@
+import {
+  Calendar,
+  CalendarDays,
+  CalendarPlus,
+  ClipboardList,
+  FileText,
+  Home,
+  Search,
+  Stethoscope,
+  User,
+  UserPlus,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+
+export type NavItem = {
+  name: string;
+  href: string;
+  icon: LucideIcon;
+};
+
+export function getNavItems(role: string): NavItem[] {
+  switch (role) {
+    case "ADMIN":
+      return [
+        { name: "Início", href: "/dashboard/admin", icon: Home },
+        { name: "Usuários", href: "/dashboard/admin/users", icon: Users },
+        {
+          name: "Gestores",
+          href: "/dashboard/admin/register-manager",
+          icon: UserPlus,
+        },
+        {
+          name: "Especialidades",
+          href: "/dashboard/admin/specialidades",
+          icon: Stethoscope,
+        },
+        {
+          name: "Questionário",
+          href: "/dashboard/admin/questionnaire",
+          icon: ClipboardList,
+        },
+      ];
+    case "PROFESSIONAL":
+      return [
+        { name: "Início", href: "/dashboard/professional", icon: Home },
+        {
+          name: "Agenda",
+          href: "/dashboard/professional/schedule",
+          icon: Calendar,
+        },
+        {
+          name: "Pacientes",
+          href: "/dashboard/professional/patients",
+          icon: Users,
+        },
+        {
+          name: "Prontuários",
+          href: "/dashboard/professional/medical-records",
+          icon: FileText,
+        },
+        {
+          name: "Perfil",
+          href: "/dashboard/professional/profile",
+          icon: User,
+        },
+      ];
+    case "MANAGER":
+      return [
+        { name: "Início", href: "/dashboard/manager", icon: Home },
+        {
+          name: "Pacientes",
+          href: "/dashboard/manager/patients",
+          icon: Users,
+        },
+        {
+          name: "Agendamentos",
+          href: "/dashboard/manager/appointments",
+          icon: CalendarDays,
+        },
+        {
+          name: "Agendar",
+          href: "/dashboard/manager/appointments/new",
+          icon: CalendarPlus,
+        },
+      ];
+    default:
+      return [
+        { name: "Início", href: "/dashboard/patient", icon: Home },
+        {
+          name: "Buscar Médicos",
+          href: "/dashboard/patient/search",
+          icon: Search,
+        },
+        {
+          name: "Consultas",
+          href: "/dashboard/patient/appointments",
+          icon: Calendar,
+        },
+        {
+          name: "Prontuários",
+          href: "/dashboard/patient/medical-records",
+          icon: FileText,
+        },
+        { name: "Perfil", href: "/dashboard/patient/profile", icon: User },
+      ];
+  }
+}

--- a/apps/web/app/ui/dashboard/sidebar/index.tsx
+++ b/apps/web/app/ui/dashboard/sidebar/index.tsx
@@ -2,19 +2,10 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
+import { LogOut } from "lucide-react";
 import { LifeMedLogo } from "../../life-med-logo";
 import { authService } from "../../../../services/auth-service";
-import {
-  LogOut,
-  Home,
-  Calendar,
-  Users,
-  FileText,
-  User,
-  Search,
-  CalendarDays,
-  CalendarPlus,
-} from "lucide-react";
+import { getNavItems } from "../nav-items";
 import {
   Sidebar,
   SidebarContent,
@@ -33,77 +24,7 @@ export function AppSidebar({ role }: { role: string }) {
   const router = useRouter();
   const { setOpenMobile } = useSidebar();
 
-  const getNavItems = () => {
-    switch (role) {
-      case "ADMIN":
-        return [];
-      case "PROFESSIONAL":
-        return [
-          { name: "Início", href: "/dashboard/professional", icon: Home },
-          {
-            name: "Agenda",
-            href: "/dashboard/professional/schedule",
-            icon: Calendar,
-          },
-          {
-            name: "Pacientes",
-            href: "/dashboard/professional/patients",
-            icon: Users,
-          },
-          {
-            name: "Prontuários",
-            href: "/dashboard/professional/medical-records",
-            icon: FileText,
-          },
-          {
-            name: "Perfil",
-            href: "/dashboard/professional/profile",
-            icon: User,
-          },
-        ];
-      case "MANAGER":
-        return [
-          { name: "Início", href: "/dashboard/manager", icon: Home },
-          {
-            name: "Pacientes",
-            href: "/dashboard/manager/patients",
-            icon: Users,
-          },
-          {
-            name: "Agendamentos",
-            href: "/dashboard/manager/appointments",
-            icon: CalendarDays,
-          },
-          {
-            name: "Agendar",
-            href: "/dashboard/manager/appointments/new",
-            icon: CalendarPlus,
-          },
-        ];
-      default:
-        return [
-          { name: "Início", href: "/dashboard/patient", icon: Home },
-          {
-            name: "Buscar Médicos",
-            href: "/dashboard/patient/search",
-            icon: Search,
-          },
-          {
-            name: "Consultas",
-            href: "/dashboard/patient/appointments",
-            icon: Calendar,
-          },
-          {
-            name: "Prontuários",
-            href: "/dashboard/patient/medical-records",
-            icon: FileText,
-          },
-          { name: "Perfil", href: "/dashboard/patient/profile", icon: User },
-        ];
-    }
-  };
-
-  const navItems = getNavItems();
+  const navItems = getNavItems(role);
 
   const handleLogout = () => {
     authService.logout();
@@ -111,47 +32,40 @@ export function AppSidebar({ role }: { role: string }) {
   };
 
   return (
-    <Sidebar collapsible="icon">
-      <SidebarHeader className="h-16 flex items-center justify-center border-b border-sidebar-border group-data-[collapsible=icon]:p-0">
+    <Sidebar
+      collapsible="icon"
+      className="group-data-[side=left]:border-r-0"
+    >
+      <SidebarHeader className="h-14 flex items-center justify-center">
         <Link
           href={`/dashboard/${role.toLowerCase()}`}
-          className="flex items-center justify-center overflow-hidden transition-all group-data-[collapsible=icon]:w-full"
+          className="flex items-center justify-center"
         >
-          <LifeMedLogo height={28} width={75} />
+          <LifeMedLogo height={24} width={64} />
         </Link>
       </SidebarHeader>
 
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupContent>
-            <SidebarMenu className="gap-2 px-2 mt-4 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:items-center">
+            <SidebarMenu>
               {navItems.map((item) => {
                 const isActive = pathname === item.href;
                 return (
-                  <SidebarMenuItem
-                    key={item.href}
-                    className="w-full flex justify-center"
-                  >
-                    <Link
-                      href={item.href}
-                      onClick={() => setOpenMobile(false)}
-                      className="block w-full"
+                  <SidebarMenuItem key={item.href}>
+                    <SidebarMenuButton
+                      render={
+                        <Link
+                          href={item.href}
+                          onClick={() => setOpenMobile(false)}
+                        />
+                      }
+                      isActive={isActive}
+                      tooltip={item.name}
                     >
-                      <SidebarMenuButton
-                        isActive={isActive}
-                        tooltip={item.name}
-                        className={`w-full flex items-center gap-3 h-11 px-3 transition-colors group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:justify-center ${
-                          isActive
-                            ? "!bg-sky-200 !text-sky-950 !font-semibold hover:!bg-sky-300"
-                            : "text-slate-600 hover:bg-slate-200 hover:text-slate-900"
-                        }`}
-                      >
-                        <item.icon className="h-5 w-5 shrink-0" />
-                        <span className="truncate text-base group-data-[collapsible=icon]:hidden">
-                          {item.name}
-                        </span>
-                      </SidebarMenuButton>
-                    </Link>
+                      <item.icon />
+                      <span>{item.name}</span>
+                    </SidebarMenuButton>
                   </SidebarMenuItem>
                 );
               })}
@@ -160,18 +74,16 @@ export function AppSidebar({ role }: { role: string }) {
         </SidebarGroup>
       </SidebarContent>
 
-      <SidebarFooter className="border-t border-sidebar-border p-4 group-data-[collapsible=icon]:p-2 group-data-[collapsible=icon]:items-center">
-        <SidebarMenu className="w-full">
-          <SidebarMenuItem className="w-full flex justify-center">
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
             <SidebarMenuButton
               onClick={handleLogout}
-              className="flex items-center gap-3 h-11 px-3 text-red-600 hover:text-red-800 hover:bg-red-100 w-full transition-colors group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:justify-center"
               tooltip="Sair"
+              className="text-destructive hover:text-destructive"
             >
-              <LogOut className="h-5 w-5 shrink-0" />
-              <span className="text-base font-medium group-data-[collapsible=icon]:hidden">
-                Sair
-              </span>
+              <LogOut />
+              <span>Sair</span>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>


### PR DESCRIPTION
Closes #164

## Summary
- Reescreve `AppSidebar` em padrão shadcn puro (sem `!important`), usando tokens `sidebar-*` e `SidebarMenuButton` com `render` prop (compat base-ui).
- `collapsible="icon"` com `SidebarTrigger` visível no header desktop; largura customizada (`--sidebar-width: 13rem`).
- Remove `SidebarInset` e borda lateral; conteúdo full-bleed sem padding fixo no `<main>`.
- Extrai `getNavItems(role)` para `app/ui/dashboard/nav-items.ts` — fonte única consumida por `AppSidebar` e `MobileNav`.
- ADMIN ganha itens reais: Início, Usuários, Gestores, Especialidades, Questionário.

## Test plan
- [ ] Colapsar/expandir via trigger no header desktop
- [ ] Colapsar via atalho `Cmd/Ctrl+B`
- [ ] Cookie `sidebar_state` persiste entre reloads
- [ ] Tooltips aparecem no estado colapsado
- [ ] Itens corretos por role (ADMIN, PROFESSIONAL, MANAGER, PATIENT)
- [ ] Mobile-navbar inferior mostra os mesmos itens
- [ ] Logout funciona no footer (desktop) e header (mobile)