### PR TITLE
refactor(ui): padronizar tabelas do dashboard (#154)

### DIFF
--- a/apps/web/app/dashboard/admin/components/SpecialityTable.tsx
+++ b/apps/web/app/dashboard/admin/components/SpecialityTable.tsx
@@ -8,7 +8,21 @@ import { useCreateSpeciality } from "@/queries/useCreateSpeciality";
 import { useUpdateSpeciality } from "@/queries/useUpdateSpeciality";
 import { useDeleteSpeciality } from "@/queries/useDeleteSpeciality";
 import { useIsMobile } from "@/hooks/useIsMobile";
-import { Stethoscope, Plus, Pencil, Trash2, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
+import { Stethoscope, Plus, Pencil, Trash2 } from "lucide-react";
+import {
+  DataTable,
+  DataTableBody,
+  DataTableCard,
+  DataTableCell,
+  DataTableEmpty,
+  DataTableHead,
+  DataTableHeadCell,
+  DataTableHeader,
+  DataTableMobileItem,
+  DataTableMobileList,
+  DataTableRow,
+  SortableHeader,
+} from "@/components/ui/data-table";
 
 type SortDir = "asc" | "desc";
 
@@ -33,27 +47,25 @@ export const SpecialitiesTable = ({ specialities }: SpecialitiesTableProps) => {
 
   const isSaving = isCreating || isUpdating;
 
-  const [sortDir, setSortDir] = useState<SortDir | null>(null);
+  const [sortField, setSortField] = useState<"name" | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
 
   const sortedSpecialities = useMemo(() => {
-    if (!sortDir) return specialities;
+    if (!sortField) return specialities;
     return [...specialities].sort((a, b) => {
       const cmp = a.name.localeCompare(b.name);
       return sortDir === "asc" ? cmp : -cmp;
     });
-  }, [specialities, sortDir]);
+  }, [specialities, sortField, sortDir]);
 
-  function toggleSort() {
-    setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+  function toggleSort(field: "name") {
+    if (sortField === field) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortField(field);
+      setSortDir("asc");
+    }
   }
-
-  const SortIcon = () => {
-    if (!sortDir)
-      return <ArrowUpDown className="ml-1.5 inline h-3.5 w-3.5 text-muted-foreground/50" />;
-    return sortDir === "asc"
-      ? <ArrowUp className="ml-1.5 inline h-3.5 w-3.5 text-foreground" />
-      : <ArrowDown className="ml-1.5 inline h-3.5 w-3.5 text-foreground" />;
-  };
 
   function openCreate() {
     setEditingId(null);
@@ -89,121 +101,114 @@ export const SpecialitiesTable = ({ specialities }: SpecialitiesTableProps) => {
 
   return (
     <>
-      <div className="rounded-xl border border-border bg-card shadow-sm overflow-hidden">
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
-          <div className="flex items-center gap-2">
-            <h2 className="text-base font-semibold text-foreground">Especialidades</h2>
-            <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-              {specialities.length}
-            </span>
-          </div>
-          <Button 
-            size="sm" 
-            onClick={openCreate} 
-            className="gap-1.5"
-            title="Adicionar nova especialidade médica"
-          >
-            <Plus className="h-3.5 w-3.5" />
-            {isMobile ? "Nova" : "Nova Especialidade"}
-          </Button>
-        </div>
-
-        {/* Empty state */}
-        {specialities.length === 0 ? (
-          <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
-            <div className="rounded-full bg-muted p-4">
-              <Stethoscope className="h-8 w-8 text-muted-foreground/50" />
-            </div>
-            <div>
-              <p className="text-sm font-medium text-foreground">Nenhuma especialidade</p>
-              <p className="text-xs text-muted-foreground mt-0.5">
-                Adicione a primeira especialidade médica.
-              </p>
-            </div>
-            <Button 
-              size="sm" 
-              variant="outline" 
-              onClick={openCreate} 
-              className="mt-1 gap-1.5"
-              title="Adicionar especialidade"
+      <DataTableCard>
+        <DataTableHeader
+          title="Especialidades"
+          count={specialities.length}
+          actions={
+            <Button
+              size="sm"
+              onClick={openCreate}
+              className="gap-1.5"
+              title="Adicionar nova especialidade médica"
             >
               <Plus className="h-3.5 w-3.5" />
-              Adicionar
+              {isMobile ? "Nova" : "Nova Especialidade"}
             </Button>
-          </div>
+          }
+        />
+
+        {specialities.length === 0 ? (
+          <DataTableEmpty
+            icon={<Stethoscope className="h-8 w-8" />}
+            title="Nenhuma especialidade"
+            description="Adicione a primeira especialidade médica."
+            action={
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={openCreate}
+                className="gap-1.5"
+                title="Adicionar especialidade"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Adicionar
+              </Button>
+            }
+          />
         ) : isMobile ? (
-          /* Mobile: cards */
-          <div className="divide-y divide-border relative">
-            {isDeleting && (
-              <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/60 backdrop-blur-sm">
-                <p className="text-sm font-medium text-muted-foreground">Excluindo...</p>
-              </div>
-            )}
-            {specialities.map((spec) => (
-              <div key={spec.id} className="flex items-center justify-between px-4 py-3.5">
-                <div className="flex items-center gap-3">
-                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
-                    <Stethoscope className="h-4 w-4" />
-                  </div>
-                  <p className="text-sm font-medium text-foreground">{spec.name}</p>
-                </div>
-                <div className="flex gap-1">
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                    onClick={() => openEdit(spec)}
-                    title={`Editar especialidade ${spec.name}`}
-                  >
-                    <Pencil className="h-3.5 w-3.5" />
-                  </Button>
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    className="h-8 w-8 text-muted-foreground hover:text-red-500 hover:bg-red-50"
-                    onClick={() => handleDelete(spec.id, spec.name)}
-                    title={`Excluir especialidade ${spec.name}`}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : (
-          /* Desktop: table */
           <div className="relative">
             {isDeleting && (
               <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/60 backdrop-blur-sm">
                 <p className="text-sm font-medium text-muted-foreground">Excluindo...</p>
               </div>
             )}
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border bg-muted/30 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  <th
-                    className="px-6 py-3 text-left cursor-pointer select-none"
-                    onClick={toggleSort}
-                    title="Ordenar por nome da especialidade"
-                  >
-                    Nome da especialidade <SortIcon />
-                  </th>
-                  <th className="px-6 py-3 text-center">Ações</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
+            <DataTableMobileList>
+              {sortedSpecialities.map((spec) => (
+                <DataTableMobileItem key={spec.id}>
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+                        <Stethoscope className="h-4 w-4" />
+                      </div>
+                      <p className="text-sm font-medium text-foreground truncate">{spec.name}</p>
+                    </div>
+                    <div className="flex gap-1 shrink-0">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                        onClick={() => openEdit(spec)}
+                        title={`Editar especialidade ${spec.name}`}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 text-muted-foreground hover:text-red-500 hover:bg-red-50"
+                        onClick={() => handleDelete(spec.id, spec.name)}
+                        title={`Excluir especialidade ${spec.name}`}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </div>
+                </DataTableMobileItem>
+              ))}
+            </DataTableMobileList>
+          </div>
+        ) : (
+          <div className="relative">
+            {isDeleting && (
+              <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/60 backdrop-blur-sm">
+                <p className="text-sm font-medium text-muted-foreground">Excluindo...</p>
+              </div>
+            )}
+            <DataTable>
+              <DataTableHead>
+                <SortableHeader
+                  field="name"
+                  currentField={sortField}
+                  direction={sortDir}
+                  onToggle={toggleSort}
+                >
+                  Nome da especialidade
+                </SortableHeader>
+                <DataTableHeadCell align="center">Ações</DataTableHeadCell>
+              </DataTableHead>
+              <DataTableBody>
                 {sortedSpecialities.map((spec) => (
-                  <tr key={spec.id} className="hover:bg-muted/30 transition-colors">
-                    <td className="px-6 py-3.5">
+                  <DataTableRow key={spec.id}>
+                    <DataTableCell>
                       <div className="flex items-center gap-3">
                         <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
                           <Stethoscope className="h-3.5 w-3.5" />
                         </div>
                         <span className="font-medium text-foreground">{spec.name}</span>
                       </div>
-                    </td>
-                    <td className="px-6 py-3.5">
+                    </DataTableCell>
+                    <DataTableCell align="center">
                       <div className="flex items-center justify-center gap-1">
                         <Button
                           size="icon"
@@ -224,16 +229,15 @@ export const SpecialitiesTable = ({ specialities }: SpecialitiesTableProps) => {
                           <Trash2 className="h-3.5 w-3.5" />
                         </Button>
                       </div>
-                    </td>
-                  </tr>
+                    </DataTableCell>
+                  </DataTableRow>
                 ))}
-              </tbody>
-            </table>
+              </DataTableBody>
+            </DataTable>
           </div>
         )}
-      </div>
+      </DataTableCard>
 
-      {/* Modal */}
       {isModalOpen && (
         <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 backdrop-blur-sm sm:items-center">
           <div className="w-full rounded-t-2xl bg-card px-6 pb-8 pt-6 shadow-xl sm:max-w-md sm:rounded-2xl sm:pb-6 animate-in fade-in slide-in-from-bottom-4 duration-200">
@@ -256,17 +260,17 @@ export const SpecialitiesTable = ({ specialities }: SpecialitiesTableProps) => {
                 title="Nome da especialidade médica"
               />
               <div className="flex gap-3 justify-end">
-                <Button 
-                  type="button" 
-                  variant="outline" 
-                  onClick={closeModal} 
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={closeModal}
                   disabled={isSaving}
                   title="Cancelar operação"
                 >
                   Cancelar
                 </Button>
-                <Button 
-                  type="submit" 
+                <Button
+                  type="submit"
                   disabled={isSaving || !newSpecialityName.trim()}
                   title="Salvar alterações"
                 >

--- a/apps/web/app/dashboard/admin/components/UsersTable.tsx
+++ b/apps/web/app/dashboard/admin/components/UsersTable.tsx
@@ -6,17 +6,25 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/shared/StatusBadge";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+  DataTable,
+  DataTableBody,
+  DataTableCard,
+  DataTableCell,
+  DataTableEmpty,
+  DataTableHead,
+  DataTableHeadCell,
+  DataTableHeader,
+  DataTableLoading,
+  DataTableMobileItem,
+  DataTableMobileList,
+  DataTableRow,
+  DataTableToolbar,
+  SortableHeader,
+} from "@/components/ui/data-table";
 import { AdminUser } from "../../../../services/admin-service";
 import { useAdminUsersTable, TypeFilter } from "@/queries/useAdminUsersTable";
 import { useIsMobile } from "@/hooks/useIsMobile";
-import { ArrowUpDown, ArrowUp, ArrowDown, Eye, Check, Ban, Pencil } from "lucide-react";
+import { Eye, Check, Ban, Pencil, Users } from "lucide-react";
 
 type SortField =
   | "name"
@@ -126,303 +134,243 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
     });
   }, [users, sortField, sortDir]);
 
-  function SortIcon({ field }: { field: SortField }) {
-    if (sortField !== field)
-      return <ArrowUpDown className="ml-1.5 inline h-3.5 w-3.5 text-muted-foreground/50" />;
-    return sortDir === "asc"
-      ? <ArrowUp className="ml-1.5 inline h-3.5 w-3.5 text-foreground" />
-      : <ArrowDown className="ml-1.5 inline h-3.5 w-3.5 text-foreground" />;
-  }
-
-  const filterBar = (
-    <div className="flex flex-wrap items-center gap-2 border-b border-border bg-muted/30 px-4 py-3 sm:px-6 sm:gap-3">
-      <div className="flex rounded-lg border border-border bg-background text-sm overflow-hidden">
-        {TYPE_TABS.map((tab) => (
-          <button
-            key={tab.value}
-            onClick={() => setTypeFilter(tab.value)}
-            title={`Filtrar por ${tab.label}`}
-            className={`px-3 py-1.5 font-medium transition-colors sm:px-4 ${
-              typeFilter === tab.value
-                ? "bg-foreground text-background"
-                : "text-muted-foreground hover:text-foreground hover:bg-muted"
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-      <Input
-        placeholder="Buscar usuário..."
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        title="Digite o nome ou e-mail para buscar"
-        className="h-8 flex-1 min-w-[160px] max-w-xs text-sm bg-background"
-      />
-    </div>
-  );
+  const stopClick = (e: React.MouseEvent) => e.stopPropagation();
 
   return (
-    <div className="w-full rounded-xl border border-border bg-card shadow-sm">
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 py-4 border-b border-border sm:px-6">
-        <div className="flex items-center gap-2">
-          <h2 className="text-base font-semibold text-foreground">Usuários</h2>
-          <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-            {sortedUsers.length}
-          </span>
+    <DataTableCard>
+      <DataTableHeader title="Usuários" count={sortedUsers.length} actions={actions} />
+
+      <DataTableToolbar>
+        <div className="flex rounded-lg border border-border bg-background text-sm overflow-hidden">
+          {TYPE_TABS.map((tab) => (
+            <button
+              key={tab.value}
+              onClick={() => setTypeFilter(tab.value)}
+              title={`Filtrar por ${tab.label}`}
+              className={`px-3 py-1.5 font-medium transition-colors sm:px-4 ${
+                typeFilter === tab.value
+                  ? "bg-foreground text-background"
+                  : "text-muted-foreground hover:text-foreground hover:bg-muted"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
         </div>
-        {actions && <div>{actions}</div>}
-      </div>
+        <Input
+          placeholder="Buscar usuário..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          title="Digite o nome ou e-mail para buscar"
+          className="h-8 flex-1 min-w-[160px] max-w-xs text-sm bg-background"
+        />
+      </DataTableToolbar>
 
-      {filterBar}
-
-      {/* Loading / empty */}
       {isLoading ? (
-        <div className="py-12 text-center text-sm text-muted-foreground">Carregando...</div>
+        <DataTableLoading message="Carregando usuários..." />
       ) : sortedUsers.length === 0 ? (
-        <div className="py-12 text-center text-sm text-muted-foreground">
-          Nenhum usuário encontrado.
-        </div>
+        <DataTableEmpty
+          icon={<Users className="h-8 w-8" />}
+          title="Nenhum usuário encontrado"
+        />
       ) : isMobile ? (
-        /* ── Mobile: cards ── */
-        <div className="divide-y divide-border">
+        <DataTableMobileList>
           {sortedUsers.map((user) => {
             const badge = TYPE_BADGE[user.role];
             const speciality = getSpeciality(user);
-            const stopClick = (e: React.MouseEvent) => e.stopPropagation();
             return (
-              <div
+              <DataTableMobileItem
                 key={user.id}
-                className="flex items-start gap-3 px-4 py-4 cursor-pointer active:bg-muted/40"
                 onClick={() => goToEdit(user.id)}
                 title={`Abrir perfil de ${user.name}`}
               >
-                {/* Avatar */}
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-foreground text-background text-xs font-bold">
-                  {getInitials(user.name)}
-                </div>
-
-                {/* Info */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <p className="text-sm font-medium text-foreground truncate">{user.name}</p>
-                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${badge.className}`}>
-                      {badge.label}
-                    </span>
+                <div className="flex items-start gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-foreground text-background text-xs font-bold">
+                    {getInitials(user.name)}
                   </div>
-                  <p className="text-xs text-muted-foreground mt-0.5 truncate">{user.email}</p>
-                  {user.role === "PROFESSIONAL" && speciality && (
-                    <p className="text-xs text-muted-foreground/70 mt-0.5 truncate">
-                      {speciality}
-                      {user.professionalProfile?.modality && ` · ${user.professionalProfile.modality}`}
-                    </p>
-                  )}
-                  {user.role === "PATIENT" && user.patientProfile?.phone && (
-                    <p className="text-xs text-muted-foreground/70 mt-0.5 truncate">
-                      Tel: {user.patientProfile.phone}
-                    </p>
-                  )}
-                  {user.createdAt && (
-                    <p className="text-[11px] text-muted-foreground/60 mt-0.5">
-                      Cadastrado em {formatDate(user.createdAt)}
-                    </p>
-                  )}
-                  <div className="mt-2">
-                    <StatusBadge status={user.status} type="user" />
-                  </div>
-                </div>
 
-                {/* Actions */}
-                <div className="flex flex-col gap-0.5 shrink-0" onClick={stopClick}>
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                    title={`Visualizar detalhes de ${user.name}`}
-                    onClick={() => router.push(`/dashboard/admin/users/${user.id}`)}
-                  >
-                    <Eye />
-                  </Button>
-                  {(user.status === "PENDING" ||
-                    user.status === "COMPLETED" ||
-                    user.status === "BLOCKED") && (
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <p className="text-sm font-medium text-foreground truncate">{user.name}</p>
+                      <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${badge.className}`}>
+                        {badge.label}
+                      </span>
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-0.5 truncate">{user.email}</p>
+                    {user.role === "PROFESSIONAL" && speciality && (
+                      <p className="text-xs text-muted-foreground/70 mt-0.5 truncate">
+                        {speciality}
+                        {user.professionalProfile?.modality && ` · ${user.professionalProfile.modality}`}
+                      </p>
+                    )}
+                    {user.role === "PATIENT" && user.patientProfile?.phone && (
+                      <p className="text-xs text-muted-foreground/70 mt-0.5 truncate">
+                        Tel: {user.patientProfile.phone}
+                      </p>
+                    )}
+                    {user.createdAt && (
+                      <p className="text-[11px] text-muted-foreground/60 mt-0.5">
+                        Cadastrado em {formatDate(user.createdAt)}
+                      </p>
+                    )}
+                    <div className="mt-2">
+                      <StatusBadge status={user.status} type="user" />
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col gap-0.5 shrink-0" onClick={stopClick}>
                     <Button
                       size="icon"
                       variant="ghost"
-                      disabled={!user.emailVerified}
-                      className="h-8 w-8 text-emerald-500 hover:text-emerald-600 hover:bg-emerald-50"
-                      title={
-                        user.emailVerified
-                          ? `Aprovar usuário ${user.name}`
-                          : `${user.name} ainda não confirmou o e-mail`
-                      }
-                      onClick={() => onStatusChange(user.id, "VERIFIED")}
+                      className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                      title={`Visualizar detalhes de ${user.name}`}
+                      onClick={() => router.push(`/dashboard/admin/users/${user.id}`)}
                     >
-                      <Check />
+                      <Eye />
                     </Button>
-                  )}
-                  {user.status === "VERIFIED" && (
+                    {(user.status === "PENDING" ||
+                      user.status === "COMPLETED" ||
+                      user.status === "BLOCKED") && (
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        disabled={!user.emailVerified}
+                        className="h-8 w-8 text-emerald-500 hover:text-emerald-600 hover:bg-emerald-50"
+                        title={
+                          user.emailVerified
+                            ? `Aprovar usuário ${user.name}`
+                            : `${user.name} ainda não confirmou o e-mail`
+                        }
+                        onClick={() => onStatusChange(user.id, "VERIFIED")}
+                      >
+                        <Check />
+                      </Button>
+                    )}
+                    {user.status === "VERIFIED" && (
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 text-red-400 hover:text-red-500 hover:bg-red-50"
+                        title={`Bloquear usuário ${user.name}`}
+                        onClick={() => onStatusChange(user.id, "BLOCKED")}
+                      >
+                        <Ban />
+                      </Button>
+                    )}
                     <Button
                       size="icon"
                       variant="ghost"
-                      className="h-8 w-8 text-red-400 hover:text-red-500 hover:bg-red-50"
-                      title={`Bloquear usuário ${user.name}`}
-                      onClick={() => onStatusChange(user.id, "BLOCKED")}
+                      className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                      title={`Editar dados de ${user.name}`}
+                      onClick={() => router.push(`/dashboard/admin/users/${user.id}?edit=1`)}
                     >
-                      <Ban />
+                      <Pencil />
                     </Button>
-                  )}
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                    title={`Editar dados de ${user.name}`}
-                    onClick={() => router.push(`/dashboard/admin/users/${user.id}?edit=1`)}
-                  >
-                    <Pencil />
-                  </Button>
+                  </div>
                 </div>
-              </div>
+              </DataTableMobileItem>
             );
           })}
-        </div>
+        </DataTableMobileList>
       ) : (
-        /* ── Desktop: table ── */
-        <Table>
-          <TableHeader>
-            <TableRow className="hover:bg-transparent">
-              <TableHead
-                className="pl-6 cursor-pointer select-none"
-                onClick={() => toggleSort("name")}
-                title="Ordenar por Nome"
-              >
-                Usuário <SortIcon field="name" />
-              </TableHead>
+        <DataTable>
+          <DataTableHead>
+            <SortableHeader field="name" currentField={sortField} direction={sortDir} onToggle={toggleSort}>
+              Usuário
+            </SortableHeader>
 
-              {typeFilter === "all" && (
-                <TableHead
-                  className="text-center cursor-pointer select-none"
-                  onClick={() => toggleSort("type")}
-                  title="Ordenar por Tipo"
-                >
-                  Tipo <SortIcon field="type" />
-                </TableHead>
-              )}
+            {typeFilter === "all" && (
+              <SortableHeader field="type" currentField={sortField} direction={sortDir} onToggle={toggleSort} align="center">
+                Tipo
+              </SortableHeader>
+            )}
 
-              {typeFilter === "PATIENT" && (
-                <>
-                  <TableHead
-                    className="text-center cursor-pointer select-none"
-                    onClick={() => toggleSort("phone")}
-                    title="Ordenar por Telefone"
-                  >
-                    Telefone <SortIcon field="phone" />
-                  </TableHead>
-                  <TableHead
-                    className="text-center cursor-pointer select-none"
-                    onClick={() => toggleSort("dateOfBirth")}
-                    title="Ordenar por Nascimento"
-                  >
-                    Nascimento <SortIcon field="dateOfBirth" />
-                  </TableHead>
-                </>
-              )}
+            {typeFilter === "PATIENT" && (
+              <>
+                <SortableHeader field="phone" currentField={sortField} direction={sortDir} onToggle={toggleSort} align="center">
+                  Telefone
+                </SortableHeader>
+                <SortableHeader field="dateOfBirth" currentField={sortField} direction={sortDir} onToggle={toggleSort} align="center">
+                  Nascimento
+                </SortableHeader>
+              </>
+            )}
 
-              {typeFilter === "PROFESSIONAL" && (
-                <>
-                  <TableHead
-                    className="text-center cursor-pointer select-none"
-                    onClick={() => toggleSort("speciality")}
-                    title="Ordenar por Especialidade"
-                  >
-                    Especialidade <SortIcon field="speciality" />
-                  </TableHead>
-                  <TableHead
-                    className="text-center cursor-pointer select-none"
-                    onClick={() => toggleSort("modality")}
-                    title="Ordenar por Modalidade"
-                  >
-                    Modalidade <SortIcon field="modality" />
-                  </TableHead>
-                </>
-              )}
+            {typeFilter === "PROFESSIONAL" && (
+              <>
+                <SortableHeader field="speciality" currentField={sortField} direction={sortDir} onToggle={toggleSort} align="center">
+                  Especialidade
+                </SortableHeader>
+                <SortableHeader field="modality" currentField={sortField} direction={sortDir} onToggle={toggleSort} align="center">
+                  Modalidade
+                </SortableHeader>
+              </>
+            )}
 
-              <TableHead
-                className="text-center cursor-pointer select-none"
-                onClick={() => toggleSort("status")}
-                title="Ordenar por Status"
-              >
-                Status <SortIcon field="status" />
-              </TableHead>
+            <SortableHeader field="status" currentField={sortField} direction={sortDir} onToggle={toggleSort} align="center">
+              Status
+            </SortableHeader>
 
-              <TableHead
-                className="text-center cursor-pointer select-none"
-                onClick={() => toggleSort("createdAt")}
-                title="Ordenar por data de cadastro"
-              >
-                Cadastrado em <SortIcon field="createdAt" />
-              </TableHead>
+            <SortableHeader field="createdAt" currentField={sortField} direction={sortDir} onToggle={toggleSort} align="center">
+              Cadastrado em
+            </SortableHeader>
 
-              <TableHead className="pr-6 text-center">Ações</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
+            <DataTableHeadCell align="center">Ações</DataTableHeadCell>
+          </DataTableHead>
+          <DataTableBody>
             {sortedUsers.map((user) => {
               const badge = TYPE_BADGE[user.role];
               const speciality = getSpeciality(user);
-              const stopClick = (e: React.MouseEvent) => e.stopPropagation();
               return (
-                <TableRow
+                <DataTableRow
                   key={user.id}
-                  className="cursor-pointer"
                   onClick={() => goToEdit(user.id)}
                   title={`Abrir perfil de ${user.name}`}
                 >
-                  <TableCell className="pl-6">
+                  <DataTableCell>
                     <p className="font-medium text-foreground">{user.name}</p>
                     <p className="text-xs text-muted-foreground mt-0.5">{user.email}</p>
-                  </TableCell>
+                  </DataTableCell>
 
                   {typeFilter === "all" && (
-                    <TableCell className="text-center">
+                    <DataTableCell align="center">
                       <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${badge.className}`}>
                         {badge.label}
                       </span>
-                    </TableCell>
+                    </DataTableCell>
                   )}
 
                   {typeFilter === "PATIENT" && (
                     <>
-                      <TableCell className="text-center text-sm text-muted-foreground">
+                      <DataTableCell align="center">
                         {user.patientProfile?.phone ?? <span className="text-muted-foreground/40">—</span>}
-                      </TableCell>
-                      <TableCell className="text-center text-sm text-muted-foreground">
+                      </DataTableCell>
+                      <DataTableCell align="center">
                         {formatDate(user.patientProfile?.dateOfBirth) ?? <span className="text-muted-foreground/40">—</span>}
-                      </TableCell>
+                      </DataTableCell>
                     </>
                   )}
 
                   {typeFilter === "PROFESSIONAL" && (
                     <>
-                      <TableCell className="text-center text-sm text-muted-foreground">
+                      <DataTableCell align="center">
                         {speciality ?? <span className="text-muted-foreground/40">—</span>}
-                      </TableCell>
-                      <TableCell className="text-center text-sm text-muted-foreground">
+                      </DataTableCell>
+                      <DataTableCell align="center">
                         {user.professionalProfile?.modality ?? <span className="text-muted-foreground/40">—</span>}
-                      </TableCell>
+                      </DataTableCell>
                     </>
                   )}
 
-                  <TableCell className="text-center">
+                  <DataTableCell align="center">
                     <StatusBadge status={user.status} type="user" />
-                  </TableCell>
+                  </DataTableCell>
 
-                  <TableCell className="text-center text-sm text-muted-foreground">
+                  <DataTableCell align="center">
                     {formatDate(user.createdAt) ?? <span className="text-muted-foreground/40">—</span>}
-                  </TableCell>
+                  </DataTableCell>
 
-                  <TableCell className="pr-6" onClick={stopClick}>
+                  <DataTableCell align="center" onClick={stopClick}>
                     <div className="flex items-center justify-center gap-0.5">
                       <Button
                         size="icon"
@@ -475,13 +423,13 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
                         <Pencil />
                       </Button>
                     </div>
-                  </TableCell>
-                </TableRow>
+                  </DataTableCell>
+                </DataTableRow>
               );
             })}
-          </TableBody>
-        </Table>
+          </DataTableBody>
+        </DataTable>
       )}
-    </div>
+    </DataTableCard>
   );
 }

--- a/apps/web/app/dashboard/manager/appointments/page.tsx
+++ b/apps/web/app/dashboard/manager/appointments/page.tsx
@@ -9,7 +9,20 @@ import { EmptyState } from '@/components/shared/EmptyState';
 import { PageHeader } from '@/components/shared/PageHeader';
 import { StatusBadge } from '@/components/shared/StatusBadge';
 import { CancelConfirmDialog } from '@/app/dashboard/patient/appointments/components/CancelConfirmDialog';
-import { Calendar, Clock, X, CheckCircle, AlertCircle, XCircle, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
+import {
+  DataTable,
+  DataTableBody,
+  DataTableCard,
+  DataTableCell,
+  DataTableEmpty,
+  DataTableHead,
+  DataTableHeadCell,
+  DataTableMobileItem,
+  DataTableMobileList,
+  DataTableRow,
+  SortableHeader,
+} from '@/components/ui/data-table';
+import { Calendar, Clock, X, CheckCircle, AlertCircle, XCircle } from 'lucide-react';
 
 type SortField = 'patient' | 'professional' | 'dateTime' | 'scheduledBy' | 'status';
 type SortDir = 'asc' | 'desc';
@@ -63,14 +76,6 @@ export default function AppointmentsPage() {
     });
   }, [filteredAppointments, sortField, sortDir]);
 
-  function SortIcon({ field }: { field: SortField }) {
-    if (sortField !== field)
-      return <ArrowUpDown className="ml-1.5 inline h-3.5 w-3.5 text-gray-400" />;
-    return sortDir === 'asc'
-      ? <ArrowUp className="ml-1.5 inline h-3.5 w-3.5 text-gray-900" />
-      : <ArrowDown className="ml-1.5 inline h-3.5 w-3.5 text-gray-900" />;
-  }
-
   const appointmentStats = useMemo(() => {
     return {
       total: appointments.length,
@@ -122,7 +127,7 @@ export default function AppointmentsPage() {
         <PageHeader
           title="Agendamentos"
           action={{
-            label: "+ Nova Consulta",
+            label: '+ Nova Consulta',
             href: '/dashboard/manager/appointments/new',
             colorClass: 'bg-blue-600 hover:bg-blue-700',
           }}
@@ -138,46 +143,46 @@ export default function AppointmentsPage() {
           <>
             {!isMobile && (
               <div className="grid grid-cols-5 gap-4 mb-8">
-                <div className="bg-white rounded-lg border border-gray-200 p-4 shadow-sm">
+                <div className="rounded-xl border border-border bg-card p-4 shadow-sm">
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-xs text-gray-500 font-medium">Total</p>
-                      <p className="text-2xl font-bold text-gray-900 mt-1">{appointmentStats.total}</p>
+                      <p className="text-xs text-muted-foreground font-medium">Total</p>
+                      <p className="text-2xl font-bold text-foreground mt-1">{appointmentStats.total}</p>
                     </div>
                     <Calendar className="w-8 h-8 text-blue-500 opacity-20" />
                   </div>
                 </div>
-                <div className="bg-white rounded-lg border border-gray-200 p-4 shadow-sm">
+                <div className="rounded-xl border border-border bg-card p-4 shadow-sm">
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-xs text-gray-500 font-medium">Pendente</p>
+                      <p className="text-xs text-muted-foreground font-medium">Pendente</p>
                       <p className="text-2xl font-bold text-yellow-600 mt-1">{appointmentStats.pending}</p>
                     </div>
                     <AlertCircle className="w-8 h-8 text-yellow-500 opacity-20" />
                   </div>
                 </div>
-                <div className="bg-white rounded-lg border border-gray-200 p-4 shadow-sm">
+                <div className="rounded-xl border border-border bg-card p-4 shadow-sm">
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-xs text-gray-500 font-medium">Confirmado</p>
+                      <p className="text-xs text-muted-foreground font-medium">Confirmado</p>
                       <p className="text-2xl font-bold text-blue-600 mt-1">{appointmentStats.confirmed}</p>
                     </div>
                     <CheckCircle className="w-8 h-8 text-blue-500 opacity-20" />
                   </div>
                 </div>
-                <div className="bg-white rounded-lg border border-gray-200 p-4 shadow-sm">
+                <div className="rounded-xl border border-border bg-card p-4 shadow-sm">
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-xs text-gray-500 font-medium">Concluído</p>
+                      <p className="text-xs text-muted-foreground font-medium">Concluído</p>
                       <p className="text-2xl font-bold text-green-600 mt-1">{appointmentStats.completed}</p>
                     </div>
                     <CheckCircle className="w-8 h-8 text-green-500 opacity-20" />
                   </div>
                 </div>
-                <div className="bg-white rounded-lg border border-gray-200 p-4 shadow-sm">
+                <div className="rounded-xl border border-border bg-card p-4 shadow-sm">
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-xs text-gray-500 font-medium">Cancelado</p>
+                      <p className="text-xs text-muted-foreground font-medium">Cancelado</p>
                       <p className="text-2xl font-bold text-red-600 mt-1">{appointmentStats.cancelled}</p>
                     </div>
                     <XCircle className="w-8 h-8 text-red-500 opacity-20" />
@@ -190,7 +195,7 @@ export default function AppointmentsPage() {
               <select
                 value={statusFilter}
                 onChange={(e) => setStatusFilter(e.target.value)}
-                className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+                className="px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-card text-foreground"
               >
                 <option value="">Todos os status</option>
                 <option value="PENDING">Pendente</option>
@@ -201,152 +206,129 @@ export default function AppointmentsPage() {
             </div>
 
             {filteredAppointments.length === 0 ? (
-              <div className="text-center py-12">
-                <Calendar className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-                <p className="text-gray-500">
-                  {statusFilter
-                    ? `Nenhuma consulta com status "${statusFilter}"`
-                    : 'Nenhuma consulta encontrada'}
-                </p>
-              </div>
+              <DataTableCard>
+                <DataTableEmpty
+                  icon={<Calendar className="h-8 w-8" />}
+                  title={
+                    statusFilter
+                      ? `Nenhuma consulta com status "${statusFilter}"`
+                      : 'Nenhuma consulta encontrada'
+                  }
+                />
+              </DataTableCard>
             ) : isMobile ? (
-              <div className="space-y-3">
-                {filteredAppointments.map((appointment: any) => (
-                  <div
-                    key={appointment.id}
-                    className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
-                  >
-                    <div className="flex justify-between items-start mb-3">
-                      <div>
-                        <h3 className="font-medium text-gray-900 text-sm">
-                          {appointment.patient?.name ||
-                            appointment.patient?.email ||
-                            'Paciente'}
-                        </h3>
-                        <p className="text-xs text-gray-500">
-                          {appointment.professional?.name ||
-                            appointment.professional?.email ||
-                            'Profissional'}
-                        </p>
-                      </div>
-                      <StatusBadge
-                        status={appointment.status || 'PENDING'}
-                        type="appointment"
-                      />
-                    </div>
-
-                    <div className="space-y-2 mb-3">
-                      <div className="flex items-center gap-2 text-xs text-gray-600">
-                        <Calendar className="w-4 h-4" />
-                        {new Date(appointment.dateTime).toLocaleDateString('pt-BR')}
-                      </div>
-                      <div className="flex items-center gap-2 text-xs text-gray-600">
-                        <Clock className="w-4 h-4" />
-                        {new Date(appointment.dateTime).toLocaleTimeString('pt-BR', {
-                          hour: '2-digit',
-                          minute: '2-digit',
-                        })}
-                      </div>
-                    </div>
-
-                    {(appointment.scheduledByManager?.user?.name ||
-                      appointment.cancelledByManager) && (
-                      <div className="bg-slate-50 rounded p-2 mb-3 text-xs space-y-1 border border-gray-200">
-                        {appointment.scheduledByManager?.user?.name && (
-                          <p className="text-gray-600">
-                            Agendado por:{' '}
-                            <span className="font-medium">
-                              {appointment.scheduledByManager.user.name}
-                            </span>
+              <DataTableCard>
+                <DataTableMobileList>
+                  {sortedAppointments.map((appointment: any) => (
+                    <DataTableMobileItem key={appointment.id}>
+                      <div className="flex justify-between items-start mb-3">
+                        <div className="min-w-0">
+                          <h3 className="font-medium text-foreground text-sm truncate">
+                            {appointment.patient?.name ||
+                              appointment.patient?.email ||
+                              'Paciente'}
+                          </h3>
+                          <p className="text-xs text-muted-foreground truncate">
+                            {appointment.professional?.name ||
+                              appointment.professional?.email ||
+                              'Profissional'}
                           </p>
-                        )}
-                        {appointment.cancelledByManager && (
-                          <p className="text-red-600">
-                            Cancelado por:{' '}
-                            <span className="font-medium">
-                              {appointment.cancelledByManager.user?.name}
-                            </span>
-                          </p>
-                        )}
+                        </div>
+                        <StatusBadge
+                          status={appointment.status || 'PENDING'}
+                          type="appointment"
+                        />
                       </div>
-                    )}
 
-                    {appointment.status !== 'CANCELLED' && (
-                      <button
-                        onClick={() => handleCancelClick(appointment.id)}
-                        disabled={cancelMutation.isPending}
-                        className="w-full px-3 py-2 text-sm text-red-600 border border-red-200 hover:bg-red-50 rounded transition disabled:opacity-50"
-                      >
-                        Cancelar
-                      </button>
-                    )}
-                  </div>
-                ))}
-              </div>
+                      <div className="space-y-2 mb-3">
+                        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                          <Calendar className="w-4 h-4" />
+                          {new Date(appointment.dateTime).toLocaleDateString('pt-BR')}
+                        </div>
+                        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                          <Clock className="w-4 h-4" />
+                          {new Date(appointment.dateTime).toLocaleTimeString('pt-BR', {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                          })}
+                        </div>
+                      </div>
+
+                      {(appointment.scheduledByManager?.user?.name ||
+                        appointment.cancelledByManager) && (
+                        <div className="rounded p-2 mb-3 text-xs space-y-1 border border-border bg-muted/30">
+                          {appointment.scheduledByManager?.user?.name && (
+                            <p className="text-muted-foreground">
+                              Agendado por:{' '}
+                              <span className="font-medium text-foreground">
+                                {appointment.scheduledByManager.user.name}
+                              </span>
+                            </p>
+                          )}
+                          {appointment.cancelledByManager && (
+                            <p className="text-red-600">
+                              Cancelado por:{' '}
+                              <span className="font-medium">
+                                {appointment.cancelledByManager.user?.name}
+                              </span>
+                            </p>
+                          )}
+                        </div>
+                      )}
+
+                      {appointment.status !== 'CANCELLED' && (
+                        <button
+                          onClick={() => handleCancelClick(appointment.id)}
+                          disabled={cancelMutation.isPending}
+                          className="w-full px-3 py-2 text-sm text-red-600 border border-red-200 hover:bg-red-50 rounded transition disabled:opacity-50"
+                        >
+                          Cancelar
+                        </button>
+                      )}
+                    </DataTableMobileItem>
+                  ))}
+                </DataTableMobileList>
+              </DataTableCard>
             ) : (
-              <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-                <table className="w-full">
-                  <thead className="bg-slate-50 border-b border-gray-200">
-                    <tr>
-                      <th
-                        className="px-6 py-3 text-left text-sm font-semibold text-gray-900 cursor-pointer select-none"
-                        onClick={() => toggleSort('patient')}
-                        title="Ordenar por paciente"
-                      >
-                        Paciente <SortIcon field="patient" />
-                      </th>
-                      <th
-                        className="px-6 py-3 text-left text-sm font-semibold text-gray-900 cursor-pointer select-none"
-                        onClick={() => toggleSort('professional')}
-                        title="Ordenar por profissional"
-                      >
-                        Profissional <SortIcon field="professional" />
-                      </th>
-                      <th
-                        className="px-6 py-3 text-left text-sm font-semibold text-gray-900 cursor-pointer select-none"
-                        onClick={() => toggleSort('dateTime')}
-                        title="Ordenar por data/hora"
-                      >
-                        Data/Hora <SortIcon field="dateTime" />
-                      </th>
-                      <th
-                        className="px-6 py-3 text-left text-sm font-semibold text-gray-900 cursor-pointer select-none"
-                        onClick={() => toggleSort('scheduledBy')}
-                        title="Ordenar por agendado por"
-                      >
-                        Agendado por <SortIcon field="scheduledBy" />
-                      </th>
-                      <th
-                        className="px-6 py-3 text-left text-sm font-semibold text-gray-900 cursor-pointer select-none"
-                        onClick={() => toggleSort('status')}
-                        title="Ordenar por status"
-                      >
-                        Status <SortIcon field="status" />
-                      </th>
-                      <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">
-                        Ações
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-200">
+              <DataTableCard>
+                <DataTable>
+                  <DataTableHead>
+                    <SortableHeader field="patient" currentField={sortField} direction={sortDir} onToggle={toggleSort}>
+                      Paciente
+                    </SortableHeader>
+                    <SortableHeader field="professional" currentField={sortField} direction={sortDir} onToggle={toggleSort}>
+                      Profissional
+                    </SortableHeader>
+                    <SortableHeader field="dateTime" currentField={sortField} direction={sortDir} onToggle={toggleSort}>
+                      Data/Hora
+                    </SortableHeader>
+                    <SortableHeader field="scheduledBy" currentField={sortField} direction={sortDir} onToggle={toggleSort}>
+                      Agendado por
+                    </SortableHeader>
+                    <SortableHeader field="status" currentField={sortField} direction={sortDir} onToggle={toggleSort}>
+                      Status
+                    </SortableHeader>
+                    <DataTableHeadCell>Ações</DataTableHeadCell>
+                  </DataTableHead>
+                  <DataTableBody>
                     {sortedAppointments.map((appointment: any) => (
-                      <tr key={appointment.id} className="hover:bg-slate-50 transition">
-                        <td className="px-6 py-4 text-sm font-medium text-gray-900">
+                      <DataTableRow key={appointment.id}>
+                        <DataTableCell className="font-medium text-foreground">
                           {appointment.patient?.name ||
                             appointment.patient?.email ||
                             '-'}
-                        </td>
-                        <td className="px-6 py-4 text-sm text-gray-600">
+                        </DataTableCell>
+                        <DataTableCell>
                           {appointment.professional?.name ||
                             appointment.professional?.email ||
                             '-'}
-                        </td>
-                        <td className="px-6 py-4 text-sm text-gray-600">
+                        </DataTableCell>
+                        <DataTableCell>
                           {new Date(appointment.dateTime).toLocaleString('pt-BR')}
-                        </td>
-                        <td className="px-6 py-4 text-sm">
+                        </DataTableCell>
+                        <DataTableCell>
                           <div className="space-y-1">
-                            <p className="text-gray-900">
+                            <p className="text-foreground">
                               {appointment.scheduledByManager?.user?.name || '-'}
                             </p>
                             {appointment.cancelledByManager && (
@@ -356,14 +338,14 @@ export default function AppointmentsPage() {
                               </p>
                             )}
                           </div>
-                        </td>
-                        <td className="px-6 py-4 text-sm">
+                        </DataTableCell>
+                        <DataTableCell>
                           <StatusBadge
                             status={appointment.status || 'PENDING'}
                             type="appointment"
                           />
-                        </td>
-                        <td className="px-6 py-4 text-sm">
+                        </DataTableCell>
+                        <DataTableCell>
                           {appointment.status !== 'CANCELLED' && (
                             <button
                               onClick={() => handleCancelClick(appointment.id)}
@@ -374,12 +356,12 @@ export default function AppointmentsPage() {
                               Cancelar
                             </button>
                           )}
-                        </td>
-                      </tr>
+                        </DataTableCell>
+                      </DataTableRow>
                     ))}
-                  </tbody>
-                </table>
-              </div>
+                  </DataTableBody>
+                </DataTable>
+              </DataTableCard>
             )}
           </>
         )}

--- a/apps/web/app/dashboard/manager/patients/page.tsx
+++ b/apps/web/app/dashboard/manager/patients/page.tsx
@@ -10,7 +10,27 @@ import { LoadingPage } from '@/components/shared/LoadingPage';
 import { EmptyState } from '@/components/shared/EmptyState';
 import { PageHeader } from '@/components/shared/PageHeader';
 import { formatPhoneNumber } from '@/app/utils/formatPhone';
-import { Search, Users, UserCheck, ClipboardCheck, ClipboardList, ArrowUpDown, ArrowUp, ArrowDown, X } from 'lucide-react';
+import {
+  DataTable,
+  DataTableBody,
+  DataTableCard,
+  DataTableCell,
+  DataTableEmpty,
+  DataTableHead,
+  DataTableHeadCell,
+  DataTableMobileItem,
+  DataTableMobileList,
+  DataTableRow,
+  SortableHeader,
+} from '@/components/ui/data-table';
+import {
+  Search,
+  Users,
+  UserCheck,
+  ClipboardCheck,
+  ClipboardList,
+  X,
+} from 'lucide-react';
 
 type SortField = 'name' | 'email' | 'phone' | 'dateOfBirth' | 'gender' | 'questionnaire';
 type SortDir = 'asc' | 'desc';
@@ -129,14 +149,6 @@ export default function PatientsPage() {
     });
   }, [filteredPatients, sortField, sortDir]);
 
-  function SortIcon({ field }: { field: SortField }) {
-    if (sortField !== field)
-      return <ArrowUpDown className="ml-1.5 inline h-3.5 w-3.5 text-gray-400" />;
-    return sortDir === 'asc'
-      ? <ArrowUp className="ml-1.5 inline h-3.5 w-3.5 text-gray-900" />
-      : <ArrowDown className="ml-1.5 inline h-3.5 w-3.5 text-gray-900" />;
-  }
-
   function handleSearch(value: string) {
     const params = new URLSearchParams(searchParams.toString());
     if (value) {
@@ -169,7 +181,7 @@ export default function PatientsPage() {
         <PageHeader
           title="Pacientes"
           action={{
-            label: "+ Novo Paciente",
+            label: '+ Novo Paciente',
             href: '/dashboard/manager/patients/new',
             colorClass: 'bg-green-600 hover:bg-green-700',
           }}
@@ -177,37 +189,37 @@ export default function PatientsPage() {
 
         {patients.length > 0 && (
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 mb-6">
-            <div className="bg-white rounded-lg border border-gray-200 p-4 shadow-sm">
+            <div className="rounded-xl border border-border bg-card p-4 shadow-sm">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-xs text-gray-500 font-medium">Total</p>
-                  <p className="text-2xl font-bold text-gray-900 mt-1">{stats.total}</p>
+                  <p className="text-xs text-muted-foreground font-medium">Total</p>
+                  <p className="text-2xl font-bold text-foreground mt-1">{stats.total}</p>
                 </div>
                 <Users className="w-7 h-7 text-blue-500 opacity-25" />
               </div>
             </div>
-            <div className="bg-white rounded-lg border border-gray-200 p-4 shadow-sm">
+            <div className="rounded-xl border border-border bg-card p-4 shadow-sm">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-xs text-gray-500 font-medium">Ativos</p>
+                  <p className="text-xs text-muted-foreground font-medium">Ativos</p>
                   <p className="text-2xl font-bold text-emerald-600 mt-1">{stats.active}</p>
                 </div>
                 <UserCheck className="w-7 h-7 text-emerald-500 opacity-25" />
               </div>
             </div>
-            <div className="bg-white rounded-lg border border-gray-200 p-4 shadow-sm">
+            <div className="rounded-xl border border-border bg-card p-4 shadow-sm">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-xs text-gray-500 font-medium">Com questionário</p>
+                  <p className="text-xs text-muted-foreground font-medium">Com questionário</p>
                   <p className="text-2xl font-bold text-blue-600 mt-1">{stats.withQuestionnaire}</p>
                 </div>
                 <ClipboardCheck className="w-7 h-7 text-blue-500 opacity-25" />
               </div>
             </div>
-            <div className="bg-white rounded-lg border border-gray-200 p-4 shadow-sm">
+            <div className="rounded-xl border border-border bg-card p-4 shadow-sm">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-xs text-gray-500 font-medium">Sem questionário</p>
+                  <p className="text-xs text-muted-foreground font-medium">Sem questionário</p>
                   <p className="text-2xl font-bold text-amber-600 mt-1">{stats.withoutQuestionnaire}</p>
                 </div>
                 <ClipboardList className="w-7 h-7 text-amber-500 opacity-25" />
@@ -218,20 +230,20 @@ export default function PatientsPage() {
 
         <div className="mb-6">
           <div className="relative">
-            <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5 pointer-events-none" />
+            <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground w-5 h-5 pointer-events-none" />
             <input
               type="text"
               placeholder="Buscar paciente por nome..."
               defaultValue={searchTerm}
               onChange={(e) => handleSearch(e.target.value)}
-              className="w-full pl-12 pr-12 py-3 border border-gray-200 rounded-xl text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition bg-white placeholder:text-gray-400"
+              className="w-full pl-12 pr-12 py-3 border border-border rounded-xl text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition bg-card placeholder:text-muted-foreground"
               aria-label="Buscar paciente por nome"
             />
             {searchTerm && (
               <button
                 type="button"
                 onClick={() => handleSearch('')}
-                className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-1 text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition"
+                className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground hover:text-foreground hover:bg-muted transition"
                 aria-label="Limpar busca"
                 title="Limpar busca"
               >
@@ -240,22 +252,22 @@ export default function PatientsPage() {
             )}
           </div>
           {searchTerm && (
-            <p className="mt-2 text-xs text-gray-500">
+            <p className="mt-2 text-xs text-muted-foreground">
               {filteredPatients.length}{' '}
               {filteredPatients.length === 1 ? 'resultado' : 'resultados'} para{' '}
-              <span className="font-medium text-gray-700">&quot;{searchTerm}&quot;</span>
+              <span className="font-medium text-foreground">&quot;{searchTerm}&quot;</span>
             </p>
           )}
         </div>
 
         {filteredPatients.length === 0 ? (
           searchTerm ? (
-            <div className="text-center py-12">
-              <Users className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-              <p className="text-gray-500 text-sm">
-                Nenhum paciente encontrado para &quot;{searchTerm}&quot;
-              </p>
-            </div>
+            <DataTableCard>
+              <DataTableEmpty
+                icon={<Users className="h-8 w-8" />}
+                title={`Nenhum paciente encontrado para "${searchTerm}"`}
+              />
+            </DataTableCard>
           ) : (
             <EmptyState
               message="Nenhum paciente cadastrado"
@@ -264,138 +276,107 @@ export default function PatientsPage() {
             />
           )
         ) : isMobile ? (
-          <div className="space-y-3">
-            {sortedPatients.map((patient) => (
-              <div
-                key={patient.id}
-                className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm hover:shadow-md transition"
-              >
-                <div className="flex gap-3 mb-3">
-                  <div
-                    className={`${getAvatarColor(patient.name)} w-12 h-12 rounded-full flex items-center justify-center text-white font-semibold text-sm flex-shrink-0`}
-                  >
-                    {getInitials(patient.name)}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <h3 className="font-medium text-gray-900 truncate">
-                      {patient.name}
-                    </h3>
-                    <p className="text-xs text-gray-500 truncate">{patient.email}</p>
-                  </div>
-                  {patient.patientProfile?.questionnaire ? (
-                    <span className="inline-flex items-center gap-1 self-start rounded-full bg-blue-50 text-blue-700 border border-blue-200 px-2 py-0.5 text-[10px] font-medium flex-shrink-0">
-                      <ClipboardCheck className="w-3 h-3" />
-                      Respondido
-                    </span>
-                  ) : (
-                    <span className="inline-flex items-center gap-1 self-start rounded-full bg-amber-50 text-amber-700 border border-amber-200 px-2 py-0.5 text-[10px] font-medium flex-shrink-0">
-                      <ClipboardList className="w-3 h-3" />
-                      Pendente
-                    </span>
-                  )}
-                </div>
-                <div className="space-y-1.5 mb-3">
-                  {patient.patientProfile?.phone && (
-                    <p className="text-xs text-gray-600">
-                      <span className="font-medium">Tel:</span> {patient.patientProfile.phone}
-                    </p>
-                  )}
-                  {patient.patientProfile?.dateOfBirth && (
-                    <p className="text-xs text-gray-600">
-                      <span className="font-medium">Nascimento:</span>{' '}
-                      {new Date(patient.patientProfile.dateOfBirth).toLocaleDateString(
-                        'pt-BR',
-                      )}
-                    </p>
-                  )}
-                </div>
-                <Link
-                  href={`/dashboard/manager/patients/${patient.id}`}
-                  className="text-sm text-blue-600 hover:text-blue-700 font-medium"
+          <DataTableCard>
+            <DataTableMobileList>
+              {sortedPatients.map((patient) => (
+                <DataTableMobileItem
+                  key={patient.id}
+                  onClick={() => router.push(`/dashboard/manager/patients/${patient.id}`)}
+                  title={`Ver detalhes de ${patient.name}`}
                 >
-                  Ver Detalhes →
-                </Link>
-              </div>
-            ))}
-          </div>
+                  <div className="flex gap-3 mb-3">
+                    <div
+                      className={`${getAvatarColor(patient.name)} w-12 h-12 rounded-full flex items-center justify-center text-white font-semibold text-sm flex-shrink-0`}
+                    >
+                      {getInitials(patient.name)}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <h3 className="font-medium text-foreground truncate">
+                        {patient.name}
+                      </h3>
+                      <p className="text-xs text-muted-foreground truncate">{patient.email}</p>
+                    </div>
+                    {patient.patientProfile?.questionnaire ? (
+                      <span className="inline-flex items-center gap-1 self-start rounded-full bg-blue-50 text-blue-700 border border-blue-200 px-2 py-0.5 text-[10px] font-medium flex-shrink-0">
+                        <ClipboardCheck className="w-3 h-3" />
+                        Respondido
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1 self-start rounded-full bg-amber-50 text-amber-700 border border-amber-200 px-2 py-0.5 text-[10px] font-medium flex-shrink-0">
+                        <ClipboardList className="w-3 h-3" />
+                        Pendente
+                      </span>
+                    )}
+                  </div>
+                  <div className="space-y-1.5">
+                    {patient.patientProfile?.phone && (
+                      <p className="text-xs text-muted-foreground">
+                        <span className="font-medium">Tel:</span> {patient.patientProfile.phone}
+                      </p>
+                    )}
+                    {patient.patientProfile?.dateOfBirth && (
+                      <p className="text-xs text-muted-foreground">
+                        <span className="font-medium">Nascimento:</span>{' '}
+                        {new Date(patient.patientProfile.dateOfBirth).toLocaleDateString(
+                          'pt-BR',
+                        )}
+                      </p>
+                    )}
+                  </div>
+                </DataTableMobileItem>
+              ))}
+            </DataTableMobileList>
+          </DataTableCard>
         ) : (
-          <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-            <table className="w-full">
-              <thead className="bg-slate-50 border-b border-gray-200">
-                <tr>
-                  <th
-                    className="px-6 py-3 text-left text-sm font-semibold text-gray-900 cursor-pointer select-none"
-                    onClick={() => toggleSort('name')}
-                    title="Ordenar por nome"
-                  >
-                    Nome <SortIcon field="name" />
-                  </th>
-                  <th
-                    className="px-6 py-3 text-left text-sm font-semibold text-gray-900 cursor-pointer select-none"
-                    onClick={() => toggleSort('email')}
-                    title="Ordenar por email"
-                  >
-                    Email <SortIcon field="email" />
-                  </th>
-                  <th
-                    className="px-6 py-3 text-left text-sm font-semibold text-gray-900 cursor-pointer select-none"
-                    onClick={() => toggleSort('phone')}
-                    title="Ordenar por telefone"
-                  >
-                    Telefone <SortIcon field="phone" />
-                  </th>
-                  <th
-                    className="px-6 py-3 text-left text-sm font-semibold text-gray-900 cursor-pointer select-none"
-                    onClick={() => toggleSort('dateOfBirth')}
-                    title="Ordenar por data de nascimento"
-                  >
-                    Data de Nascimento <SortIcon field="dateOfBirth" />
-                  </th>
-                  <th
-                    className="px-6 py-3 text-left text-sm font-semibold text-gray-900 cursor-pointer select-none"
-                    onClick={() => toggleSort('gender')}
-                    title="Ordenar por gênero"
-                  >
-                    Gênero <SortIcon field="gender" />
-                  </th>
-                  <th
-                    className="px-6 py-3 text-left text-sm font-semibold text-gray-900 cursor-pointer select-none"
-                    onClick={() => toggleSort('questionnaire')}
-                    title="Ordenar por questionário"
-                  >
-                    Questionário <SortIcon field="questionnaire" />
-                  </th>
-                  <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">
-                    Ações
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200">
+          <DataTableCard>
+            <DataTable>
+              <DataTableHead>
+                <SortableHeader field="name" currentField={sortField} direction={sortDir} onToggle={toggleSort}>
+                  Nome
+                </SortableHeader>
+                <SortableHeader field="email" currentField={sortField} direction={sortDir} onToggle={toggleSort}>
+                  Email
+                </SortableHeader>
+                <SortableHeader field="phone" currentField={sortField} direction={sortDir} onToggle={toggleSort}>
+                  Telefone
+                </SortableHeader>
+                <SortableHeader field="dateOfBirth" currentField={sortField} direction={sortDir} onToggle={toggleSort}>
+                  Data de Nascimento
+                </SortableHeader>
+                <SortableHeader field="gender" currentField={sortField} direction={sortDir} onToggle={toggleSort}>
+                  Gênero
+                </SortableHeader>
+                <SortableHeader field="questionnaire" currentField={sortField} direction={sortDir} onToggle={toggleSort}>
+                  Questionário
+                </SortableHeader>
+                <DataTableHeadCell>Ações</DataTableHeadCell>
+              </DataTableHead>
+              <DataTableBody>
                 {sortedPatients.map((patient) => (
-                  <tr key={patient.id} className="hover:bg-slate-50 transition">
-                    <td className="px-6 py-4 text-sm">
+                  <DataTableRow key={patient.id}>
+                    <DataTableCell>
                       <div className="flex items-center gap-3">
                         <div
                           className={`${getAvatarColor(patient.name)} w-10 h-10 rounded-full flex items-center justify-center text-white font-semibold text-xs`}
                         >
                           {getInitials(patient.name)}
                         </div>
-                        <span className="font-medium text-gray-900">{patient.name}</span>
+                        <span className="font-medium text-foreground">{patient.name}</span>
                       </div>
-                    </td>
-                    <td className="px-6 py-4 text-sm text-gray-600">{patient.email}</td>
-                    <td className="px-6 py-4 text-sm text-gray-600">
+                    </DataTableCell>
+                    <DataTableCell>{patient.email}</DataTableCell>
+                    <DataTableCell>
                       {formatPhoneNumber(patient.patientProfile?.phone) || '-'}
-                    </td>
-                    <td className="px-6 py-4 text-sm text-gray-600">
+                    </DataTableCell>
+                    <DataTableCell>
                       {patient.patientProfile?.dateOfBirth
                         ? formatLocalDate(patient.patientProfile.dateOfBirth)
                         : '-'}
-                    </td>
-                    <td className="px-6 py-4 text-sm text-gray-600">
+                    </DataTableCell>
+                    <DataTableCell>
                       {patient.patientProfile?.gender ?? '-'}
-                    </td>
-                    <td className="px-6 py-4 text-sm">
+                    </DataTableCell>
+                    <DataTableCell>
                       {patient.patientProfile?.questionnaire ? (
                         <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 text-blue-700 border border-blue-200 px-2 py-0.5 text-xs font-medium">
                           <ClipboardCheck className="w-3 h-3" />
@@ -407,20 +388,20 @@ export default function PatientsPage() {
                           Pendente
                         </span>
                       )}
-                    </td>
-                    <td className="px-6 py-4 text-sm">
+                    </DataTableCell>
+                    <DataTableCell>
                       <Link
                         href={`/dashboard/manager/patients/${patient.id}`}
                         className="text-blue-600 hover:text-blue-700 font-medium transition"
                       >
                         Ver Detalhes
                       </Link>
-                    </td>
-                  </tr>
+                    </DataTableCell>
+                  </DataTableRow>
                 ))}
-              </tbody>
-            </table>
-          </div>
+              </DataTableBody>
+            </DataTable>
+          </DataTableCard>
         )}
       </div>
     </div>

--- a/apps/web/components/ui/data-table.tsx
+++ b/apps/web/components/ui/data-table.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import * as React from "react";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Spinner } from "@/components/ui/spinner";
+
+export function DataTableCard({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "w-full rounded-xl border border-border bg-card shadow-sm overflow-hidden",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DataTableHeader({
+  title,
+  count,
+  actions,
+}: {
+  title: string;
+  count?: number;
+  actions?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-4 sm:px-6">
+      <div className="flex items-center gap-2 min-w-0">
+        <h2 className="text-base font-semibold text-foreground truncate">{title}</h2>
+        {typeof count === "number" && (
+          <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+            {count}
+          </span>
+        )}
+      </div>
+      {actions && <div className="shrink-0">{actions}</div>}
+    </div>
+  );
+}
+
+export function DataTableToolbar({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-2 border-b border-border bg-muted/30 px-4 py-3 sm:px-6 sm:gap-3",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DataTable({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className="relative w-full overflow-x-auto">
+      <table className={cn("w-full text-sm", className)}>{children}</table>
+    </div>
+  );
+}
+
+export function DataTableHead({ children }: { children: React.ReactNode }) {
+  return (
+    <thead className="border-b border-border bg-muted/30 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+      <tr>{children}</tr>
+    </thead>
+  );
+}
+
+export function DataTableBody({ children }: { children: React.ReactNode }) {
+  return <tbody>{children}</tbody>;
+}
+
+export function DataTableRow({
+  className,
+  onClick,
+  title,
+  children,
+}: {
+  className?: string;
+  onClick?: () => void;
+  title?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <tr
+      onClick={onClick}
+      title={title}
+      className={cn(
+        "transition-colors hover:bg-muted/30",
+        onClick && "cursor-pointer",
+        className,
+      )}
+    >
+      {children}
+    </tr>
+  );
+}
+
+type SortDir = "asc" | "desc";
+
+export function SortableHeader<F extends string>({
+  field,
+  currentField,
+  direction,
+  onToggle,
+  align = "left",
+  className,
+  children,
+}: {
+  field: F;
+  currentField: F | null;
+  direction: SortDir;
+  onToggle: (field: F) => void;
+  align?: "left" | "center" | "right";
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const isActive = currentField === field;
+  const alignClass =
+    align === "center" ? "text-center" : align === "right" ? "text-right" : "text-left";
+  return (
+    <th
+      onClick={() => onToggle(field)}
+      title={typeof children === "string" ? `Ordenar por ${children}` : "Ordenar"}
+      className={cn(
+        "px-6 py-3 cursor-pointer select-none align-middle",
+        alignClass,
+        className,
+      )}
+    >
+      <span className="inline-flex items-center">
+        {children}
+        {!isActive && (
+          <ArrowUpDown className="ml-1.5 inline h-3.5 w-3.5 text-muted-foreground/50" />
+        )}
+        {isActive && direction === "asc" && (
+          <ArrowUp className="ml-1.5 inline h-3.5 w-3.5 text-foreground" />
+        )}
+        {isActive && direction === "desc" && (
+          <ArrowDown className="ml-1.5 inline h-3.5 w-3.5 text-foreground" />
+        )}
+      </span>
+    </th>
+  );
+}
+
+export function DataTableHeadCell({
+  align = "left",
+  className,
+  children,
+}: {
+  align?: "left" | "center" | "right";
+  className?: string;
+  children?: React.ReactNode;
+}) {
+  const alignClass =
+    align === "center" ? "text-center" : align === "right" ? "text-right" : "text-left";
+  return (
+    <th className={cn("px-6 py-3 align-middle", alignClass, className)}>{children}</th>
+  );
+}
+
+export function DataTableCell({
+  align = "left",
+  className,
+  onClick,
+  children,
+}: {
+  align?: "left" | "center" | "right";
+  className?: string;
+  onClick?: (e: React.MouseEvent) => void;
+  children?: React.ReactNode;
+}) {
+  const alignClass =
+    align === "center" ? "text-center" : align === "right" ? "text-right" : "text-left";
+  return (
+    <td
+      onClick={onClick}
+      className={cn("px-6 py-3.5 align-middle text-sm text-muted-foreground", alignClass, className)}
+    >
+      {children}
+    </td>
+  );
+}
+
+export function DataTableLoading({ message = "Carregando..." }: { message?: string }) {
+  return (
+    <div className="flex items-center justify-center gap-3 py-16">
+      <Spinner size="sm" />
+      <p className="text-sm text-muted-foreground">{message}</p>
+    </div>
+  );
+}
+
+export function DataTableEmpty({
+  icon,
+  title,
+  description,
+  action,
+}: {
+  icon?: React.ReactNode;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-16 text-center px-4">
+      {icon && <div className="rounded-full bg-muted p-4 text-muted-foreground/50">{icon}</div>}
+      <div>
+        <p className="text-sm font-medium text-foreground">{title}</p>
+        {description && (
+          <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
+        )}
+      </div>
+      {action && <div className="mt-1">{action}</div>}
+    </div>
+  );
+}
+
+export function DataTableMobileList({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <div className={cn("p-3 space-y-2", className)}>{children}</div>;
+}
+
+export function DataTableMobileItem({
+  className,
+  onClick,
+  title,
+  children,
+}: {
+  className?: string;
+  onClick?: () => void;
+  title?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      onClick={onClick}
+      title={title}
+      className={cn(
+        "rounded-lg border border-border bg-card px-4 py-3 transition-colors hover:bg-muted/30",
+        onClick && "cursor-pointer active:bg-muted/40",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #154

## Summary

- Cria primitivos `DataTable` em `apps/web/components/ui/data-table.tsx` (Card, Header, Toolbar, Head/Body/Row/Cell, `SortableHeader`, `Empty`, `Loading`, `MobileList/Item`) consolidando o padrão visual a partir da `UsersTable` (a mais moderna)
- Aplica o padrão nas 4 tabelas existentes — `admin/UsersTable`, `admin/SpecialityTable`, `manager/patients`, `manager/appointments` — preservando 100% das funcionalidades: ordenação por coluna, busca com Fuse, filtros (tabs/select), ações por linha e responsividade
- **Remove os divisores entre linhas** (`border-b`/`divide-y`) por preferência visual — tabelas mais limpas, hover é o único feedback de linha
- Padroniza cores via tokens do design system (`bg-card`, `border-border`, `text-foreground`, `text-muted-foreground`, `bg-muted/30`) substituindo hex literais (`bg-white`, `gray-200`, `slate-50`) nos stats cards e em wrappers de tabela

## Test plan
- [ ] `/dashboard/admin` (UsersTable): tabs Todos/Pacientes/Profissionais/Gestores filtram, busca por nome/email funciona, sort em todas as colunas, ações (ver/aprovar/bloquear/editar) funcionam, mobile renderiza cards
- [ ] `/dashboard/admin/specialidades`: criar/editar/excluir funciona, sort por nome funciona, empty state aparece sem especialidades, mobile renderiza cards
- [ ] `/dashboard/manager/patients`: busca Fuse por nome funciona, sort em todas as colunas, "Ver Detalhes" navega, stats cards renderizam, mobile renderiza cards clicáveis
- [ ] `/dashboard/manager/appointments`: filtro de status funciona, sort em todas as colunas, cancelamento abre dialog, mobile renderiza cards
- [ ] Visual: tabelas sem linhas pretas entre itens; cabeçalhos uniformes (uppercase, `bg-muted/30`); hover `bg-muted/30` consistente