### PR TITLE
refactor(ui): padronizar layout e tipografia das páginas do dashboard

### DIFF
--- a/apps/web/app/dashboard/admin/page.tsx
+++ b/apps/web/app/dashboard/admin/page.tsx
@@ -6,6 +6,7 @@ import { adminService } from "../../../services/admin-service";
 import { toast } from "sonner";
 import { UsersTable } from "./components/UsersTable";
 import { useQueryClient } from "@tanstack/react-query";
+import { PageShell } from "../../ui/dashboard/page-shell";
 
 const AdminDashboard = () => {
   const queryClient = useQueryClient();
@@ -53,9 +54,9 @@ const AdminDashboard = () => {
   );
 
   return (
-    <section className="px-4 py-4 sm:px-6 sm:py-6">
+    <PageShell>
       <UsersTable onStatusChange={handleStatusChange} actions={actions} />
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/admin/questionnaire/page.tsx
+++ b/apps/web/app/dashboard/admin/questionnaire/page.tsx
@@ -3,10 +3,11 @@
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { QuestionnaireManager } from "@/components/questionnaire/QuestionnaireManager";
+import { PageShell } from "../../../ui/dashboard/page-shell";
 
 export default function AdminQuestionnairePage() {
   return (
-    <div className="px-4 py-4 sm:px-6 sm:py-6">
+    <PageShell>
       <Link
         href="/dashboard/admin"
         className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
@@ -15,6 +16,6 @@ export default function AdminQuestionnairePage() {
         Painel Administrativo
       </Link>
       <QuestionnaireManager />
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/app/dashboard/admin/register-manager/page.tsx
+++ b/apps/web/app/dashboard/admin/register-manager/page.tsx
@@ -4,6 +4,7 @@ import { Controller, useForm } from "react-hook-form";
 import { PhoneInputBR } from "@/components/ui/phone-input-br";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -13,6 +14,7 @@ import { PasswordField } from "@/app/auth/register/components/PasswordField";
 import { applyCpfMask } from "@/lib/cpf";
 import { useRegisterManagerMutation } from "@/queries/useRegisterManagerMutation";
 import { registerManagerSchema, type RegisterManagerSchema } from "@/app/auth/register-manager/register-manager.validation";
+import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 
 export default function RegisterManagerPage() {
   const router = useRouter();
@@ -64,26 +66,21 @@ export default function RegisterManagerPage() {
   };
 
   return (
-    <section className="px-4 py-4 sm:px-6 sm:py-6">
-      <div className="mx-auto max-w-3xl space-y-6">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => router.push("/dashboard/admin")}
-          title="Voltar para a tela do administrador"
-        >
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          Voltar
-        </Button>
+    <PageShell>
+      <Link
+        href="/dashboard/admin"
+        className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Painel Administrativo
+      </Link>
 
-        <div>
-          <h1 className="text-2xl font-semibold text-foreground">Cadastrar gestor</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Crie uma conta de gestor vinculada à administração do sistema.
-          </p>
-        </div>
+      <PageHeader
+        title="Cadastrar gestor"
+        description="Crie uma conta de gestor vinculada à administração do sistema."
+      />
 
-        <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
+      <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div className="space-y-1.5">
@@ -151,8 +148,7 @@ export default function RegisterManagerPage() {
               </Button>
             </div>
           </form>
-        </div>
       </div>
-    </section>
+    </PageShell>
   );
 }

--- a/apps/web/app/dashboard/admin/specialidades/page.tsx
+++ b/apps/web/app/dashboard/admin/specialidades/page.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft } from "lucide-react";
 import { SpecialitiesTable } from "../components/SpecialityTable";
 import { useSpecialitiesQuery } from "@/queries/useSpecialitiesQuery";
 import { LoadingPage } from "@/components/shared/LoadingPage";
+import { PageShell } from "../../../ui/dashboard/page-shell";
 
 export default function SpecialidadesPage() {
   const { data: specialities = [], isLoading } = useSpecialitiesQuery();
@@ -12,7 +13,7 @@ export default function SpecialidadesPage() {
   if (isLoading) return <LoadingPage />;
 
   return (
-    <div className="px-4 py-4 sm:px-6 sm:py-6">
+    <PageShell>
       <Link
         href="/dashboard/admin"
         className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
@@ -22,6 +23,6 @@ export default function SpecialidadesPage() {
       </Link>
 
       <SpecialitiesTable specialities={specialities} />
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/app/dashboard/admin/users/[id]/page.tsx
+++ b/apps/web/app/dashboard/admin/users/[id]/page.tsx
@@ -10,6 +10,7 @@ import { PatientProfileForm } from "./components/PatientProfileForm";
 import { ProfessionalProfileForm } from "./components/ProfessionalProfileForm";
 import { useAdminUserForm } from "./useAdminUserForm";
 import { ArrowLeft } from "lucide-react";
+import { PageShell, PageHeader } from "../../../../ui/dashboard/page-shell";
 
 const AdminUserProfilePage = () => {
   const {
@@ -29,14 +30,14 @@ const AdminUserProfilePage = () => {
   } = useAdminUserForm();
 
   if (isLoading) return (
-    <div className="py-24 px-8 flex justify-center items-center">
+    <PageShell className="flex items-center justify-center min-h-[60vh]">
       <Spinner size="lg" />
-    </div>
+    </PageShell>
   );
 
   if (!user) {
     return (
-      <section className="w-full min-h-screen mx-auto px-16 py-8 bg-[#f8fafc]">
+      <PageShell>
         <Button
           onClick={() => router.push("/dashboard/admin")}
           variant="outline"
@@ -46,11 +47,11 @@ const AdminUserProfilePage = () => {
           <ArrowLeft className="mr-2 h-4 w-4" />
           Voltar
         </Button>
-        <div className="mb-8">
-          <h1 className="text-4xl font-bold text-gray-900 tracking-tight">Perfil do Usuário</h1>
-          <p className="mt-1 text-base text-gray-500">{error ?? "Usuário não encontrado."}</p>
-        </div>
-      </section>
+        <PageHeader
+          title="Perfil do Usuário"
+          description={error ?? "Usuário não encontrado."}
+        />
+      </PageShell>
     );
   }
 
@@ -62,7 +63,7 @@ const AdminUserProfilePage = () => {
     : null;
 
   return (
-    <section className="w-full min-h-screen mx-auto px-16 py-8 bg-[#f8fafc]">
+    <PageShell>
       <Button
         onClick={() => router.push("/dashboard/admin")}
         variant="outline"
@@ -73,10 +74,10 @@ const AdminUserProfilePage = () => {
         Voltar
       </Button>
 
-      <div className="mb-8">
-        <h1 className="text-4xl font-bold text-gray-900 tracking-tight">Perfil do Usuário</h1>
-        <p className="mt-1 text-base text-gray-500">Visualização e edição de dados cadastrais.</p>
-      </div>
+      <PageHeader
+        title="Perfil do Usuário"
+        description="Visualização e edição de dados cadastrais."
+      />
 
       <Card className="border border-gray-200 rounded-xl bg-white">
         <CardContent className="p-12 space-y-8">
@@ -148,7 +149,7 @@ const AdminUserProfilePage = () => {
           <AddressForm userId={user?.id || ""} />
         </CardContent>
       </Card>
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/manager/appointments/new/page.tsx
+++ b/apps/web/app/dashboard/manager/appointments/new/page.tsx
@@ -5,6 +5,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { managerService } from "../../../../../services/manager-service";
 import { toast } from "sonner";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { PageShell, PageHeader } from "../../../../ui/dashboard/page-shell";
 import { SearchBar } from "../../../patient/search/components/SearchBar";
 import { DoctorCard } from "../../../patient/search/components/DoctorCard";
 import { EmptySearch } from "../../../patient/search/components/EmptySearch";
@@ -96,16 +97,8 @@ const NewApointmentPage = () => {
     });
 
   return (
-    <section
-      className={`w-full min-h-screen mx-auto bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
-    >
-      <div className="mb-8">
-        <h1
-          className={`my-10 font-bold text-gray-900 tracking-tight ${isMobile ? "text-2xl" : "text-4xl"}`}
-        >
-          Agendamento de consulta
-        </h1>
-      </div>
+    <PageShell>
+      <PageHeader title="Agendamento de consulta" />
 
       <SearchBar
         search={search}
@@ -160,7 +153,7 @@ const NewApointmentPage = () => {
         patients={patients}
         professional={bookingProfessional as unknown as Professional}
       />
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/manager/appointments/page.tsx
+++ b/apps/web/app/dashboard/manager/appointments/page.tsx
@@ -6,7 +6,8 @@ import { useCancelAppointmentManagerMutation } from '@/queries/useCancelAppointm
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { LoadingPage } from '@/components/shared/LoadingPage';
 import { EmptyState } from '@/components/shared/EmptyState';
-import { PageHeader } from '@/components/shared/PageHeader';
+import { PageHeader as SharedPageHeader } from '@/components/shared/PageHeader';
+import { PageShell } from '../../../ui/dashboard/page-shell';
 import { StatusBadge } from '@/components/shared/StatusBadge';
 import { CancelConfirmDialog } from '@/app/dashboard/patient/appointments/components/CancelConfirmDialog';
 import { Calendar, Clock, X, CheckCircle, AlertCircle, XCircle, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
@@ -106,20 +107,18 @@ export default function AppointmentsPage() {
 
   if (error) {
     return (
-      <div className={`${isMobile ? 'p-4' : 'py-12 px-8'}`}>
-        <div className="max-w-6xl mx-auto">
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-800">
-            Erro ao carregar consultas
-          </div>
+      <PageShell>
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-800">
+          Erro ao carregar consultas
         </div>
-      </div>
+      </PageShell>
     );
   }
 
   return (
-    <div className={`${isMobile ? 'p-4 pb-20' : 'py-8 px-4'} bg-gradient-to-br from-slate-50 via-white to-slate-50 min-h-screen`}>
+    <PageShell>
       <div className="max-w-7xl mx-auto">
-        <PageHeader
+        <SharedPageHeader
           title="Agendamentos"
           action={{
             label: "+ Nova Consulta",
@@ -391,6 +390,6 @@ export default function AppointmentsPage() {
         onConfirm={handleCancelConfirm}
         isLoading={cancelMutation.isPending}
       />
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/app/dashboard/manager/page.tsx
+++ b/apps/web/app/dashboard/manager/page.tsx
@@ -9,6 +9,7 @@ import { useListAppointmentsQuery } from "@/queries/useListAppointmentsQuery";
 import { LoadingPage } from "@/components/shared/LoadingPage";
 import { Users, Calendar, FileText, Plus, ClipboardList } from "lucide-react";
 import Link from "next/link";
+import { PageShell, PageHeader } from "../../ui/dashboard/page-shell";
 
 const ManagerDashboard = () => {
   const { data: user, isLoading: loadingUser } = useUserQuery();
@@ -79,15 +80,11 @@ const ManagerDashboard = () => {
   const userName = user?.name?.split(" ")[0] || "";
 
   return (
-    <section className="min-h-screen w-full bg-slate-50 p-8">
-      <div className="mb-10">
-        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-          Bem-vindo, {userName}!
-        </h1>
-        <p className="mt-2 text-slate-600">
-          Você está no painel do gestor. Gerencie pacientes e consultas.
-        </p>
-      </div>
+    <PageShell>
+      <PageHeader
+        title={`Bem-vindo, ${userName}!`}
+        description="Você está no painel do gestor. Gerencie pacientes e consultas."
+      />
 
       <div className="mb-10 grid grid-cols-1 gap-6 md:grid-cols-3">
         {stats.map((stat) => (
@@ -160,7 +157,7 @@ const ManagerDashboard = () => {
           </ul>
         </CardContent>
       </Card>
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/manager/patients/[id]/page.tsx
+++ b/apps/web/app/dashboard/manager/patients/[id]/page.tsx
@@ -19,6 +19,7 @@ import { AddressForm } from "@/components/address/AddressForm";
 import { PhoneInputBR } from "@/components/ui/phone-input-br";
 import { useQueryClient } from "@tanstack/react-query";
 import { applyCpfMask } from "@/lib/cpf";
+import { PageShell, PageHeader } from "../../../../ui/dashboard/page-shell";
 
 export default function PatientDetailsPage() {
   const router = useRouter();
@@ -102,17 +103,15 @@ export default function PatientDetailsPage() {
 
   if (isLoading) {
     return (
-      <section className="min-h-screen w-full bg-slate-50 p-8">
-        <div className="flex items-center justify-center">
-          <p className="text-slate-600">Carregando detalhes do paciente...</p>
-        </div>
-      </section>
+      <PageShell className="flex items-center justify-center min-h-[60vh]">
+        <p className="text-slate-600">Carregando detalhes do paciente...</p>
+      </PageShell>
     );
   }
 
   if (error || !patient) {
     return (
-      <section className="min-h-screen w-full bg-slate-50 p-8">
+      <PageShell>
         <div className="max-w-4xl mx-auto">
           <Button
             onClick={() => router.push("/dashboard/manager/patients")}
@@ -136,12 +135,12 @@ export default function PatientDetailsPage() {
             </CardContent>
           </Card>
         </div>
-      </section>
+      </PageShell>
     );
   }
 
   return (
-    <section className="min-h-screen w-full bg-slate-50 p-8">
+    <PageShell>
       <div className="max-w-4xl mx-auto">
         <Button
           onClick={() => router.push("/dashboard/manager/patients")}
@@ -457,6 +456,6 @@ export default function PatientDetailsPage() {
             </CardContent>
           </Card>
         </div>
-      </section>
+      </PageShell>
     );
 }

--- a/apps/web/app/dashboard/manager/patients/new/page.tsx
+++ b/apps/web/app/dashboard/manager/patients/new/page.tsx
@@ -12,6 +12,7 @@ import { useAddressCep } from '@/hooks/useAddressCep';
 import { AddressFields } from '@/components/address';
 import { newPatientSchema, type NewPatientSchema } from './new-patient.validation';
 import { PhoneInputBR } from '@/components/ui/phone-input-br';
+import { PageShell } from '../../../../ui/dashboard/page-shell';
 
 export default function NewPatientPage() {
   const router = useRouter();
@@ -68,7 +69,7 @@ export default function NewPatientPage() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 py-8 px-4">
+    <PageShell>
       <div className="max-w-2xl mx-auto">
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
           <h1 className="text-3xl font-bold text-gray-900 mb-6">
@@ -207,6 +208,6 @@ export default function NewPatientPage() {
         </form>
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/app/dashboard/manager/patients/page.tsx
+++ b/apps/web/app/dashboard/manager/patients/page.tsx
@@ -8,7 +8,8 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import Link from 'next/link';
 import { LoadingPage } from '@/components/shared/LoadingPage';
 import { EmptyState } from '@/components/shared/EmptyState';
-import { PageHeader } from '@/components/shared/PageHeader';
+import { PageHeader as SharedPageHeader } from '@/components/shared/PageHeader';
+import { PageShell } from '../../../ui/dashboard/page-shell';
 import { formatPhoneNumber } from '@/app/utils/formatPhone';
 import { Search, Users, UserCheck, ClipboardCheck, ClipboardList, ArrowUpDown, ArrowUp, ArrowDown, X } from 'lucide-react';
 
@@ -153,20 +154,18 @@ export default function PatientsPage() {
 
   if (error) {
     return (
-      <div className={`${isMobile ? 'p-4' : 'py-12 px-8'}`}>
-        <div className="max-w-6xl mx-auto">
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-800">
-            Erro ao carregar pacientes
-          </div>
+      <PageShell>
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-800">
+          Erro ao carregar pacientes
         </div>
-      </div>
+      </PageShell>
     );
   }
 
   return (
-    <div className={`${isMobile ? 'p-4 pb-20' : 'py-8 px-4'} bg-gradient-to-br from-slate-50 via-white to-slate-50 min-h-screen`}>
+    <PageShell>
       <div className="max-w-7xl mx-auto">
-        <PageHeader
+        <SharedPageHeader
           title="Pacientes"
           action={{
             label: "+ Novo Paciente",
@@ -423,6 +422,6 @@ export default function PatientsPage() {
           </div>
         )}
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/app/dashboard/manager/professionals/[id]/schedule/page.tsx
+++ b/apps/web/app/dashboard/manager/professionals/[id]/schedule/page.tsx
@@ -11,6 +11,7 @@ import Link from 'next/link';
 import { useDailyScheduleQuery } from '@/queries/useDailyScheduleQuery';
 import { ScheduleTimeline } from '@/app/dashboard/professional/schedule/components/ScheduleTimeline';
 import { LoadingPage } from '@/components/shared/LoadingPage';
+import { PageShell, PageHeader } from '../../../../../ui/dashboard/page-shell';
 
 type Appointment = {
   id: string;
@@ -109,20 +110,14 @@ export default function ProfessionalSchedulePage() {
   }
 
   return (
-    <section className="w-full min-h-screen mx-auto px-4 sm:px-8 lg:px-16 py-6 sm:py-8 bg-[#f8fafc]">
-      <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center">
-        <div>
-          <Link href="/dashboard/manager/appointments" className="text-blue-600 hover:underline text-sm mb-2 block">
-            ← Voltar para consultas
-          </Link>
-          <h1 className="text-2xl sm:text-4xl font-bold text-gray-900 tracking-tight">
-            Agenda do Profissional
-          </h1>
-          <p className="mt-1 text-sm sm:text-base text-gray-500">
-            Visualize os horários e consultas agendadas.
-          </p>
-        </div>
-      </div>
+    <PageShell>
+      <Link href="/dashboard/manager/appointments" className="text-blue-600 hover:underline text-sm mb-2 block">
+        ← Voltar para consultas
+      </Link>
+      <PageHeader
+        title="Agenda do Profissional"
+        description="Visualize os horários e consultas agendadas."
+      />
 
       <div className="grid grid-cols-1 lg:grid-cols-[360px_1fr] lg:items-start gap-6">
         <aside className="flex flex-col gap-6">
@@ -161,6 +156,6 @@ export default function ProfessionalSchedulePage() {
           </div>
         </main>
       </div>
-    </section>
+    </PageShell>
   );
 }

--- a/apps/web/app/dashboard/manager/questionnaire/page.tsx
+++ b/apps/web/app/dashboard/manager/questionnaire/page.tsx
@@ -3,10 +3,11 @@
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { QuestionnaireManager } from "@/components/questionnaire/QuestionnaireManager";
+import { PageShell } from "../../../ui/dashboard/page-shell";
 
 export default function ManagerQuestionnairePage() {
   return (
-    <div className="px-4 py-4 sm:px-6 sm:py-6">
+    <PageShell>
       <Link
         href="/dashboard/manager"
         className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
@@ -15,6 +16,6 @@ export default function ManagerQuestionnairePage() {
         Painel do Gestor
       </Link>
       <QuestionnaireManager />
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/app/dashboard/patient/appointments/page.tsx
+++ b/apps/web/app/dashboard/patient/appointments/page.tsx
@@ -18,6 +18,7 @@ import {
   appointmentsService,
   AppointmentResponse,
 } from "@/services/appointments-service";
+import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 
 function mapApiToAppointment(appt: AppointmentResponse): Appointment {
   return {
@@ -176,34 +177,22 @@ const AppointmentsPage = () => {
         : "Fazer download do histórico de consultas canceladas";
 
   return (
-    <section
-      className={`w-full min-h-screen mx-auto bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
-    >
-      <div
-        className={`mb-8 flex justify-between items-start flex-wrap gap-4 ${isMobile ? "flex-col" : ""}`}
-      >
-        <div>
-          <h1
-            className={`font-bold text-gray-900 tracking-tight ${isMobile ? "text-2xl" : "text-4xl"}`}
+    <PageShell>
+      <PageHeader
+        title="Minhas Consultas"
+        description="Acompanhe e gerencie suas consultas agendadas."
+        actions={
+          <Button
+            size={isMobile ? "default" : "lg"}
+            onClick={() => router.push("/dashboard/patient/search")}
+            title="Buscar médicos e agendar uma nova consulta"
+            className={isMobile ? "w-full" : ""}
           >
-            Minhas Consultas
-          </h1>
-          <p
-            className={`mt-1 text-gray-500 ${isMobile ? "text-sm" : "text-base"}`}
-          >
-            Acompanhe e gerencie suas consultas agendadas.
-          </p>
-        </div>
-        <Button
-          size={isMobile ? "default" : "lg"}
-          onClick={() => router.push("/dashboard/patient/search")}
-          title="Buscar médicos e agendar uma nova consulta"
-          className={isMobile ? "w-full" : ""}
-        >
-          <SearchIcon />
-          Nova Consulta
-        </Button>
-      </div>
+            <SearchIcon />
+            Nova Consulta
+          </Button>
+        }
+      />
 
       <AppointmentTabs
         activeTab={activeTab}
@@ -272,7 +261,7 @@ const AppointmentsPage = () => {
         open={isDetailsModalOpen}
         onOpenChange={setIsDetailsModalOpen}
       />
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/patient/medical-records/[id]/page.tsx
+++ b/apps/web/app/dashboard/patient/medical-records/[id]/page.tsx
@@ -10,6 +10,7 @@ import { useIsMobile } from "@/hooks/useIsMobile";
 import { useMedicalRecordByIdQuery } from "@/queries/useMedicalRecords";
 import { medicalRecordsService } from "@/services/medical-records-service";
 import { CalendarIcon } from "../../../../utils/icons";
+import { PageShell } from "../../../../ui/dashboard/page-shell";
 
 const FIELDS = [
   { key: "chiefComplaint", label: "Queixa principal" },
@@ -39,17 +40,15 @@ const PatientMedicalRecordDetailsPage = () => {
 
   if (isLoading) {
     return (
-      <section className="w-full min-h-screen flex justify-center items-center bg-[#f8fafc]">
+      <PageShell className="flex items-center justify-center min-h-[60vh]">
         <Spinner size="lg" />
-      </section>
+      </PageShell>
     );
   }
 
   if (!record) {
     return (
-      <section
-        className={`w-full min-h-screen bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
-      >
+      <PageShell>
         <p className="text-base text-slate-700">Prontuário não encontrado.</p>
         <Button
           variant="outline"
@@ -58,7 +57,7 @@ const PatientMedicalRecordDetailsPage = () => {
         >
           Voltar para a lista
         </Button>
-      </section>
+      </PageShell>
     );
   }
 
@@ -76,9 +75,7 @@ const PatientMedicalRecordDetailsPage = () => {
   };
 
   return (
-    <section
-      className={`w-full min-h-screen bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
-    >
+    <PageShell>
       <div className="mb-6 flex items-center gap-3 flex-wrap">
         <Button
           variant="outline"
@@ -151,7 +148,7 @@ const PatientMedicalRecordDetailsPage = () => {
           </p>
         </CardContent>
       </Card>
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/patient/medical-records/page.tsx
+++ b/apps/web/app/dashboard/patient/medical-records/page.tsx
@@ -7,9 +7,9 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import { Badge } from "@/components/ui/badge";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import { useMedicalRecordsListForPatientQuery } from "@/queries/useMedicalRecords";
 import { CalendarIcon, EyeIcon, SearchIcon } from "../../../utils/icons";
+import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 
 const PAGE_SIZE = 10;
 
@@ -30,7 +30,6 @@ function truncate(text: string | null, max = 120) {
 
 const PatientMedicalRecordsPage = () => {
   const router = useRouter();
-  const isMobile = useIsMobile();
   const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
@@ -60,22 +59,11 @@ const PatientMedicalRecordsPage = () => {
   const hasFilters = Boolean(search);
 
   return (
-    <section
-      className={`w-full min-h-screen mx-auto bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
-    >
-      <div className="mb-8">
-        <h1
-          className={`font-bold text-gray-900 tracking-tight ${isMobile ? "text-2xl" : "text-4xl"}`}
-        >
-          Meus Prontuários
-        </h1>
-        <p
-          className={`mt-1 text-gray-500 ${isMobile ? "text-sm" : "text-base"}`}
-        >
-          Histórico dos prontuários das suas consultas.
-          {total > 0 && ` ${total} no total.`}
-        </p>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Meus Prontuários"
+        description={`Histórico dos prontuários das suas consultas.${total > 0 ? ` ${total} no total.` : ""}`}
+      />
 
       <Card className="mb-6 border border-gray-200 rounded-xl bg-white">
         <CardContent className="p-4 sm:p-5">
@@ -222,7 +210,7 @@ const PatientMedicalRecordsPage = () => {
           </div>
         </div>
       )}
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/patient/page.tsx
+++ b/apps/web/app/dashboard/patient/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { useRouter } from "next/navigation";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { PageShell, PageHeader } from "../../ui/dashboard/page-shell";
 import { usersService } from "@/services/users-service";
 import { professionalsService } from "@/services/professionals-service";
 import {
@@ -107,38 +108,28 @@ const PatientDashboard = () => {
 
   if (isLoading) {
     return (
-      <section className="min-h-screen w-full bg-slate-50 flex items-center justify-center">
+      <PageShell className="flex items-center justify-center min-h-[60vh]">
         <Spinner size="lg" />
-      </section>
+      </PageShell>
     );
   }
 
   return (
-    <section
-      className={`min-h-screen w-full bg-slate-50 ${isMobile ? "p-4" : "p-8"}`}
-    >
-      <div
-        className={`mb-6 flex items-end justify-between ${isMobile ? "flex-col items-start gap-3" : ""}`}
-      >
-        <div>
-          <h1
-            className={`font-bold tracking-tight text-gray-900 ${isMobile ? "text-xl" : "text-2xl"}`}
+    <PageShell>
+      <PageHeader
+        title={userName ? `Olá, ${userName}!` : "Painel do Paciente"}
+        description="Acompanhe suas consultas e encontre profissionais de saúde."
+        actions={
+          <Button
+            onClick={goToSearch}
+            title="Buscar e agendar com novos profissionais de saúde"
+            className={`gap-2 ${isMobile ? "w-full" : ""}`}
           >
-            {userName ? `Olá, ${userName}!` : "Painel do Paciente"}
-          </h1>
-          <p className="mt-0.5 text-sm text-gray-500">
-            Acompanhe suas consultas e encontre profissionais de saúde.
-          </p>
-        </div>
-        <Button
-          onClick={goToSearch}
-          title="Buscar e agendar com novos profissionais de saúde"
-          className={`gap-2 ${isMobile ? "w-full" : ""}`}
-        >
-          <SearchIcon size={16} />
-          Buscar Médicos
-        </Button>
-      </div>
+            <SearchIcon size={16} />
+            Buscar Médicos
+          </Button>
+        }
+      />
 
       <div
         className={`mb-6 grid gap-4 ${isMobile ? "grid-cols-1" : "grid-cols-1 lg:grid-cols-[1fr_340px]"}`}
@@ -174,7 +165,7 @@ const PatientDashboard = () => {
           />
         </div>
       </div>
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/patient/profile/page.tsx
+++ b/apps/web/app/dashboard/patient/profile/page.tsx
@@ -7,6 +7,7 @@ import { Separator } from "@/components/ui/separator";
 import { AddressForm } from "@/components/address/AddressForm";
 import { usePatientProfileForm } from "./usePatientProfileForm";
 import { PatientInfoForm } from "./components/PatientInfoForm";
+import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 
 const PatientProfilePage = () => {
   const {
@@ -22,31 +23,27 @@ const PatientProfilePage = () => {
 
   if (isLoading) {
     return (
-      <div className="py-24 px-8 flex justify-center items-center">
+      <PageShell className="flex items-center justify-center min-h-[60vh]">
         <Spinner size="lg" />
-      </div>
+      </PageShell>
     );
   }
 
   return (
-    <section className="w-full min-h-screen mx-auto px-16 py-8 bg-[#f8fafc]">
-      <div className="mb-8 flex justify-between items-start flex-wrap gap-4">
-        <div>
-          <h1 className="text-4xl font-bold text-gray-900 tracking-tight">
-            Meu Perfil
-          </h1>
-          <p className="mt-1 text-base text-gray-500">
-            Gerencie suas informações pessoais.
-          </p>
-        </div>
-        <Button
-          size="lg"
-          onClick={() => (isEditing ? handleCancel() : setIsEditing(true))}
-          title={isEditing ? "Cancelar edição" : "Habilitar edição do perfil"}
-        >
-          {isEditing ? "Cancelar" : "Editar Perfil"}
-        </Button>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Meu Perfil"
+        description="Gerencie suas informações pessoais."
+        actions={
+          <Button
+            size="lg"
+            onClick={() => (isEditing ? handleCancel() : setIsEditing(true))}
+            title={isEditing ? "Cancelar edição" : "Habilitar edição do perfil"}
+          >
+            {isEditing ? "Cancelar" : "Editar Perfil"}
+          </Button>
+        }
+      />
 
       <Card className="border border-gray-200 rounded-xl bg-white">
         <CardContent className="p-12 space-y-8">
@@ -109,7 +106,7 @@ const PatientProfilePage = () => {
           <AddressForm userId={user?.id || ""} />
         </CardContent>
       </Card>
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/patient/search/page.tsx
+++ b/apps/web/app/dashboard/patient/search/page.tsx
@@ -15,6 +15,7 @@ import {
 import { BookingModal } from "./components/BookingModal";
 import { AddressData } from "./components/addressMaps";
 import { getAvailableLocations, getLocationValue } from "./components/locationFilters";
+import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 
 type Professional = {
   id: string;
@@ -96,24 +97,11 @@ const SearchDoctorsPage = () => {
     });
 
   return (
-    <section
-      className={`w-full min-h-screen mx-auto bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
-    >
-      <div className="mb-8 flex justify-between items-start flex-wrap gap-4">
-        <div>
-          <h1
-            className={`font-bold text-gray-900 tracking-tight ${isMobile ? "text-2xl" : "text-4xl"}`}
-          >
-            Buscar Médicos
-          </h1>
-          <p
-            className={`mt-1 text-gray-500 ${isMobile ? "text-sm" : "text-base"}`}
-          >
-            Encontre profissionais de saúde voluntários e agende sua consulta
-            gratuitamente.
-          </p>
-        </div>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Buscar Médicos"
+        description="Encontre profissionais de saúde voluntários e agende sua consulta gratuitamente."
+      />
 
       <div title="Pesquisar e filtrar médicos por nome, especialidade ou localização">
         <SearchBar
@@ -173,7 +161,7 @@ const SearchDoctorsPage = () => {
         }}
         professional={bookingProfessional as unknown as Professional}
       />
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/professional/medical-records/[id]/page.tsx
+++ b/apps/web/app/dashboard/professional/medical-records/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
   MedicalRecordResponse,
 } from "@/services/medical-records-service";
 import { CalendarIcon } from "../../../../utils/icons";
+import { PageShell } from "../../../../ui/dashboard/page-shell";
 
 type ClinicalKey =
   | "chiefComplaint"
@@ -135,17 +136,15 @@ const MedicalRecordDetailsPage = () => {
 
   if (isLoading) {
     return (
-      <section className="w-full min-h-screen flex justify-center items-center bg-[#f8fafc]">
+      <PageShell className="flex items-center justify-center min-h-[60vh]">
         <Spinner size="lg" />
-      </section>
+      </PageShell>
     );
   }
 
   if (!record) {
     return (
-      <section
-        className={`w-full min-h-screen bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
-      >
+      <PageShell>
         <p className="text-base text-slate-700">Prontuário não encontrado.</p>
         <Button
           variant="outline"
@@ -154,16 +153,14 @@ const MedicalRecordDetailsPage = () => {
         >
           Voltar para a lista
         </Button>
-      </section>
+      </PageShell>
     );
   }
 
   const isSaving = updateMutation.isPending;
 
   return (
-    <section
-      className={`w-full min-h-screen bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
-    >
+    <PageShell>
       <div className="mb-6 flex items-center gap-3 flex-wrap">
         <Button
           variant="outline"
@@ -317,7 +314,7 @@ const MedicalRecordDetailsPage = () => {
           )}
         </CardContent>
       </Card>
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/professional/medical-records/new/page.tsx
+++ b/apps/web/app/dashboard/professional/medical-records/new/page.tsx
@@ -5,11 +5,11 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import {
   useCreateMedicalRecordMutation,
   useMedicalRecordByAppointmentQuery,
 } from "@/queries/useMedicalRecords";
+import { PageShell, PageHeader } from "../../../../ui/dashboard/page-shell";
 
 type ClinicalKey =
   | "chiefComplaint"
@@ -63,7 +63,6 @@ const EMPTY: Record<ClinicalKey, string> = {
 const NewMedicalRecordPage = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const isMobile = useIsMobile();
   const appointmentId = searchParams.get("appointmentId");
   const patientName = searchParams.get("patientName") ?? "Paciente";
 
@@ -84,7 +83,7 @@ const NewMedicalRecordPage = () => {
 
   if (!appointmentId) {
     return (
-      <section className="w-full min-h-screen px-4 py-8 sm:px-16 bg-[#f8fafc]">
+      <PageShell>
         <p className="text-base text-slate-700">
           Consulta não informada. Volte para a agenda e selecione uma consulta.
         </p>
@@ -95,15 +94,15 @@ const NewMedicalRecordPage = () => {
         >
           Ir para agenda
         </Button>
-      </section>
+      </PageShell>
     );
   }
 
   if (isLoading) {
     return (
-      <section className="w-full min-h-screen flex justify-center items-center bg-[#f8fafc]">
+      <PageShell className="flex items-center justify-center min-h-[60vh]">
         <Spinner size="lg" />
-      </section>
+      </PageShell>
     );
   }
 
@@ -129,9 +128,7 @@ const NewMedicalRecordPage = () => {
   };
 
   return (
-    <section
-      className={`w-full min-h-screen bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
-    >
+    <PageShell>
       <div className="mb-6 flex items-center gap-3 flex-wrap">
         <Button
           variant="outline"
@@ -143,16 +140,10 @@ const NewMedicalRecordPage = () => {
         </Button>
       </div>
 
-      <div className="mb-6">
-        <h1
-          className={`font-bold text-slate-900 tracking-tight ${isMobile ? "text-xl" : "text-2xl"}`}
-        >
-          Novo prontuário
-        </h1>
-        <p className="mt-1 text-sm text-slate-500">
-          Paciente: <span className="font-medium">{patientName}</span>
-        </p>
-      </div>
+      <PageHeader
+        title="Novo prontuário"
+        description={`Paciente: ${patientName}`}
+      />
 
       <Card className="border border-gray-200 rounded-xl bg-white">
         <CardContent className="p-5 sm:p-6 flex flex-col gap-5">
@@ -213,7 +204,7 @@ const NewMedicalRecordPage = () => {
           </div>
         </CardContent>
       </Card>
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/professional/medical-records/page.tsx
+++ b/apps/web/app/dashboard/professional/medical-records/page.tsx
@@ -7,13 +7,13 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import { Badge } from "@/components/ui/badge";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import { useMedicalRecordsListQuery } from "@/queries/useMedicalRecords";
 import {
   CalendarIcon,
   SearchIcon,
   EyeIcon,
 } from "../../../utils/icons";
+import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 
 const PAGE_SIZE = 10;
 
@@ -35,7 +35,6 @@ function truncate(text: string | null, max = 120) {
 
 const MedicalRecordsListPage = () => {
   const router = useRouter();
-  const isMobile = useIsMobile();
   const [search, setSearch] = useState("");
   const [searchInput, setSearchInput] = useState("");
   const [startDate, setStartDate] = useState("");
@@ -76,21 +75,11 @@ const MedicalRecordsListPage = () => {
   const hasFilters = Boolean(search || startDate || endDate);
 
   return (
-    <section
-      className={`w-full min-h-screen mx-auto bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
-    >
-      <div className="mb-8">
-        <h1
-          className={`font-bold text-gray-900 tracking-tight ${isMobile ? "text-2xl" : "text-4xl"}`}
-        >
-          Prontuários
-        </h1>
-        <p
-          className={`mt-1 text-gray-500 ${isMobile ? "text-sm" : "text-base"}`}
-        >
-          Prontuários médicos criados por você. {total > 0 && `${total} no total.`}
-        </p>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Prontuários"
+        description={`Prontuários médicos criados por você.${total > 0 ? ` ${total} no total.` : ""}`}
+      />
 
       <Card className="mb-6 border border-gray-200 rounded-xl bg-white">
         <CardContent className="p-4 sm:p-5">
@@ -268,7 +257,7 @@ const MedicalRecordsListPage = () => {
           </div>
         </div>
       )}
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/professional/page.tsx
+++ b/apps/web/app/dashboard/professional/page.tsx
@@ -20,6 +20,7 @@ import { useDailyScheduleQuery } from "@/queries/useDailyScheduleQuery";
 import { useProfessionalPatients } from "@/queries/useProfessionalPatients";
 import { useUpdateAppointmentStatusMutation } from "@/queries/useProfessionalAppointments";
 import { ConfirmModal } from "./schedule/components/ConfirmModal";
+import { PageShell, PageHeader } from "../../ui/dashboard/page-shell";
 
 type Appointment = {
   id: string;
@@ -151,33 +152,29 @@ const ProfessionalDashboard = () => {
 
   if (isLoading) {
     return (
-      <div className="flex w-full min-h-screen items-center justify-center bg-[#f8fafc]">
+      <PageShell className="flex items-center justify-center min-h-[60vh]">
         <Spinner size="lg" />
-      </div>
+      </PageShell>
     );
   }
 
   return (
-    <section className="w-full min-h-screen mx-auto px-4 py-6 sm:px-16 sm:py-8 bg-[#f8fafc]">
-      <div className="mb-10 flex justify-between items-center max-sm:flex-col max-sm:items-start max-sm:gap-4">
-        <div>
-          <h1 className="text-3xl sm:text-4xl font-bold text-gray-900 tracking-tight">
-            Painel Profissional
-          </h1>
-          <p className="mt-1 text-sm sm:text-base text-gray-500">
-            Gerencie suas consultas e acompanhe seu dia.
-          </p>
-        </div>
-        <Button
-          size="lg"
-          className="w-full sm:w-auto"
-          title="Acessar calendário completo da agenda"
-          onClick={handleCalendarClick}
-        >
-          <CalendarIcon />
-          Minha Agenda
-        </Button>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Painel Profissional"
+        description="Gerencie suas consultas e acompanhe seu dia."
+        actions={
+          <Button
+            size="lg"
+            className="w-full sm:w-auto"
+            title="Acessar calendário completo da agenda"
+            onClick={handleCalendarClick}
+          >
+            <CalendarIcon />
+            Minha Agenda
+          </Button>
+        }
+      />
       <div className="mb-8 grid grid-cols-1 md:grid-cols-3 gap-4">
         {stats.map((stat, index) => (
           <Card
@@ -375,7 +372,7 @@ const ProfessionalDashboard = () => {
         pendingStatus={pendingAction?.status || ""}
         onConfirm={handleConfirmAction}
       />
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/dashboard/professional/patients/page.tsx
+++ b/apps/web/app/dashboard/professional/patients/page.tsx
@@ -7,6 +7,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { SearchIcon, UsersIcon } from "../../../utils/icons";
 import { useProfessionalPatients } from "@/queries/useProfessionalPatients";
 import { PatientCard, PatientCardData } from "./components/PatientCard";
+import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 
 function onlyDigits(value: string) {
   return value.replace(/\D/g, "");
@@ -36,21 +37,11 @@ export default function PatientsPage() {
   const totalLabel =
     patients.length === 1 ? "1 paciente" : `${patients.length} pacientes`;
 
+  const headerDescription = `Acompanhe o perfil e o histórico dos pacientes que você atende.${!isLoading && patients.length > 0 ? ` · ${totalLabel}` : ""}`;
+
   return (
-    <section className="w-full min-h-screen mx-auto px-4 py-6 sm:px-16 sm:py-8 bg-[#f8fafc]">
-      <div className="mb-6 sm:mb-8">
-        <h1 className="text-2xl sm:text-4xl font-bold text-gray-900 tracking-tight">
-          Pacientes
-        </h1>
-        <p className="mt-1 text-sm sm:text-base text-gray-500">
-          Acompanhe o perfil e o histórico dos pacientes que você atende.
-          {!isLoading && patients.length > 0 && (
-            <span className="ml-1 text-gray-700 font-medium">
-              · {totalLabel}
-            </span>
-          )}
-        </p>
-      </div>
+    <PageShell>
+      <PageHeader title="Pacientes" description={headerDescription} />
 
       <Card className="mb-6 border border-gray-200 rounded-xl bg-white">
         <CardContent className="p-4 sm:p-5">
@@ -123,6 +114,6 @@ export default function PatientsPage() {
           ))}
         </div>
       )}
-    </section>
+    </PageShell>
   );
 }

--- a/apps/web/app/dashboard/professional/profile/page.tsx
+++ b/apps/web/app/dashboard/professional/profile/page.tsx
@@ -9,6 +9,7 @@ import { ProfileAvatar } from "./components/ProfileAvatar";
 import { ProfessionalInfoForm } from "./components/ProfessionalInfoForm";
 import { SocialLinksForm } from "./components/SocialLinksForm";
 import { useProfileForm } from "./useProfileForm";
+import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 
 export default function PerfilPage() {
   const {
@@ -32,31 +33,27 @@ export default function PerfilPage() {
 
   if (isLoading) {
     return (
-      <div className="py-24 px-8 flex justify-center items-center">
+      <PageShell className="flex items-center justify-center min-h-[60vh]">
         <Spinner size="lg" />
-      </div>
+      </PageShell>
     );
   }
 
   return (
-    <div className="w-full min-h-screen mx-auto px-16 py-8 bg-[#f8fafc]">
-      <div className="flex justify-between items-start mb-8 flex-wrap gap-4 max-sm:flex-col max-sm:items-start">
-        <div>
-          <h1 className="text-4xl font-bold text-gray-900 tracking-tight">
-            Meu Perfil
-          </h1>
-          <p className="mt-1 text-base text-gray-500">
-            Gerencie suas informações profissionais.
-          </p>
-        </div>
-        <Button
-          size="lg"
-          onClick={() => (isEditing ? handleCancel() : setIsEditing(true))}
-          title={isEditing ? "Cancelar edição" : "Habilitar edição do perfil"}
-        >
-          {isEditing ? "Cancelar" : "Editar Perfil"}
-        </Button>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Meu Perfil"
+        description="Gerencie suas informações profissionais."
+        actions={
+          <Button
+            size="lg"
+            onClick={() => (isEditing ? handleCancel() : setIsEditing(true))}
+            title={isEditing ? "Cancelar edição" : "Habilitar edição do perfil"}
+          >
+            {isEditing ? "Cancelar" : "Editar Perfil"}
+          </Button>
+        }
+      />
 
       <Card className="border border-gray-200 rounded-xl bg-white">
         <CardContent className="p-8 space-y-8">
@@ -120,6 +117,6 @@ export default function PerfilPage() {
           <AddressForm userId={user?.id || ""} />
         </CardContent>
       </Card>
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/app/dashboard/professional/schedule/page.tsx
+++ b/apps/web/app/dashboard/professional/schedule/page.tsx
@@ -12,6 +12,7 @@ import { useUpdateAppointmentStatusMutation } from "@/queries/useProfessionalApp
 import { ScheduleTimeline } from "./components/ScheduleTimeline";
 import ScheduleModal from "./scheduleModal";
 import { BlockScheduleModal } from "./components/BlockScheduleModal";
+import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 
 type Appointment = {
   id: string;
@@ -117,30 +118,26 @@ const SchedulePage = () => {
   };
 
   return (
-    <section className="w-full min-h-screen mx-auto px-4 sm:px-8 lg:px-16 py-6 sm:py-8 bg-[#f8fafc]">
-      <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center">
-        <div>
-          <h1 className="text-2xl sm:text-4xl font-bold text-gray-900 tracking-tight">
-            Minha Agenda
-          </h1>
-          <p className="mt-1 text-sm sm:text-base text-gray-500">
-            Visualize e gerencie seus horários.
-          </p>
-        </div>
-        <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
-          <Button variant="outline" title="Cancelar a agenda do dia" size="lg" onClick={() => setIsBlockModalOpen(true)} className="w-full sm:w-auto border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700">
-            Cancelar Agenda
-          </Button>
-          <Button
-          size="lg"
-          onClick={() => setIsOpen(true)}
-          className="w-full sm:w-auto"
-          title="Configurar horários e dias de atendimento"
-        >
-            Gerenciar Horários
-          </Button>
-        </div>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Minha Agenda"
+        description="Visualize e gerencie seus horários."
+        actions={
+          <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
+            <Button variant="outline" title="Cancelar a agenda do dia" size="lg" onClick={() => setIsBlockModalOpen(true)} className="w-full sm:w-auto border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700">
+              Cancelar Agenda
+            </Button>
+            <Button
+              size="lg"
+              onClick={() => setIsOpen(true)}
+              className="w-full sm:w-auto"
+              title="Configurar horários e dias de atendimento"
+            >
+              Gerenciar Horários
+            </Button>
+          </div>
+        }
+      />
 
       <div className="grid grid-cols-1 lg:grid-cols-[360px_1fr] lg:items-start gap-6">
         <aside className="flex flex-col gap-6">
@@ -190,10 +187,10 @@ const SchedulePage = () => {
       <ScheduleModal isOpen={isOpen} onOpenChange={(open) => setIsOpen(open)} />
       <BlockScheduleModal 
         isOpen={isBlockModalOpen} 
-        onOpenChange={setIsBlockModalOpen} 
-        selectedDate={selectedDate} 
+        onOpenChange={setIsBlockModalOpen}
+        selectedDate={selectedDate}
       />
-    </section>
+    </PageShell>
   );
 };
 

--- a/apps/web/app/ui/dashboard/page-shell.tsx
+++ b/apps/web/app/ui/dashboard/page-shell.tsx
@@ -1,0 +1,45 @@
+import { type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export function PageShell({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "w-full px-4 sm:px-6 lg:px-8 py-6 sm:py-8",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function PageHeader({
+  title,
+  description,
+  actions,
+}: {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+}) {
+  return (
+    <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0">
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+          {title}
+        </h1>
+        {description && (
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #165

## Summary
- Adiciona componentes compartilhados `PageShell` e `PageHeader` em `app/ui/dashboard/page-shell.tsx`.
- `PageShell` aplica padding consistente (`px-4 sm:px-6 lg:px-8 py-6 sm:py-8`); `PageHeader` uniformiza título (`text-2xl font-bold tracking-tight`) e subtítulo (`text-sm muted`).
- Aplica o padrão em ~25 páginas (admin, manager, professional, patient e subrotas).
- Remove backgrounds locais (`bg-slate-50`, `bg-[#f8fafc]`) duplicados — herdam do layout pai.
- Padroniza `/admin/register-manager`: remove `max-w-3xl mx-auto` e troca botão "Voltar" pelo link discreto "← Painel Administrativo" no mesmo estilo de `/admin/specialidades`.

## Test plan
- [ ] Todas as rotas começam o conteúdo na mesma coluna (mesmo padding-left)
- [ ] Títulos e subtítulos com o mesmo tamanho em todas as páginas
- [ ] Nenhum wrapper define `bg-*` próprio
- [ ] `/admin/register-manager` alinha com `/admin/specialidades` e `/admin`
- [ ] `tsc --noEmit` limpo