### PR TITLE
fix(web): fechar gaps de responsividade mobile (#157)

### DIFF
--- a/apps/web/app/auth/register/components/PatientFields.tsx
+++ b/apps/web/app/auth/register/components/PatientFields.tsx
@@ -18,7 +18,7 @@ export function PatientFields({ register, control, errors, isLoading, onCpfChang
   return (
     <>
       {/* CPF + Celular */}
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="cpf" className="text-sm font-semibold text-[#374151]">CPF</Label>
           <Input
@@ -54,7 +54,7 @@ export function PatientFields({ register, control, errors, isLoading, onCpfChang
       </div>
 
       {/* Data de nascimento + Gênero */}
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="dateOfBirth" className="text-sm font-semibold text-[#374151]">Data de nascimento</Label>
           <input

--- a/apps/web/app/auth/register/components/ProfessionalFields.tsx
+++ b/apps/web/app/auth/register/components/ProfessionalFields.tsx
@@ -23,7 +23,7 @@ export function ProfessionalFields({
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="cpf" className="text-sm font-semibold text-[#374151]">CPF</Label>
           <Input
@@ -54,7 +54,7 @@ export function ProfessionalFields({
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="modality" className="text-sm font-semibold text-[#374151]">Modalidade de atendimento</Label>
           <select
@@ -91,7 +91,7 @@ export function ProfessionalFields({
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="primarySpecialty" className="text-sm font-semibold text-[#374151]">
             Especialidade Principal

--- a/apps/web/app/auth/register/page.tsx
+++ b/apps/web/app/auth/register/page.tsx
@@ -83,7 +83,7 @@ const RegisterPage = () => {
         </div>
 
         {/* Nome + E-mail em grid */}
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="name" className="text-sm font-semibold text-[#374151]">Nome completo</Label>
             <Input 
@@ -127,7 +127,7 @@ const RegisterPage = () => {
         )}
 
         {/* Senhas em grid */}
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <PasswordField
             name="password"
             label="Senha"

--- a/apps/web/app/dashboard/admin/components/SpecialityTable.tsx
+++ b/apps/web/app/dashboard/admin/components/SpecialityTable.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input";
 import { useCreateSpeciality } from "@/queries/useCreateSpeciality";
 import { useUpdateSpeciality } from "@/queries/useUpdateSpeciality";
 import { useDeleteSpeciality } from "@/queries/useDeleteSpeciality";
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { useIsMobile, useMounted } from "@/hooks/useIsMobile";
 import { Stethoscope, Plus, Pencil, Trash2 } from "lucide-react";
 import {
   DataTable,
@@ -37,6 +37,7 @@ interface SpecialitiesTableProps {
 
 export const SpecialitiesTable = ({ specialities }: SpecialitiesTableProps) => {
   const isMobile = useIsMobile();
+  const mounted = useMounted();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [newSpecialityName, setNewSpecialityName] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -118,7 +119,9 @@ export const SpecialitiesTable = ({ specialities }: SpecialitiesTableProps) => {
           }
         />
 
-        {specialities.length === 0 ? (
+        {!mounted ? (
+          <div className="h-40" aria-hidden="true" />
+        ) : specialities.length === 0 ? (
           <DataTableEmpty
             icon={<Stethoscope className="h-8 w-8" />}
             title="Nenhuma especialidade"

--- a/apps/web/app/dashboard/admin/components/UsersTable.tsx
+++ b/apps/web/app/dashboard/admin/components/UsersTable.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/data-table";
 import { AdminUser } from "../../../../services/admin-service";
 import { useAdminUsersTable, TypeFilter } from "@/queries/useAdminUsersTable";
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { useIsMobile, useMounted } from "@/hooks/useIsMobile";
 import { Eye, Check, Ban, Pencil, Users } from "lucide-react";
 
 type SortField =
@@ -82,6 +82,7 @@ function getSpeciality(user: AdminUser) {
 function UsersTableInner({ onStatusChange, actions }: Props) {
   const router = useRouter();
   const isMobile = useIsMobile();
+  const mounted = useMounted();
   const { users, isLoading, search, setSearch, typeFilter, setTypeFilter } = useAdminUsersTable();
 
   const [sortField, setSortField] = useState<SortField | null>(null);
@@ -166,7 +167,7 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
         />
       </DataTableToolbar>
 
-      {isLoading ? (
+      {isLoading || !mounted ? (
         <DataTableLoading message="Carregando usuários..." />
       ) : sortedUsers.length === 0 ? (
         <DataTableEmpty

--- a/apps/web/app/dashboard/manager/appointments/new/components/ManagerBookingModal.tsx
+++ b/apps/web/app/dashboard/manager/appointments/new/components/ManagerBookingModal.tsx
@@ -400,7 +400,7 @@ export function ManagerBookingModal({
                     </div>
                   ) : availableSlots.length > 0 ? (
                     <div className="relative">
-                      <div className="grid grid-cols-4 sm:grid-cols-5 gap-2 max-h-56 overflow-y-auto p-3 bg-gray-50 rounded-lg border border-gray-200">
+                      <div className="grid grid-cols-2 sm:grid-cols-5 gap-2 max-h-56 overflow-y-auto p-3 bg-gray-50 rounded-lg border border-gray-200">
                         {availableSlots.map((slot) => {
                           const isSelected = selectedSlot === slot.time;
                           return (
@@ -478,7 +478,7 @@ export function ManagerBookingModal({
                   </span>
                 </div>
 
-                <div className="grid grid-cols-2 gap-x-6 gap-y-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3">
                   <div className="flex items-start gap-2.5">
                     <div className="w-8 h-8 rounded-lg bg-white border border-blue-100 flex items-center justify-center flex-shrink-0 mt-0.5">
                       <User size={14} className="text-blue-600" weight="duotone" />

--- a/apps/web/app/dashboard/manager/appointments/page.tsx
+++ b/apps/web/app/dashboard/manager/appointments/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from 'react';
 import { useListAppointmentsQuery } from '@/queries/useListAppointmentsQuery';
 import { useCancelAppointmentManagerMutation } from '@/queries/useCancelAppointmentManagerMutation';
-import { useIsMobile } from '@/hooks/useIsMobile';
+import { useIsMobile, useMounted } from '@/hooks/useIsMobile';
 import { LoadingPage } from '@/components/shared/LoadingPage';
 import { EmptyState } from '@/components/shared/EmptyState';
 import { PageHeader as SharedPageHeader } from '@/components/shared/PageHeader';
@@ -30,6 +30,7 @@ type SortDir = 'asc' | 'desc';
 
 export default function AppointmentsPage() {
   const isMobile = useIsMobile();
+  const mounted = useMounted();
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [selectedAppointmentId, setSelectedAppointmentId] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<string>('');
@@ -204,7 +205,9 @@ export default function AppointmentsPage() {
               </select>
             </div>
 
-            {filteredAppointments.length === 0 ? (
+            {!mounted ? (
+              <div className="h-40" aria-hidden="true" />
+            ) : filteredAppointments.length === 0 ? (
               <DataTableCard>
                 <DataTableEmpty
                   icon={<Calendar className="h-8 w-8" />}
@@ -289,7 +292,7 @@ export default function AppointmentsPage() {
                 </DataTableMobileList>
               </DataTableCard>
             ) : (
-              <DataTableCard>
+              <DataTableCard className="overflow-x-auto">
                 <DataTable>
                   <DataTableHead>
                     <SortableHeader field="patient" currentField={sortField} direction={sortDir} onToggle={toggleSort}>

--- a/apps/web/app/dashboard/manager/patients/[id]/page.tsx
+++ b/apps/web/app/dashboard/manager/patients/[id]/page.tsx
@@ -156,7 +156,7 @@ export default function PatientDetailsPage() {
           <CardContent className="p-8">
             <div className="flex justify-between items-start mb-6">
               <div>
-                <h1 className="text-3xl font-bold text-gray-900 mb-2">
+                <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
                   Detalhes do Paciente
                 </h1>
                 <p className="text-slate-600">

--- a/apps/web/app/dashboard/manager/patients/new/page.tsx
+++ b/apps/web/app/dashboard/manager/patients/new/page.tsx
@@ -72,7 +72,7 @@ export default function NewPatientPage() {
     <PageShell>
       <div className="max-w-2xl mx-auto">
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-6">
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-6">
             Cadastrar Novo Paciente
           </h1>
 

--- a/apps/web/app/dashboard/manager/patients/page.tsx
+++ b/apps/web/app/dashboard/manager/patients/page.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Fuse from 'fuse.js';
 import { useListPatientsQuery } from '@/queries/useListPatientsQuery';
-import { useIsMobile } from '@/hooks/useIsMobile';
+import { useIsMobile, useMounted } from '@/hooks/useIsMobile';
 import Link from 'next/link';
 import { LoadingPage } from '@/components/shared/LoadingPage';
 import { EmptyState } from '@/components/shared/EmptyState';
@@ -84,6 +84,7 @@ const formatLocalDate = (dateString: string) => {
 export default function PatientsPage() {
   const router = useRouter();
   const isMobile = useIsMobile();
+  const mounted = useMounted();
   const searchParams = useSearchParams();
   const searchTerm = searchParams.get('search') ?? '';
 
@@ -259,7 +260,9 @@ export default function PatientsPage() {
           )}
         </div>
 
-        {filteredPatients.length === 0 ? (
+        {!mounted ? (
+          <div className="h-40" aria-hidden="true" />
+        ) : filteredPatients.length === 0 ? (
           searchTerm ? (
             <DataTableCard>
               <DataTableEmpty
@@ -327,7 +330,7 @@ export default function PatientsPage() {
             </DataTableMobileList>
           </DataTableCard>
         ) : (
-          <DataTableCard>
+          <DataTableCard className="overflow-x-auto">
             <DataTable>
               <DataTableHead>
                 <SortableHeader field="name" currentField={sortField} direction={sortDir} onToggle={toggleSort}>

--- a/apps/web/app/dashboard/professional/page.tsx
+++ b/apps/web/app/dashboard/professional/page.tsx
@@ -210,7 +210,7 @@ const ProfessionalDashboard = () => {
             </div>
             {nextAppointment ? (
               <Card className="border-l-4 border-l-[#006fee]">
-                <CardContent className="p-6 flex flex-col md:flex-row md:justify-between md:items-center gap-6">
+                <CardContent className="p-6 flex flex-col md:flex-row md:flex-wrap md:justify-between md:items-center gap-4 md:gap-6">
                   <div className="flex items-center gap-4">
                     <div>
                       <h3 className="text-lg font-semibold text-gray-700">

--- a/apps/web/hooks/useIsMobile.ts
+++ b/apps/web/hooks/useIsMobile.ts
@@ -20,3 +20,13 @@ export function useIsMobile() {
 
   return isMobile;
 }
+
+export function useMounted() {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return mounted;
+}


### PR DESCRIPTION
## Summary

Fecha os gaps remanescentes de responsividade mobile listados na issue #157. Sem reescrever telas que já estão responsivas.

- **Register**: `grid-cols-2` → `grid-cols-1 sm:grid-cols-2` em `page.tsx`, `PatientFields.tsx`, `ProfessionalFields.tsx` (quebrava em 360–390px).
- **Manager tables** (`patients`, `appointments`): `overflow-x-auto` no wrapper desktop como rede de segurança + gating de hidratação via novo `useMounted` para evitar flash.
- **ManagerBookingModal**: grids densos (`grid-cols-4 sm:grid-cols-5`, `grid-cols-2 gap-x-6`) reajustados para caber em 360px.
- **Professional home**: `flex-wrap` no card de próximo agendamento para que as ações reflowem.
- **Tipografia**: títulos de `patients/new` e `patients/[id]` `text-3xl` → `text-2xl sm:text-3xl`.
- **Hook**: `apps/web/hooks/useIsMobile.ts` agora exporta `useMounted`.
- **Admin tables** (`UsersTable`, `SpecialityTable`): usam `useMounted` para evitar flash na hidratação.

### Fora desta PR
- Admin mobile nav via `Sheet`: a `MobileNav` atual já é role-aware e atende ADMIN (corrigido pela PR #166 da nova sidebar) — gap obsoleto.

## Test plan

- [ ] `/auth/register` em 360px: Paciente e Profissional sem grids forçando 2 colunas
- [ ] `/dashboard/manager/patients` e `/dashboard/manager/appointments` em 360/390/768px: sem overflow horizontal, sem flash de hidratação
- [ ] `/dashboard/manager/appointments/new` modal de booking em 360px: sem overflow
- [ ] `/dashboard/professional` card de próximo agendamento em 768px: ações reflowem
- [ ] `/dashboard/manager/patients/new` e `/dashboard/manager/patients/[id]`: títulos escalam suavemente
- [ ] `/dashboard/admin` tabelas: sem flash na carga inicial
- [ ] Nenhuma regressão visual nas telas já responsivas (schedule, dashboards home, perfil, questionário, auth)

Closes #157