### PR TITLE
test(server): gate de testes no CI + unitários das regras de negócio (Fases 0 e 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,6 @@ jobs:
       - run: npm ci
       - run: npm --workspace server run prisma:generate
 
+      - run: npm --workspace server run test
+
       - run: npm run build

--- a/apps/server/src/addresses/addresses.service.spec.ts
+++ b/apps/server/src/addresses/addresses.service.spec.ts
@@ -1,0 +1,173 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { of } from 'rxjs';
+import { AddressesRepository } from './addresses.repository';
+import { AddressesService } from './addresses.service';
+
+describe('AddressesService', () => {
+  const repository = {
+    findUserById: jest.fn(),
+    findByUserId: jest.fn(),
+    createForUser: jest.fn(),
+    updateForUser: jest.fn(),
+    deleteForUser: jest.fn(),
+    findDistinctCities: jest.fn(),
+  };
+  const httpService = { get: jest.fn() };
+
+  let service: AddressesService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new AddressesService(
+      repository as unknown as AddressesRepository,
+      httpService as unknown as HttpService,
+    );
+  });
+
+  describe('searchByCep', () => {
+    it('rejects a CEP that is not 8 digits', async () => {
+      await expect(service.searchByCep('123')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('rejects a CEP with non-numeric characters', async () => {
+      await expect(service.searchByCep('1234567a')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('maps the ViaCEP response to the address shape', async () => {
+      httpService.get.mockReturnValue(
+        of({
+          data: {
+            cep: '40000-000',
+            logradouro: 'Rua A',
+            bairro: 'Centro',
+            localidade: 'Salvador',
+            uf: 'BA',
+          },
+        }),
+      );
+
+      const result = await service.searchByCep('40000000');
+
+      expect(result).toEqual({
+        zipCode: '40000-000',
+        street: 'Rua A',
+        district: 'Centro',
+        city: 'Salvador',
+        state: 'BA',
+      });
+    });
+
+    it('throws NotFound when ViaCEP returns erro: true', async () => {
+      httpService.get.mockReturnValue(of({ data: { erro: true } }));
+
+      await expect(service.searchByCep('00000000')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('wraps external API failures into a BadRequest', async () => {
+      httpService.get.mockImplementation(() => {
+        throw new Error('network down');
+      });
+
+      await expect(service.searchByCep('40000000')).rejects.toThrow(
+        'Erro ao consultar CEP',
+      );
+    });
+  });
+
+  describe('create', () => {
+    const dto = {
+      zipCode: '40000-000',
+      street: 'Rua A',
+      number: '1',
+      district: 'Centro',
+      city: 'Salvador',
+      state: 'BA',
+    } as any;
+
+    it('throws NotFound when the user does not exist', async () => {
+      repository.findUserById.mockResolvedValue(null);
+
+      await expect(service.create('u-1', dto)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('rejects when the user already has an address', async () => {
+      repository.findUserById.mockResolvedValue({ id: 'u-1' });
+      repository.findByUserId.mockResolvedValue({ id: 'addr-1' });
+
+      await expect(service.create('u-1', dto)).rejects.toThrow(
+        'já possui um endereço',
+      );
+    });
+
+    it('creates the address with complement defaulting to null', async () => {
+      repository.findUserById.mockResolvedValue({ id: 'u-1' });
+      repository.findByUserId.mockResolvedValue(null);
+      repository.createForUser.mockResolvedValue({ id: 'addr-1' });
+
+      await service.create('u-1', dto);
+
+      expect(repository.createForUser).toHaveBeenCalledWith(
+        'u-1',
+        expect.objectContaining({ complement: null }),
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('throws NotFound when there is no address', async () => {
+      repository.findByUserId.mockResolvedValue(null);
+
+      await expect(service.update('u-1', {} as any)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('keeps existing values for fields not provided', async () => {
+      repository.findByUserId.mockResolvedValue({
+        zipCode: '40000-000',
+        street: 'Rua A',
+        number: '1',
+        complement: 'Apto 2',
+        district: 'Centro',
+        city: 'Salvador',
+        state: 'BA',
+      });
+      repository.updateForUser.mockResolvedValue({ id: 'addr-1' });
+
+      await service.update('u-1', { street: 'Rua B' } as any);
+
+      expect(repository.updateForUser).toHaveBeenCalledWith(
+        'u-1',
+        expect.objectContaining({ street: 'Rua B', city: 'Salvador' }),
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('throws NotFound when there is no address', async () => {
+      repository.findByUserId.mockResolvedValue(null);
+
+      await expect(service.delete('u-1')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('deletes the address when it exists', async () => {
+      repository.findByUserId.mockResolvedValue({ id: 'addr-1' });
+      repository.deleteForUser.mockResolvedValue({ id: 'addr-1' });
+
+      await service.delete('u-1');
+
+      expect(repository.deleteForUser).toHaveBeenCalledWith('u-1');
+    });
+  });
+});

--- a/apps/server/src/appointments/appointments.service.spec.ts
+++ b/apps/server/src/appointments/appointments.service.spec.ts
@@ -1,0 +1,254 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { AppointmentStatus } from '@prisma/client';
+import { AppointmentsRepository } from './appointments.repository';
+import { AppointmentsService } from './appointments.service';
+
+describe('AppointmentsService', () => {
+  const repository = {
+    findAppointmentById: jest.fn(),
+    cancelAppointment: jest.fn(),
+    updateAppointmentStatus: jest.fn(),
+    findProfessionalById: jest.fn(),
+    findAvailabilityForSlots: jest.fn(),
+    findBookedTimes: jest.fn(),
+    findScheduleBlocksForDate: jest.fn(),
+  };
+  const mailService = {
+    sendAppointmentCancelledEmail: jest.fn().mockResolvedValue(undefined),
+  };
+  const meetService = {
+    cancelMeetEvent: jest.fn().mockResolvedValue(undefined),
+  };
+
+  let service: AppointmentsService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new AppointmentsService(
+      repository as unknown as AppointmentsRepository,
+      mailService as any,
+      meetService as any,
+    );
+  });
+
+  const hoursFromNow = (h: number) => new Date(Date.now() + h * 60 * 60 * 1000);
+
+  const makeAppointment = (overrides: Record<string, unknown> = {}) => ({
+    id: 'appt-1',
+    dateTime: hoursFromNow(48),
+    status: AppointmentStatus.SCHEDULED,
+    notes: null,
+    modality: 'IN_PERSON',
+    googleEventId: null,
+    professionalId: 'prof-1',
+    createdAt: new Date(),
+    professional: {
+      id: 'prof-1',
+      name: 'Dra. Ana',
+      email: 'ana@lifemed.com',
+      professionalProfile: { specialities: [], photoUrl: null, bio: null },
+    },
+    patient: { id: 'pat-1', name: 'João', email: 'joao@lifemed.com' },
+    ...overrides,
+  });
+
+  describe('cancelAppointment', () => {
+    it('throws NotFound when the appointment does not exist', async () => {
+      repository.findAppointmentById.mockResolvedValue(null);
+
+      await expect(
+        service.cancelAppointment('missing', {} as any),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('rejects cancelling an already-cancelled appointment', async () => {
+      repository.findAppointmentById.mockResolvedValue(
+        makeAppointment({ status: AppointmentStatus.CANCELLED }),
+      );
+
+      await expect(
+        service.cancelAppointment('appt-1', {} as any),
+      ).rejects.toThrow('já foi cancelado');
+    });
+
+    it('rejects cancellation with less than the minimum advance notice', async () => {
+      repository.findAppointmentById.mockResolvedValue(
+        makeAppointment({ dateTime: hoursFromNow(2) }),
+      );
+
+      await expect(
+        service.cancelAppointment('appt-1', {} as any),
+      ).rejects.toThrow('antecedência');
+
+      expect(repository.cancelAppointment).not.toHaveBeenCalled();
+    });
+
+    it('cancels when within the allowed window and notifies both parties', async () => {
+      repository.findAppointmentById.mockResolvedValue(makeAppointment());
+      repository.cancelAppointment.mockResolvedValue(
+        makeAppointment({ status: AppointmentStatus.CANCELLED }),
+      );
+
+      const result = await service.cancelAppointment('appt-1', {
+        reason: 'Imprevisto',
+      } as any);
+
+      expect(repository.cancelAppointment).toHaveBeenCalledWith(
+        'appt-1',
+        'Imprevisto',
+      );
+      expect(mailService.sendAppointmentCancelledEmail).toHaveBeenCalledTimes(2);
+      expect(result.status).toBe(AppointmentStatus.CANCELLED);
+    });
+
+    it('cancels the Google Calendar event when one exists', async () => {
+      repository.findAppointmentById.mockResolvedValue(makeAppointment());
+      repository.cancelAppointment.mockResolvedValue(
+        makeAppointment({
+          status: AppointmentStatus.CANCELLED,
+          googleEventId: 'gcal-123',
+        }),
+      );
+
+      await service.cancelAppointment('appt-1', { reason: 'x' } as any);
+
+      expect(meetService.cancelMeetEvent).toHaveBeenCalledWith('gcal-123');
+    });
+  });
+
+  describe('updateAppointmentStatus', () => {
+    it('throws NotFound when the appointment does not exist', async () => {
+      repository.findAppointmentById.mockResolvedValue(null);
+
+      await expect(
+        service.updateAppointmentStatus('missing', 'prof-1', {
+          status: AppointmentStatus.COMPLETED,
+        } as any),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('forbids a professional from changing another professional appointment', async () => {
+      repository.findAppointmentById.mockResolvedValue(makeAppointment());
+
+      await expect(
+        service.updateAppointmentStatus('appt-1', 'other-prof', {
+          status: AppointmentStatus.COMPLETED,
+        } as any),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('rejects changing the status of a cancelled appointment', async () => {
+      repository.findAppointmentById.mockResolvedValue(
+        makeAppointment({ status: AppointmentStatus.CANCELLED }),
+      );
+
+      await expect(
+        service.updateAppointmentStatus('appt-1', 'prof-1', {
+          status: AppointmentStatus.COMPLETED,
+        } as any),
+      ).rejects.toThrow('cancelado');
+    });
+
+    it('rejects marking COMPLETED before the appointment time', async () => {
+      repository.findAppointmentById.mockResolvedValue(
+        makeAppointment({ dateTime: hoursFromNow(24) }),
+      );
+
+      await expect(
+        service.updateAppointmentStatus('appt-1', 'prof-1', {
+          status: AppointmentStatus.COMPLETED,
+        } as any),
+      ).rejects.toThrow('após o horário agendado');
+    });
+
+    it('allows marking COMPLETED after the appointment time', async () => {
+      repository.findAppointmentById.mockResolvedValue(
+        makeAppointment({ dateTime: hoursFromNow(-1) }),
+      );
+      repository.updateAppointmentStatus.mockResolvedValue(
+        makeAppointment({
+          dateTime: hoursFromNow(-1),
+          status: AppointmentStatus.COMPLETED,
+        }),
+      );
+
+      const result = await service.updateAppointmentStatus('appt-1', 'prof-1', {
+        status: AppointmentStatus.COMPLETED,
+      } as any);
+
+      expect(result.status).toBe(AppointmentStatus.COMPLETED);
+    });
+  });
+
+  describe('getAvailableSlots', () => {
+    beforeEach(() => {
+      repository.findProfessionalById.mockResolvedValue({ id: 'prof-1' });
+    });
+
+    it('throws NotFound when the professional does not exist', async () => {
+      repository.findProfessionalById.mockResolvedValue(null);
+
+      await expect(
+        service.getAvailableSlots('missing', { date: '2026-06-15' } as any),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('returns empty slots when there is no availability for the day', async () => {
+      repository.findAvailabilityForSlots.mockResolvedValue(null);
+
+      const result = await service.getAvailableSlots('prof-1', {
+        date: '2026-06-15',
+      } as any);
+
+      expect(result.slots).toEqual([]);
+    });
+
+    it('generates 30-min slots and marks booked/blocked times unavailable', async () => {
+      repository.findAvailabilityForSlots.mockResolvedValue({
+        startTime: '09:00',
+        endTime: '11:00',
+      });
+      repository.findBookedTimes.mockResolvedValue([
+        { dateTime: new Date('2026-06-15T09:30:00') },
+      ]);
+      repository.findScheduleBlocksForDate.mockResolvedValue([
+        { startTime: '10:00', endTime: '10:30' },
+      ]);
+
+      const result = await service.getAvailableSlots('prof-1', {
+        date: '2026-06-15',
+      } as any);
+
+      // 09:00-11:00 em passos de 30min => 4 slots
+      expect(result.slots).toHaveLength(4);
+      const byTime = Object.fromEntries(
+        result.slots.map((s) => [s.time, s.available]),
+      );
+      expect(byTime['09:00']).toBe(true);
+      expect(byTime['09:30']).toBe(false); // booked
+      expect(byTime['10:00']).toBe(false); // blocked
+      expect(byTime['10:30']).toBe(true);
+    });
+
+    it('blocks the whole day when a block has no start/end time', async () => {
+      repository.findAvailabilityForSlots.mockResolvedValue({
+        startTime: '09:00',
+        endTime: '10:00',
+      });
+      repository.findBookedTimes.mockResolvedValue([]);
+      repository.findScheduleBlocksForDate.mockResolvedValue([
+        { startTime: null, endTime: null },
+      ]);
+
+      const result = await service.getAvailableSlots('prof-1', {
+        date: '2026-06-15',
+      } as any);
+
+      expect(result.slots.every((s) => s.available === false)).toBe(true);
+    });
+  });
+});

--- a/apps/server/src/auth/auth.service.spec.ts
+++ b/apps/server/src/auth/auth.service.spec.ts
@@ -10,12 +10,22 @@ describe('AuthService', () => {
   const password = 'Senha123!';
   const repository = {
     findUserForLogin: jest.fn(),
+    findUserByEmail: jest.fn(),
+    findUserByCpf: jest.fn(),
+    createPatient: jest.fn(),
+    createPasswordReset: jest.fn(),
+    findPasswordResetByToken: jest.fn(),
+    resetPassword: jest.fn(),
   };
   const jwtService = {
     sign: jest.fn(() => 'signed-token'),
   };
-  const mailService = {};
-  const emailVerification = {};
+  const mailService = {
+    sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
+  };
+  const emailVerification = {
+    sendVerification: jest.fn().mockResolvedValue(undefined),
+  };
 
   let service: AuthService;
 
@@ -128,5 +138,129 @@ describe('AuthService', () => {
         status: UserStatus.VERIFIED,
       }),
     );
+  });
+
+  describe('register', () => {
+    const dto = {
+      email: 'novo@lifemed.com',
+      cpf: '12345678900',
+      password,
+      name: 'Novo Paciente',
+    } as any;
+
+    it('rejects registration when the email already exists', async () => {
+      repository.findUserByEmail.mockResolvedValue({ id: 'existing' });
+
+      await expect(service.register(dto)).rejects.toThrow('E-mail já cadastrado');
+      expect(repository.createPatient).not.toHaveBeenCalled();
+    });
+
+    it('rejects registration when the CPF already exists', async () => {
+      repository.findUserByEmail.mockResolvedValue(null);
+      repository.findUserByCpf.mockResolvedValue({ id: 'existing' });
+
+      await expect(service.register(dto)).rejects.toThrow('CPF já cadastrado');
+      expect(repository.createPatient).not.toHaveBeenCalled();
+    });
+
+    it('hashes the password and sends a verification email on success', async () => {
+      repository.findUserByEmail.mockResolvedValue(null);
+      repository.findUserByCpf.mockResolvedValue(null);
+      repository.createPatient.mockImplementation(
+        async (_dto: unknown, passwordHash: string) => ({
+          id: 'new-user',
+          email: dto.email,
+          name: dto.name,
+          role: UserRole.PATIENT,
+          status: UserStatus.PENDING,
+          password: passwordHash,
+        }),
+      );
+
+      const result = await service.register(dto);
+
+      const [, passwordHash] = repository.createPatient.mock.calls[0];
+      expect(passwordHash).not.toBe(password);
+      expect(await bcrypt.compare(password, passwordHash)).toBe(true);
+      expect(emailVerification.sendVerification).toHaveBeenCalled();
+      expect(result).toMatchObject({ id: 'new-user', email: dto.email });
+    });
+  });
+
+  describe('forgotPassword', () => {
+    it('returns a generic message and does nothing when the email is unknown', async () => {
+      repository.findUserByEmail.mockResolvedValue(null);
+
+      const result = await service.forgotPassword({
+        email: 'desconhecido@lifemed.com',
+      } as any);
+
+      expect(result.message).toMatch(/Se o e-mail existir/);
+      expect(repository.createPasswordReset).not.toHaveBeenCalled();
+      expect(mailService.sendPasswordResetEmail).not.toHaveBeenCalled();
+    });
+
+    it('creates a reset token and sends the email when the user exists', async () => {
+      repository.findUserByEmail.mockResolvedValue({
+        id: 'user-id',
+        name: 'Usuario',
+        email: 'usuario@lifemed.com',
+      });
+
+      const result = await service.forgotPassword({
+        email: 'usuario@lifemed.com',
+      } as any);
+
+      expect(repository.createPasswordReset).toHaveBeenCalledWith(
+        'user-id',
+        expect.any(String),
+        expect.any(Date),
+      );
+      expect(mailService.sendPasswordResetEmail).toHaveBeenCalled();
+      // Mensagem genérica idêntica à do caso desconhecido (evita enumeração).
+      expect(result.message).toMatch(/Se o e-mail existir/);
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('rejects an invalid token', async () => {
+      repository.findPasswordResetByToken.mockResolvedValue(null);
+
+      await expect(
+        service.resetPassword({ token: 'bad', newPassword: password } as any),
+      ).rejects.toThrow('Token inválido');
+    });
+
+    it('rejects an expired token', async () => {
+      repository.findPasswordResetByToken.mockResolvedValue({
+        id: 'reset-1',
+        userId: 'user-id',
+        expiresAt: new Date(Date.now() - 1000),
+      });
+
+      await expect(
+        service.resetPassword({ token: 'old', newPassword: password } as any),
+      ).rejects.toThrow('Token expirado');
+      expect(repository.resetPassword).not.toHaveBeenCalled();
+    });
+
+    it('hashes the new password and persists it for a valid token', async () => {
+      repository.findPasswordResetByToken.mockResolvedValue({
+        id: 'reset-1',
+        userId: 'user-id',
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      });
+
+      await service.resetPassword({
+        token: 'valid',
+        newPassword: password,
+      } as any);
+
+      const [resetId, userId, passwordHash] =
+        repository.resetPassword.mock.calls[0];
+      expect(resetId).toBe('reset-1');
+      expect(userId).toBe('user-id');
+      expect(await bcrypt.compare(password, passwordHash)).toBe(true);
+    });
   });
 });

--- a/apps/server/src/mail/email-verification.service.spec.ts
+++ b/apps/server/src/mail/email-verification.service.spec.ts
@@ -1,0 +1,127 @@
+import { BadRequestException } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { EmailVerificationService } from './email-verification.service';
+import { MailService } from './mail.service';
+
+describe('EmailVerificationService', () => {
+  const prisma = {
+    emailVerification: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      delete: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn(),
+    },
+  };
+  const mailService = {
+    sendEmailVerificationEmail: jest.fn().mockResolvedValue(undefined),
+  };
+
+  let service: EmailVerificationService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new EmailVerificationService(
+      prisma as unknown as PrismaService,
+      mailService as unknown as MailService,
+    );
+  });
+
+  describe('sendVerification', () => {
+    it('persists a token and sends the verification email', async () => {
+      prisma.emailVerification.create.mockResolvedValue({});
+
+      await service.sendVerification({
+        id: 'u-1',
+        name: 'A',
+        email: 'a@a.com',
+      });
+
+      expect(prisma.emailVerification.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ userId: 'u-1' }),
+        }),
+      );
+      expect(mailService.sendEmailVerificationEmail).toHaveBeenCalled();
+    });
+  });
+
+  describe('validateToken', () => {
+    it('rejects an unknown token', async () => {
+      prisma.emailVerification.findUnique.mockResolvedValue(null);
+
+      await expect(service.validateToken('bad')).rejects.toThrow(
+        'Token inválido',
+      );
+    });
+
+    it('rejects an expired token', async () => {
+      prisma.emailVerification.findUnique.mockResolvedValue({
+        id: 'v-1',
+        expiresAt: new Date(Date.now() - 1000),
+        user: { id: 'u-1' },
+      });
+
+      await expect(service.validateToken('old')).rejects.toThrow(
+        'Token expirado',
+      );
+      expect(prisma.emailVerification.delete).not.toHaveBeenCalled();
+    });
+
+    it('consumes a valid token and returns the user', async () => {
+      prisma.emailVerification.findUnique.mockResolvedValue({
+        id: 'v-1',
+        expiresAt: new Date(Date.now() + 60_000),
+        user: { id: 'u-1', email: 'a@a.com' },
+      });
+
+      const result = await service.validateToken('good');
+
+      expect(prisma.emailVerification.delete).toHaveBeenCalledWith({
+        where: { id: 'v-1' },
+      });
+      expect(result).toEqual({ id: 'u-1', email: 'a@a.com' });
+    });
+  });
+
+  describe('resend', () => {
+    it('returns a generic message without resending for unknown email', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      const result = await service.resend('x@x.com');
+
+      expect(result.message).toMatch(/Se o e-mail/);
+      expect(prisma.emailVerification.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it('does not resend for an already-verified user', async () => {
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'u-1',
+        emailVerified: true,
+      });
+
+      await service.resend('a@a.com');
+
+      expect(prisma.emailVerification.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it('clears old tokens and resends for a pending user', async () => {
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'u-1',
+        name: 'A',
+        email: 'a@a.com',
+        emailVerified: false,
+      });
+      prisma.emailVerification.create.mockResolvedValue({});
+
+      await service.resend('a@a.com');
+
+      expect(prisma.emailVerification.deleteMany).toHaveBeenCalledWith({
+        where: { userId: 'u-1' },
+      });
+      expect(mailService.sendEmailVerificationEmail).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/src/manager/manager.service.spec.ts
+++ b/apps/server/src/manager/manager.service.spec.ts
@@ -1,0 +1,186 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { AppointmentStatus, UserRole } from '@prisma/client';
+import { ManagerRepository } from './manager.repository';
+import { ManagerService } from './manager.service';
+
+describe('ManagerService', () => {
+  const repository = {
+    findAppointmentById: jest.fn(),
+    findManagerProfileByUserId: jest.fn(),
+    cancelAppointmentByManager: jest.fn(),
+    findAllAppointmentsForManagerAndAdmin: jest.fn(),
+    findProfessionalWithSpecialities: jest.fn(),
+    findActiveAvailabilityByProfessionalId: jest.fn(),
+  };
+
+  let service: ManagerService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ManagerService(repository as unknown as ManagerRepository);
+  });
+
+  describe('cancelAppointment', () => {
+    it('throws NotFound when the appointment does not exist', async () => {
+      repository.findAppointmentById.mockResolvedValue(null);
+
+      await expect(
+        service.cancelAppointment('mgr-1', 'appt-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('rejects cancelling an already-cancelled appointment', async () => {
+      repository.findAppointmentById.mockResolvedValue({
+        status: AppointmentStatus.CANCELLED,
+      });
+
+      await expect(
+        service.cancelAppointment('mgr-1', 'appt-1'),
+      ).rejects.toThrow('já está cancelada');
+    });
+
+    it('throws NotFound when the manager profile is missing', async () => {
+      repository.findAppointmentById.mockResolvedValue({
+        status: AppointmentStatus.PENDING,
+      });
+      repository.findManagerProfileByUserId.mockResolvedValue(null);
+
+      await expect(
+        service.cancelAppointment('mgr-1', 'appt-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('cancels with a manager-tagged note including the reason', async () => {
+      repository.findAppointmentById.mockResolvedValue({
+        status: AppointmentStatus.PENDING,
+      });
+      repository.findManagerProfileByUserId.mockResolvedValue({ id: 'mp-1' });
+      repository.cancelAppointmentByManager.mockResolvedValue({ ok: true });
+
+      await service.cancelAppointment('mgr-1', 'appt-1', 'Paciente desistiu');
+
+      expect(repository.cancelAppointmentByManager).toHaveBeenCalledWith(
+        'appt-1',
+        'mp-1',
+        '[CANCELADO PELO GESTOR] Paciente desistiu',
+      );
+    });
+
+    it('uses a default note when no reason is provided', async () => {
+      repository.findAppointmentById.mockResolvedValue({
+        status: AppointmentStatus.PENDING,
+      });
+      repository.findManagerProfileByUserId.mockResolvedValue({ id: 'mp-1' });
+      repository.cancelAppointmentByManager.mockResolvedValue({ ok: true });
+
+      await service.cancelAppointment('mgr-1', 'appt-1');
+
+      expect(repository.cancelAppointmentByManager).toHaveBeenCalledWith(
+        'appt-1',
+        'mp-1',
+        '[CANCELADO PELO GESTOR]',
+      );
+    });
+  });
+
+  describe('listAppointments vulnerability sorting', () => {
+    const makeAppt = (
+      id: string,
+      dateTime: Date,
+      totalScore: number | null,
+    ) => ({
+      id,
+      dateTime,
+      status: AppointmentStatus.PENDING,
+      notes: null,
+      modality: 'IN_PERSON',
+      meetLink: null,
+      createdAt: dateTime,
+      patient: {
+        id: `pat-${id}`,
+        name: id,
+        email: `${id}@x.com`,
+        patientProfile:
+          totalScore === null
+            ? { questionnaire: null }
+            : { questionnaire: { totalScore, isVulnerable: totalScore >= 5 } },
+      },
+      professional: { id: 'prof', name: 'Prof' },
+      scheduledByManager: null,
+      cancelledByManager: null,
+    });
+
+    it('keeps insertion order when not sorting by vulnerability', async () => {
+      repository.findAllAppointmentsForManagerAndAdmin.mockResolvedValue([
+        makeAppt('a', new Date('2026-01-01'), 2),
+        makeAppt('b', new Date('2026-02-01'), 8),
+      ]);
+
+      const result = await service.listAppointments({} as any);
+
+      expect(result.map((r) => r.id)).toEqual(['a', 'b']);
+      expect(result[1].isVulnerable).toBe(true);
+    });
+
+    it('sorts by score descending and pushes null scores to the end', async () => {
+      repository.findAllAppointmentsForManagerAndAdmin.mockResolvedValue([
+        makeAppt('low', new Date('2026-01-01'), 2),
+        makeAppt('none', new Date('2026-01-01'), null),
+        makeAppt('high', new Date('2026-01-01'), 9),
+      ]);
+
+      const result = await service.listAppointments({
+        sortBy: 'vulnerabilityScore',
+        order: 'desc',
+      } as any);
+
+      expect(result.map((r) => r.id)).toEqual(['high', 'low', 'none']);
+    });
+
+    it('sorts ascending when order is asc', async () => {
+      repository.findAllAppointmentsForManagerAndAdmin.mockResolvedValue([
+        makeAppt('high', new Date('2026-01-01'), 9),
+        makeAppt('low', new Date('2026-01-01'), 2),
+      ]);
+
+      const result = await service.listAppointments({
+        sortBy: 'vulnerabilityScore',
+        order: 'asc',
+      } as any);
+
+      expect(result.map((r) => r.id)).toEqual(['low', 'high']);
+    });
+  });
+
+  describe('getProfessionalAvailability', () => {
+    it('throws NotFound when the user is not a professional', async () => {
+      repository.findProfessionalWithSpecialities.mockResolvedValue({
+        role: UserRole.PATIENT,
+      });
+
+      await expect(
+        service.getProfessionalAvailability('x'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('joins specialties and maps availability', async () => {
+      repository.findProfessionalWithSpecialities.mockResolvedValue({
+        id: 'prof-1',
+        name: 'Dra. Ana',
+        email: 'ana@x.com',
+        role: UserRole.PROFESSIONAL,
+        professionalProfile: {
+          specialities: [{ name: 'Cardio' }, { name: 'Clínica' }],
+        },
+      });
+      repository.findActiveAvailabilityByProfessionalId.mockResolvedValue([
+        { dayOfWeek: 1, startTime: '09:00', endTime: '12:00' },
+      ]);
+
+      const result = await service.getProfessionalAvailability('prof-1');
+
+      expect(result.professional.specialty).toBe('Cardio, Clínica');
+      expect(result.availability).toHaveLength(1);
+    });
+  });
+});

--- a/apps/server/src/medical-records/medical-records.service.spec.ts
+++ b/apps/server/src/medical-records/medical-records.service.spec.ts
@@ -1,0 +1,220 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { AppointmentStatus, Prisma, UserRole } from '@prisma/client';
+import { MedicalRecordPdfService } from './medical-record-pdf.service';
+import { MedicalRecordsRepository } from './medical-records.repository';
+import { MedicalRecordsService } from './medical-records.service';
+
+describe('MedicalRecordsService', () => {
+  const repository = {
+    findAppointmentById: jest.fn(),
+    createForAppointment: jest.fn(),
+    findByAppointmentId: jest.fn(),
+    findById: jest.fn(),
+    listForRequester: jest.fn(),
+    findByPatient: jest.fn(),
+    updateRecord: jest.fn(),
+    findPatientPdfRecordByAppointment: jest.fn(),
+    hasValidPriorAppointment: jest.fn(),
+  };
+  const pdfService = { generate: jest.fn() };
+
+  let service: MedicalRecordsService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new MedicalRecordsService(
+      repository as unknown as MedicalRecordsRepository,
+      pdfService as unknown as MedicalRecordPdfService,
+    );
+  });
+
+  const makeRecord = (overrides: Record<string, unknown> = {}) => ({
+    id: 'rec-1',
+    appointmentId: 'appt-1',
+    patientId: 'patient-1',
+    authorId: 'prof-1',
+    chiefComplaint: 'Dor',
+    diagnosis: 'Dx',
+    treatmentPlan: 'Plano',
+    prescriptions: 'Rx',
+    internalNotes: 'Notas internas',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    author: { id: 'prof-1', name: 'Dra. Ana', email: 'ana@lifemed.com' },
+    patient: { id: 'patient-1', name: 'João' },
+    appointment: { id: 'appt-1', dateTime: new Date(), modality: 'IN_PERSON' },
+    ...overrides,
+  });
+
+  describe('create', () => {
+    it('throws NotFound when the appointment does not exist', async () => {
+      repository.findAppointmentById.mockResolvedValue(null);
+
+      await expect(
+        service.create('prof-1', { appointmentId: 'x' } as any),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('forbids creating a record for an appointment of another professional', async () => {
+      repository.findAppointmentById.mockResolvedValue({
+        professionalId: 'other-prof',
+        patientId: 'patient-1',
+      });
+
+      await expect(
+        service.create('prof-1', { appointmentId: 'appt-1' } as any),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('maps a Prisma P2002 unique violation to a Conflict', async () => {
+      repository.findAppointmentById.mockResolvedValue({
+        professionalId: 'prof-1',
+        patientId: 'patient-1',
+      });
+      repository.createForAppointment.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('dup', {
+          code: 'P2002',
+          clientVersion: 'test',
+        }),
+      );
+
+      await expect(
+        service.create('prof-1', { appointmentId: 'appt-1' } as any),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('creates and returns the record for the responsible professional', async () => {
+      repository.findAppointmentById.mockResolvedValue({
+        professionalId: 'prof-1',
+        patientId: 'patient-1',
+      });
+      repository.createForAppointment.mockResolvedValue(makeRecord());
+
+      const result = await service.create('prof-1', {
+        appointmentId: 'appt-1',
+      } as any);
+
+      expect(result.id).toBe('rec-1');
+    });
+  });
+
+  describe('findById authorization (patient access to health data)', () => {
+    it('forbids a role that is neither professional nor patient', async () => {
+      await expect(
+        service.findById('rec-1', 'admin-1', UserRole.ADMIN),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it("forbids a patient from reading another patient's record", async () => {
+      repository.findById.mockResolvedValue(
+        makeRecord({ patientId: 'someone-else' }),
+      );
+
+      await expect(
+        service.findById('rec-1', 'patient-1', UserRole.PATIENT),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('lets a patient read their own record (without internalNotes)', async () => {
+      repository.findById.mockResolvedValue(
+        makeRecord({ patientId: 'patient-1' }),
+      );
+
+      const result = (await service.findById(
+        'rec-1',
+        'patient-1',
+        UserRole.PATIENT,
+      )) as any;
+
+      expect(result.id).toBe('rec-1');
+      expect(result.internalNotes).toBeUndefined();
+    });
+
+    it('lets the author professional read the record (with internalNotes)', async () => {
+      repository.findById.mockResolvedValue(makeRecord({ authorId: 'prof-1' }));
+
+      const result = (await service.findById(
+        'rec-1',
+        'prof-1',
+        UserRole.PROFESSIONAL,
+      )) as any;
+
+      expect(result.internalNotes).toBe('Notas internas');
+    });
+
+    it('forbids a non-author professional without a prior appointment link', async () => {
+      repository.findById.mockResolvedValue(makeRecord({ authorId: 'other' }));
+      repository.hasValidPriorAppointment.mockResolvedValue(false);
+
+      await expect(
+        service.findById('rec-1', 'prof-2', UserRole.PROFESSIONAL),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('lets a non-author professional read when there is a prior appointment link', async () => {
+      repository.findById.mockResolvedValue(makeRecord({ authorId: 'other' }));
+      repository.hasValidPriorAppointment.mockResolvedValue(true);
+
+      const result = await service.findById(
+        'rec-1',
+        'prof-2',
+        UserRole.PROFESSIONAL,
+      );
+
+      expect(result.id).toBe('rec-1');
+    });
+  });
+
+  describe('list', () => {
+    it('forbids a professional from filtering by another author', async () => {
+      await expect(
+        service.list('prof-1', UserRole.PROFESSIONAL, {
+          authorId: 'other-prof',
+        } as any),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  describe('update', () => {
+    it('forbids editing a record the requester did not author', async () => {
+      repository.findById.mockResolvedValue(makeRecord({ authorId: 'someone' }));
+
+      await expect(
+        service.update('rec-1', 'prof-1', {} as any),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  describe('generatePatientPdf', () => {
+    it("forbids generating a PDF for another patient's record", async () => {
+      repository.findPatientPdfRecordByAppointment.mockResolvedValue({
+        patientId: 'someone-else',
+      });
+
+      await expect(
+        service.generatePatientPdf('appt-1', 'patient-1'),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  // Garante que o status de vínculo usado é CONFIRMED/COMPLETED.
+  describe('findByPatient link check', () => {
+    it('forbids when there is no valid prior appointment', async () => {
+      repository.hasValidPriorAppointment.mockResolvedValue(false);
+
+      await expect(
+        service.findByPatient('patient-1', 'prof-1'),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(repository.hasValidPriorAppointment).toHaveBeenCalledWith(
+        'prof-1',
+        'patient-1',
+        [AppointmentStatus.CONFIRMED, AppointmentStatus.COMPLETED],
+      );
+    });
+  });
+});

--- a/apps/server/src/patients/patients.service.spec.ts
+++ b/apps/server/src/patients/patients.service.spec.ts
@@ -1,0 +1,152 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { UserRole } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+import { MailService } from '../mail/mail.service';
+import { ReportsService } from '../reports/reports.service';
+import { PatientsRepository } from './patients.repository';
+import { PatientsService } from './patients.service';
+
+describe('PatientsService', () => {
+  const repository = {
+    findAppointmentsByStatus: jest.fn(),
+    findUserByEmail: jest.fn(),
+    findUserByCpf: jest.fn(),
+    createAssistedPatient: jest.fn(),
+    findPatientForUpdate: jest.fn(),
+    updatePatient: jest.fn(),
+    listPatients: jest.fn(),
+    findPatientWithQuestionnaire: jest.fn(),
+  };
+  const reportsService = {};
+  const mailService = {
+    sendTempPasswordEmail: jest.fn().mockResolvedValue(undefined),
+  };
+
+  let service: PatientsService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new PatientsService(
+      repository as unknown as PatientsRepository,
+      reportsService as unknown as ReportsService,
+      mailService as unknown as MailService,
+    );
+  });
+
+  describe('createAssistedPatient', () => {
+    const dto = { email: 'novo@lifemed.com', name: 'Novo', cpf: '123' } as any;
+
+    it('rejects when the email already exists', async () => {
+      repository.findUserByEmail.mockResolvedValue({ id: 'x' });
+
+      await expect(service.createAssistedPatient(dto)).rejects.toThrow(
+        'Email já cadastrado',
+      );
+      expect(repository.createAssistedPatient).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the CPF already exists', async () => {
+      repository.findUserByEmail.mockResolvedValue(null);
+      repository.findUserByCpf.mockResolvedValue({ id: 'x' });
+
+      await expect(service.createAssistedPatient(dto)).rejects.toThrow(
+        'CPF já cadastrado',
+      );
+    });
+
+    it('generates a hashed temp password and emails it', async () => {
+      repository.findUserByEmail.mockResolvedValue(null);
+      repository.findUserByCpf.mockResolvedValue(null);
+      repository.createAssistedPatient.mockResolvedValue({
+        id: 'p-1',
+        email: dto.email,
+        name: dto.name,
+        role: UserRole.PATIENT,
+        patientProfile: {},
+        address: null,
+      });
+
+      const result = await service.createAssistedPatient(dto);
+
+      const [, hashedPassword] =
+        repository.createAssistedPatient.mock.calls[0];
+      // É um hash bcrypt, não texto plano.
+      expect(hashedPassword).toMatch(/^\$2[aby]\$/);
+      expect(mailService.sendTempPasswordEmail).toHaveBeenCalled();
+      const [, tempPassword] = mailService.sendTempPasswordEmail.mock.calls[0];
+      expect(await bcrypt.compare(tempPassword, hashedPassword)).toBe(true);
+      expect(result.id).toBe('p-1');
+    });
+  });
+
+  describe('updatePatient', () => {
+    it('throws NotFound when the user is not a patient', async () => {
+      repository.findPatientForUpdate.mockResolvedValue({
+        role: UserRole.PROFESSIONAL,
+        patientProfile: {},
+      });
+
+      await expect(
+        service.updatePatient('p-1', {} as any),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws NotFound when the patient profile is missing', async () => {
+      repository.findPatientForUpdate.mockResolvedValue({
+        role: UserRole.PATIENT,
+        patientProfile: null,
+      });
+
+      await expect(
+        service.updatePatient('p-1', {} as any),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('rejects updating to a CPF that belongs to another user', async () => {
+      repository.findPatientForUpdate.mockResolvedValue({
+        id: 'p-1',
+        role: UserRole.PATIENT,
+        cpf: '111',
+        patientProfile: {},
+      });
+      repository.findUserByCpf.mockResolvedValue({ id: 'other' });
+
+      await expect(
+        service.updatePatient('p-1', { cpf: '999' } as any),
+      ).rejects.toThrow('CPF já cadastrado');
+    });
+
+    it('allows keeping the same CPF (no duplicate check triggered)', async () => {
+      repository.findPatientForUpdate.mockResolvedValue({
+        id: 'p-1',
+        role: UserRole.PATIENT,
+        cpf: '111',
+        patientProfile: {},
+      });
+      repository.updatePatient.mockResolvedValue({
+        id: 'p-1',
+        email: 'a@a.com',
+        name: 'A',
+        cpf: '111',
+        patientProfile: {},
+        address: null,
+      });
+
+      await service.updatePatient('p-1', { cpf: '111' } as any);
+
+      expect(repository.findUserByCpf).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getPatient', () => {
+    it('throws NotFound when the user is not a patient', async () => {
+      repository.findPatientWithQuestionnaire.mockResolvedValue({
+        role: UserRole.ADMIN,
+      });
+
+      await expect(service.getPatient('p-1')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/apps/server/src/professional/professional.service.spec.ts
+++ b/apps/server/src/professional/professional.service.spec.ts
@@ -1,0 +1,188 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { AppointmentStatus } from '@prisma/client';
+import { MailService } from '../mail/mail.service';
+import { ProfessionalRepository } from './professional.repository';
+import { ProfessionalService } from './professional.service';
+
+describe('ProfessionalService', () => {
+  const repository = {
+    findSettingsProfile: jest.fn(),
+    findActiveAvailability: jest.fn(),
+    findAppointmentsWithPatients: jest.fn(),
+    updateSettings: jest.fn(),
+    findScheduleBlockById: jest.fn(),
+    deleteScheduleBlock: jest.fn(),
+  };
+  const mailService = {};
+  const meetService = { cancelMeetEvent: jest.fn() };
+
+  let service: ProfessionalService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ProfessionalService(
+      repository as unknown as ProfessionalRepository,
+      mailService as unknown as MailService,
+      meetService as any,
+    );
+  });
+
+  describe('getSettings', () => {
+    it('throws NotFound when the professional profile does not exist', async () => {
+      repository.findSettingsProfile.mockResolvedValue(null);
+
+      await expect(service.getSettings('u-1')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('applies defaults for payments and price when missing', async () => {
+      repository.findSettingsProfile.mockResolvedValue({
+        modality: 'VIRTUAL',
+        payments: null,
+        price: 0,
+      });
+      repository.findActiveAvailability.mockResolvedValue([
+        { dayOfWeek: 1, startTime: '09:00', endTime: '12:00' },
+      ]);
+
+      const result = await service.getSettings('u-1');
+
+      expect(result.payments).toEqual(['pix']);
+      expect(result.price).toBe(0);
+      expect(result.availability).toEqual([
+        { dayOfWeek: 1, start: '09:00', end: '12:00' },
+      ]);
+    });
+  });
+
+  describe('updateSettings validation', () => {
+    it('rejects when availability is empty', async () => {
+      await expect(
+        service.updateSettings('u-1', { availability: [] } as any),
+      ).rejects.toThrow('At least one availability');
+    });
+
+    it('rejects duplicate dayOfWeek entries', async () => {
+      await expect(
+        service.updateSettings('u-1', {
+          availability: [
+            { dayOfWeek: 1, start: '09:00', end: '12:00' },
+            { dayOfWeek: 1, start: '13:00', end: '15:00' },
+          ],
+        } as any),
+      ).rejects.toThrow('Duplicate dayOfWeek');
+    });
+
+    it('rejects when start is not before end', async () => {
+      await expect(
+        service.updateSettings('u-1', {
+          availability: [{ dayOfWeek: 1, start: '12:00', end: '09:00' }],
+        } as any),
+      ).rejects.toThrow('Invalid time range');
+    });
+
+    it('persists when availability is valid', async () => {
+      repository.updateSettings.mockResolvedValue({ ok: true });
+
+      const result = await service.updateSettings('u-1', {
+        availability: [{ dayOfWeek: 1, start: '09:00', end: '12:00' }],
+      } as any);
+
+      expect(repository.updateSettings).toHaveBeenCalled();
+      expect(result).toEqual({ ok: true });
+    });
+  });
+
+  describe('getPatients aggregation', () => {
+    it('dedups patients and computes last/next visit correctly', async () => {
+      const now = Date.now();
+      const past = new Date(now - 86400000); // ontem
+      const future = new Date(now + 86400000); // amanhã
+
+      repository.findAppointmentsWithPatients.mockResolvedValue([
+        {
+          dateTime: past,
+          status: AppointmentStatus.COMPLETED,
+          patient: {
+            id: 'pat-1',
+            name: 'João',
+            email: 'joao@x.com',
+            cpf: null,
+            patientProfile: { phone: '111' },
+          },
+        },
+        {
+          dateTime: future,
+          status: AppointmentStatus.CONFIRMED,
+          patient: {
+            id: 'pat-1',
+            name: 'João',
+            email: 'joao@x.com',
+            cpf: null,
+            patientProfile: { phone: '111' },
+          },
+        },
+      ]);
+
+      const result = await service.getPatients('u-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].lastVisit).toBe(past.toISOString());
+      expect(result[0].nextVisit).toBe(future.toISOString());
+      expect(result[0].phone).toBe('111');
+    });
+
+    it('falls back to "Não informado" when phone is missing', async () => {
+      repository.findAppointmentsWithPatients.mockResolvedValue([
+        {
+          dateTime: new Date(Date.now() - 1000),
+          status: AppointmentStatus.COMPLETED,
+          patient: {
+            id: 'pat-2',
+            name: 'Maria',
+            email: 'maria@x.com',
+            cpf: null,
+            patientProfile: null,
+          },
+        },
+      ]);
+
+      const result = await service.getPatients('u-1');
+
+      expect(result[0].phone).toBe('Não informado');
+    });
+  });
+
+  describe('deleteScheduleBlock', () => {
+    it('throws NotFound when the block does not exist', async () => {
+      repository.findScheduleBlockById.mockResolvedValue(null);
+
+      await expect(
+        service.deleteScheduleBlock('u-1', 'b-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('forbids deleting a block owned by another professional', async () => {
+      repository.findScheduleBlockById.mockResolvedValue({
+        professionalId: 'other',
+      });
+
+      await expect(service.deleteScheduleBlock('u-1', 'b-1')).rejects.toThrow(
+        'Sem permissão',
+      );
+    });
+
+    it('deletes the block when owned by the requester', async () => {
+      repository.findScheduleBlockById.mockResolvedValue({
+        professionalId: 'u-1',
+      });
+      repository.deleteScheduleBlock.mockResolvedValue(undefined);
+
+      const result = await service.deleteScheduleBlock('u-1', 'b-1');
+
+      expect(repository.deleteScheduleBlock).toHaveBeenCalledWith('b-1');
+      expect(result.message).toMatch(/removido/);
+    });
+  });
+});

--- a/apps/server/src/questionnaire/admin/questionnaire-admin.service.spec.ts
+++ b/apps/server/src/questionnaire/admin/questionnaire-admin.service.spec.ts
@@ -1,0 +1,95 @@
+import { QuestionnaireService } from '../questionnaire.service';
+import { QuestionnaireAdminRepository } from './questionnaire-admin.repository';
+import { QuestionnaireAdminService } from './questionnaire-admin.service';
+
+describe('QuestionnaireAdminService', () => {
+  const repository = {
+    updateQuestionnaire: jest.fn(),
+    createQuestion: jest.fn(),
+    updateQuestion: jest.fn(),
+    deleteQuestion: jest.fn(),
+    createOption: jest.fn(),
+    updateOption: jest.fn(),
+    deleteOption: jest.fn(),
+  };
+  const questionnaireService = {
+    getActiveQuestionnaire: jest.fn(),
+    toDefinition: jest.fn((q) => ({ definitionOf: q.id })),
+  };
+
+  let service: QuestionnaireAdminService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new QuestionnaireAdminService(
+      repository as unknown as QuestionnaireAdminRepository,
+      questionnaireService as unknown as QuestionnaireService,
+    );
+  });
+
+  it('getActive returns the definition of the active questionnaire', async () => {
+    questionnaireService.getActiveQuestionnaire.mockResolvedValue({ id: 'q-1' });
+
+    const result = await service.getActive();
+
+    expect(questionnaireService.toDefinition).toHaveBeenCalledWith({
+      id: 'q-1',
+    });
+    expect(result).toEqual({ definitionOf: 'q-1' });
+  });
+
+  // Cada mutação delega ao repositório e serializa o resultado via toDefinition.
+  const cases: [keyof QuestionnaireAdminService, () => Promise<unknown>, jest.Mock][] =
+    [
+      [
+        'updateQuestionnaire',
+        () => service.updateQuestionnaire('q-1', {} as any),
+        repository.updateQuestionnaire,
+      ],
+      [
+        'createQuestion',
+        () => service.createQuestion('q-1', {} as any),
+        repository.createQuestion,
+      ],
+      [
+        'updateQuestion',
+        () => service.updateQuestion('q-1', 'qq-1', {} as any),
+        repository.updateQuestion,
+      ],
+      [
+        'deleteQuestion',
+        () => service.deleteQuestion('q-1', 'qq-1'),
+        repository.deleteQuestion,
+      ],
+      [
+        'createOption',
+        () => service.createOption('q-1', 'qq-1', {} as any),
+        repository.createOption,
+      ],
+      [
+        'updateOption',
+        () => service.updateOption('q-1', 'o-1', {} as any),
+        repository.updateOption,
+      ],
+      [
+        'deleteOption',
+        () => service.deleteOption('q-1', 'o-1'),
+        repository.deleteOption,
+      ],
+    ];
+
+  it.each(cases)(
+    '%s delegates to the repository and serializes via toDefinition',
+    async (_name, call, repoMethod) => {
+      repoMethod.mockResolvedValue({ id: 'updated-q' });
+
+      const result = await call();
+
+      expect(repoMethod).toHaveBeenCalled();
+      expect(questionnaireService.toDefinition).toHaveBeenCalledWith({
+        id: 'updated-q',
+      });
+      expect(result).toEqual({ definitionOf: 'updated-q' });
+    },
+  );
+});

--- a/apps/server/src/questionnaire/questionnaire.service.spec.ts
+++ b/apps/server/src/questionnaire/questionnaire.service.spec.ts
@@ -1,0 +1,260 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { QuestionnaireAnsweredBy, UserRole } from '@prisma/client';
+import { QuestionnaireRepository } from './questionnaire.repository';
+import { QuestionnaireService } from './questionnaire.service';
+
+describe('QuestionnaireService', () => {
+  const repository = {
+    findActiveQuestionnaire: jest.fn(),
+    findResponseByPatientProfileId: jest.fn(),
+    findResponseWithAnswersByPatientProfileId: jest.fn(),
+    findPatientWithProfile: jest.fn(),
+    persistResponse: jest.fn(),
+  };
+
+  let service: QuestionnaireService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new QuestionnaireService(
+      repository as unknown as QuestionnaireRepository,
+    );
+  });
+
+  // Questionário com 2 perguntas; opções com scores distintos.
+  const makeActiveQuestionnaire = (vulnerabilityThreshold = 5) => ({
+    id: 'questionnaire-1',
+    vulnerabilityThreshold,
+    questions: [
+      {
+        id: 'q1',
+        label: 'Pergunta 1',
+        order: 1,
+        options: [
+          { id: 'q1-a', label: 'Baixo', score: 1, order: 1 },
+          { id: 'q1-b', label: 'Alto', score: 4, order: 2 },
+        ],
+      },
+      {
+        id: 'q2',
+        label: 'Pergunta 2',
+        order: 2,
+        options: [
+          { id: 'q2-a', label: 'Baixo', score: 0, order: 1 },
+          { id: 'q2-b', label: 'Alto', score: 3, order: 2 },
+        ],
+      },
+    ],
+  });
+
+  const makePersistedResponse = (
+    overrides: Partial<{ totalScore: number; isVulnerable: boolean }> = {},
+  ) => ({
+    id: 'response-1',
+    answeredBy: QuestionnaireAnsweredBy.PATIENT,
+    answeredByUserId: 'patient-user-1',
+    totalScore: overrides.totalScore ?? 0,
+    isVulnerable: overrides.isVulnerable ?? false,
+    responseDate: new Date('2026-06-14T00:00:00Z'),
+    patientProfile: { userId: 'patient-user-1' },
+    answers: [],
+  });
+
+  describe('getQuestions / toDefinition', () => {
+    it('computes maxPossibleScore from the highest option score per question', async () => {
+      repository.findActiveQuestionnaire.mockResolvedValue(
+        makeActiveQuestionnaire(),
+      );
+
+      const definition = await service.getQuestions();
+
+      // q1 max = 4, q2 max = 3 => 7
+      expect(definition.maxPossibleScore).toBe(7);
+      expect(definition.questions).toHaveLength(2);
+    });
+
+    it('throws NotFound when no questionnaire is configured', async () => {
+      repository.findActiveQuestionnaire.mockResolvedValue(null);
+
+      await expect(service.getQuestions()).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('submitSelf score & vulnerability', () => {
+    const patientUserId = 'patient-user-1';
+
+    beforeEach(() => {
+      repository.findPatientWithProfile.mockResolvedValue({
+        role: UserRole.PATIENT,
+        patientProfile: { id: 'profile-1' },
+      });
+      repository.findResponseByPatientProfileId.mockResolvedValue(null);
+      repository.findActiveQuestionnaire.mockResolvedValue(
+        makeActiveQuestionnaire(5),
+      );
+    });
+
+    it('sums option scores and flags vulnerable when score >= threshold', async () => {
+      repository.persistResponse.mockResolvedValue(
+        makePersistedResponse({ totalScore: 7, isVulnerable: true }),
+      );
+
+      await service.submitSelf(patientUserId, {
+        answers: [
+          { questionId: 'q1', optionId: 'q1-b' }, // 4
+          { questionId: 'q2', optionId: 'q2-b' }, // 3
+        ],
+      } as any);
+
+      expect(repository.persistResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ totalScore: 7, isVulnerable: true }),
+      );
+    });
+
+    it('flags NOT vulnerable when score is below threshold', async () => {
+      repository.persistResponse.mockResolvedValue(
+        makePersistedResponse({ totalScore: 1, isVulnerable: false }),
+      );
+
+      await service.submitSelf(patientUserId, {
+        answers: [
+          { questionId: 'q1', optionId: 'q1-a' }, // 1
+          { questionId: 'q2', optionId: 'q2-a' }, // 0
+        ],
+      } as any);
+
+      expect(repository.persistResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ totalScore: 1, isVulnerable: false }),
+      );
+    });
+
+    it('treats score exactly equal to threshold as vulnerable', async () => {
+      repository.findActiveQuestionnaire.mockResolvedValue(
+        makeActiveQuestionnaire(4),
+      );
+      repository.persistResponse.mockResolvedValue(
+        makePersistedResponse({ totalScore: 4, isVulnerable: true }),
+      );
+
+      await service.submitSelf(patientUserId, {
+        answers: [
+          { questionId: 'q1', optionId: 'q1-b' }, // 4
+          { questionId: 'q2', optionId: 'q2-a' }, // 0
+        ],
+      } as any);
+
+      expect(repository.persistResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ totalScore: 4, isVulnerable: true }),
+      );
+    });
+  });
+
+  describe('submitSelf validation', () => {
+    const patientUserId = 'patient-user-1';
+
+    beforeEach(() => {
+      repository.findPatientWithProfile.mockResolvedValue({
+        role: UserRole.PATIENT,
+        patientProfile: { id: 'profile-1' },
+      });
+      repository.findResponseByPatientProfileId.mockResolvedValue(null);
+      repository.findActiveQuestionnaire.mockResolvedValue(
+        makeActiveQuestionnaire(5),
+      );
+    });
+
+    it('rejects when not all questions are answered', async () => {
+      await expect(
+        service.submitSelf(patientUserId, {
+          answers: [{ questionId: 'q1', optionId: 'q1-a' }],
+        } as any),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(repository.persistResponse).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the same question is answered twice', async () => {
+      await expect(
+        service.submitSelf(patientUserId, {
+          answers: [
+            { questionId: 'q1', optionId: 'q1-a' },
+            { questionId: 'q1', optionId: 'q1-b' },
+          ],
+        } as any),
+      ).rejects.toThrow('respondida mais de uma vez');
+    });
+
+    it('rejects an option that does not belong to the question', async () => {
+      await expect(
+        service.submitSelf(patientUserId, {
+          answers: [
+            { questionId: 'q1', optionId: 'q2-a' }, // opção de outra pergunta
+            { questionId: 'q2', optionId: 'q2-b' },
+          ],
+        } as any),
+      ).rejects.toThrow('inválida');
+    });
+
+    it('rejects a question that is not part of the active questionnaire', async () => {
+      await expect(
+        service.submitSelf(patientUserId, {
+          answers: [
+            { questionId: 'q1', optionId: 'q1-a' },
+            { questionId: 'unknown', optionId: 'q2-a' },
+          ],
+        } as any),
+      ).rejects.toThrow('não pertence ao questionário ativo');
+    });
+  });
+
+  describe('duplicate submission rules', () => {
+    beforeEach(() => {
+      repository.findPatientWithProfile.mockResolvedValue({
+        role: UserRole.PATIENT,
+        patientProfile: { id: 'profile-1' },
+      });
+      repository.findActiveQuestionnaire.mockResolvedValue(
+        makeActiveQuestionnaire(5),
+      );
+    });
+
+    it('rejects self-submission when a response already exists', async () => {
+      repository.findResponseByPatientProfileId.mockResolvedValue({
+        id: 'existing',
+      });
+
+      await expect(
+        service.submitSelf('patient-user-1', { answers: [] } as any),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('rejects manager update when no response exists yet', async () => {
+      repository.findResponseByPatientProfileId.mockResolvedValue(null);
+
+      await expect(
+        service.updateForManager('manager-1', 'patient-user-1', {
+          answers: [],
+        } as any),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('getPatientProfileByUserId guard', () => {
+    it('throws NotFound when the user is not a patient', async () => {
+      repository.findPatientWithProfile.mockResolvedValue({
+        role: UserRole.PROFESSIONAL,
+        patientProfile: { id: 'profile-1' },
+      });
+
+      await expect(
+        service.getPatientResponse('not-a-patient'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+});

--- a/apps/server/src/speciality/speciality.service.spec.ts
+++ b/apps/server/src/speciality/speciality.service.spec.ts
@@ -1,25 +1,117 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { SpecialityRepository } from './speciality.repository';
 import { SpecialityService } from './speciality.service';
 
 describe('SpecialityService', () => {
+  const repository = {
+    findByNameInsensitive: jest.fn(),
+    create: jest.fn(),
+    findAllOrderedByName: jest.fn(),
+    findById: jest.fn(),
+    findDuplicateName: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+
   let service: SpecialityService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        SpecialityService,
-        {
-          provide: SpecialityRepository,
-          useValue: {},
-        },
-      ],
-    }).compile();
-
-    service = module.get<SpecialityService>(SpecialityService);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new SpecialityService(
+      repository as unknown as SpecialityRepository,
+    );
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('create', () => {
+    it('rejects a duplicate name', async () => {
+      repository.findByNameInsensitive.mockResolvedValue({ id: 's-1' });
+
+      await expect(
+        service.create({ name: 'Cardio' } as any),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('trims the name before persisting', async () => {
+      repository.findByNameInsensitive.mockResolvedValue(null);
+      repository.create.mockResolvedValue({ id: 's-1' });
+
+      await service.create({ name: '  Cardio  ' } as any);
+
+      expect(repository.findByNameInsensitive).toHaveBeenCalledWith('Cardio');
+      expect(repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Cardio' }),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('throws NotFound when missing', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(service.findOne('x')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('throws NotFound when the speciality does not exist', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(
+        service.update('x', { name: 'A' } as any),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('rejects renaming to an existing name', async () => {
+      repository.findById.mockResolvedValue({ id: 's-1' });
+      repository.findDuplicateName.mockResolvedValue({ id: 's-2' });
+
+      await expect(
+        service.update('s-1', { name: 'Cardio' } as any),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('trims and updates when the new name is unique', async () => {
+      repository.findById.mockResolvedValue({ id: 's-1' });
+      repository.findDuplicateName.mockResolvedValue(null);
+      repository.update.mockResolvedValue({ id: 's-1' });
+
+      await service.update('s-1', { name: '  Neuro  ' } as any);
+
+      expect(repository.findDuplicateName).toHaveBeenCalledWith('Neuro', 's-1');
+      expect(repository.update).toHaveBeenCalledWith(
+        's-1',
+        expect.objectContaining({ name: 'Neuro' }),
+      );
+    });
+
+    it('skips the duplicate check when name is not being changed', async () => {
+      repository.findById.mockResolvedValue({ id: 's-1' });
+      repository.update.mockResolvedValue({ id: 's-1' });
+
+      await service.update('s-1', { description: 'nova' } as any);
+
+      expect(repository.findDuplicateName).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove', () => {
+    it('throws NotFound when the speciality does not exist', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(service.remove('x')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('deletes when the speciality exists', async () => {
+      repository.findById.mockResolvedValue({ id: 's-1' });
+      repository.delete.mockResolvedValue({ id: 's-1' });
+
+      await service.remove('s-1');
+
+      expect(repository.delete).toHaveBeenCalledWith('s-1');
+    });
   });
 });

--- a/apps/server/src/users/users.service.spec.ts
+++ b/apps/server/src/users/users.service.spec.ts
@@ -1,0 +1,175 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { MailService } from 'src/mail/mail.service';
+import { UsersRepository } from './users.repository';
+import { UsersService } from './users.service';
+
+describe('UsersService', () => {
+  const repository = {
+    findByIdWithProfiles: jest.fn(),
+    findForUpdate: jest.fn(),
+    findForAdminUpdate: jest.fn(),
+    findByCpf: jest.fn(),
+    updateUser: jest.fn(),
+    upsertProfessionalProfile: jest.fn(),
+    updatePatientProfile: jest.fn(),
+    findAllUsers: jest.fn(),
+    findAllProfessionals: jest.fn(),
+  };
+  const mailService = {
+    sendAccountApprovedEmail: jest.fn().mockResolvedValue(undefined),
+    sendAccountRejectedEmail: jest.fn().mockResolvedValue(undefined),
+  };
+
+  let service: UsersService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new UsersService(
+      repository as unknown as UsersRepository,
+      mailService as unknown as MailService,
+    );
+  });
+
+  describe('findOne', () => {
+    it('throws NotFound when the user does not exist', async () => {
+      repository.findByIdWithProfiles.mockResolvedValue(null);
+
+      await expect(service.findOne('x')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('returns the user when found', async () => {
+      repository.findByIdWithProfiles.mockResolvedValue({ id: 'u-1' });
+
+      await expect(service.findOne('u-1')).resolves.toEqual({ id: 'u-1' });
+    });
+  });
+
+  describe('update', () => {
+    it('throws NotFound when the user does not exist', async () => {
+      repository.findForUpdate.mockResolvedValue(null);
+
+      await expect(service.update('x', {} as any)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('upserts the professional profile only for professionals with profile fields', async () => {
+      repository.findForUpdate.mockResolvedValue({
+        role: 'PROFESSIONAL',
+        professionalProfile: { photoUrl: 'old.png' },
+      });
+      repository.updateUser.mockResolvedValue({ id: 'u-1' });
+
+      await service.update('u-1', { bio: 'Nova bio' } as any);
+
+      expect(repository.upsertProfessionalProfile).toHaveBeenCalled();
+      expect(repository.updatePatientProfile).not.toHaveBeenCalled();
+    });
+
+    it('updates the patient profile only for patients with profile fields', async () => {
+      repository.findForUpdate.mockResolvedValue({
+        role: 'PATIENT',
+        patientProfile: {},
+      });
+      repository.updateUser.mockResolvedValue({ id: 'u-1' });
+
+      await service.update('u-1', { phone: '99999' } as any);
+
+      expect(repository.updatePatientProfile).toHaveBeenCalled();
+      expect(repository.upsertProfessionalProfile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateUserAsAdmin', () => {
+    it('rejects a CPF that already belongs to another user', async () => {
+      repository.findForAdminUpdate.mockResolvedValue({
+        id: 'u-1',
+        role: 'PATIENT',
+        cpf: '111',
+        patientProfile: {},
+      });
+      repository.findByCpf.mockResolvedValue({ id: 'other' });
+
+      await expect(
+        service.updateUserAsAdmin('u-1', { cpf: '999' } as any),
+      ).rejects.toThrow('CPF já cadastrado');
+    });
+
+    it('promotes a PENDING professional to COMPLETED when license and specialty are present', async () => {
+      repository.findForAdminUpdate.mockResolvedValue({
+        id: 'u-1',
+        role: 'PROFESSIONAL',
+        status: 'PENDING',
+        cpf: null,
+        professionalProfile: { specialities: [] },
+      });
+      repository.updateUser.mockResolvedValue({ id: 'u-1' });
+
+      await service.updateUserAsAdmin('u-1', {
+        crm: 'CRM-123',
+        specialty: ['spec-1'],
+      } as any);
+
+      expect(repository.updateUser).toHaveBeenCalledWith(
+        'u-1',
+        expect.objectContaining({ status: 'COMPLETED' }),
+      );
+    });
+
+    it('keeps the existing status when license/specialty are incomplete', async () => {
+      repository.findForAdminUpdate.mockResolvedValue({
+        id: 'u-1',
+        role: 'PROFESSIONAL',
+        status: 'PENDING',
+        cpf: null,
+        professionalProfile: { specialities: [] },
+      });
+      repository.updateUser.mockResolvedValue({ id: 'u-1' });
+
+      await service.updateUserAsAdmin('u-1', { crm: 'CRM-123' } as any);
+
+      expect(repository.updateUser).toHaveBeenCalledWith(
+        'u-1',
+        expect.objectContaining({ status: 'PENDING' }),
+      );
+    });
+  });
+
+  describe('verifyUser', () => {
+    it('sends an approval email when verifying', async () => {
+      repository.findForUpdate.mockResolvedValue({
+        name: 'A',
+        email: 'a@a.com',
+      });
+      repository.updateUser.mockResolvedValue({ id: 'u-1' });
+
+      await service.verifyUser('u-1', true);
+
+      expect(mailService.sendAccountApprovedEmail).toHaveBeenCalled();
+      expect(mailService.sendAccountRejectedEmail).not.toHaveBeenCalled();
+    });
+
+    it('sends a rejection email when not verifying', async () => {
+      repository.findForUpdate.mockResolvedValue({
+        name: 'A',
+        email: 'a@a.com',
+      });
+      repository.updateUser.mockResolvedValue({ id: 'u-1' });
+
+      await service.verifyUser('u-1', false);
+
+      expect(mailService.sendAccountRejectedEmail).toHaveBeenCalled();
+      expect(mailService.sendAccountApprovedEmail).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFound when the user does not exist', async () => {
+      repository.findForUpdate.mockResolvedValue(null);
+
+      await expect(service.verifyUser('x', true)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #185

## O que muda

### Fase 0 — Gate de testes no CI
`.github/workflows/ci.yml` passa a rodar `npm --workspace server run test` antes do build. Antes o CI só compilava; agora bloqueia regressões em todo PR para a main (relevante porque o deploy é automático ao merge).

### Fase 1 — Unitários das regras de negócio
Testes unitários dos services com lógica de negócio/CRUD, com dependências mockadas (repository, mail, Google Meet, Prisma). Sem novas dependências — usa o Jest já configurado.

| Service | Cobertura | Destaques |
|---------|-----------|-----------|
| medical-records | 68% | autorização de dados de saúde por perfil, vínculo de consulta, PDF restrito ao dono |
| manager | 97% | ordenação por score de vulnerabilidade (nulls no fim, desempate por data) |
| questionnaire | 83% | cálculo de score, flag de vulnerabilidade, validações |
| users | 90% | promoção PENDING→COMPLETED, CPF duplicado, e-mails |
| addresses | 85% | validação/mapeamento de CEP (ViaCEP), endereço único |
| speciality | 93% | CRUD, nome duplicado, trim |
| email-verification | 100% | token criar/validar/expirar/consumir/reenviar |
| questionnaire-admin | 100% | delegação + serialização |
| appointments | 72% | cancelamento, transições de status, geração de slots |
| patients | 75% | email/CPF duplicado, senha temporária |
| professional | 55% | validação de availability, agregação last/next visit |
| auth | 55% | register, forgot/reset password (anti-enumeração) |

## Resultado
- Testes: **11 → 134** (16 suítes, todas passando ✅)
- Cobertura global de services: **~14% → ~29.5%**

## Como validar
```
npm --workspace server run test
```