### PR TITLE
feat(prisma): adicionar suporte a multi-schema

### DIFF
--- a/apps/server/prisma/schema/base.prisma
+++ b/apps/server/prisma/schema/base.prisma
@@ -5,4 +5,5 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
+  schemas  = ["public", "users", "profiles", "scheduling", "questionnaire", "medical"]
 }

--- a/apps/server/prisma/schema/medical-records.prisma
+++ b/apps/server/prisma/schema/medical-records.prisma
@@ -21,4 +21,5 @@ model MedicalRecord {
 
   @@index([patientId, createdAt])
   @@map("medical_records")
+  @@schema("medical")
 }

--- a/apps/server/prisma/schema/profiles.prisma
+++ b/apps/server/prisma/schema/profiles.prisma
@@ -12,6 +12,7 @@ model ProfessionalProfile {
   payments            Json?
 
   @@map("professional_profiles")
+  @@schema("profiles")
 }
 
 model PatientProfile {
@@ -27,6 +28,7 @@ model PatientProfile {
   updatedAt              DateTime                    @updatedAt @map("updated_at")
 
   @@map("patient_profiles")
+  @@schema("profiles")
 }
 
 model ManagerProfile {
@@ -43,6 +45,7 @@ model ManagerProfile {
   cancelledAppointments Appointment[] @relation("CancelledByManager")
 
   @@map("manager_profiles")
+  @@schema("profiles")
 }
 
 model Address {
@@ -62,4 +65,5 @@ model Address {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   @@map("addresses")
+  @@schema("profiles")
 }

--- a/apps/server/prisma/schema/questionnaire.prisma
+++ b/apps/server/prisma/schema/questionnaire.prisma
@@ -1,6 +1,8 @@
 enum QuestionnaireAnsweredBy {
   PATIENT
   MANAGER
+
+  @@schema("questionnaire")
 }
 
 model Questionnaire {
@@ -12,6 +14,7 @@ model Questionnaire {
   responses VulnerabilityQuestionnaire[]
 
   @@map("questionnaires")
+  @@schema("questionnaire")
 }
 
 model Question {
@@ -27,6 +30,7 @@ model Question {
 
   @@index([questionnaireId, order])
   @@map("questions")
+  @@schema("questionnaire")
 }
 
 model QuestionOption {
@@ -42,6 +46,7 @@ model QuestionOption {
 
   @@index([questionId, order])
   @@map("question_options")
+  @@schema("questionnaire")
 }
 
 model VulnerabilityQuestionnaire {
@@ -60,6 +65,7 @@ model VulnerabilityQuestionnaire {
   answers QuestionnaireAnswer[]
 
   @@map("vulnerability_questionnaires")
+  @@schema("questionnaire")
 }
 
 model QuestionnaireAnswer {
@@ -74,4 +80,5 @@ model QuestionnaireAnswer {
 
   @@unique([vulnerabilityQuestionnaireId, questionId])
   @@map("questionnaire_answers")
+  @@schema("questionnaire")
 }

--- a/apps/server/prisma/schema/scheduling.prisma
+++ b/apps/server/prisma/schema/scheduling.prisma
@@ -2,6 +2,8 @@ enum AppointmentModality {
   VIRTUAL
   HOME_VISIT
   CLINIC
+
+  @@schema("scheduling")
 }
 
 enum AppointmentStatus {
@@ -10,6 +12,8 @@ enum AppointmentStatus {
   COMPLETED
   CANCELLED
   NO_SHOW
+
+  @@schema("scheduling")
 }
 
 model Appointment {
@@ -41,6 +45,7 @@ model Appointment {
   medicalRecord MedicalRecord?
 
   @@map("appointments")
+  @@schema("scheduling")
 }
 
 model Availability {
@@ -56,6 +61,7 @@ model Availability {
   validUntil DateTime? @map("valid_until")
 
   @@map("availability")
+  @@schema("scheduling")
 }
 
 model ScheduleBlock {
@@ -70,4 +76,5 @@ model ScheduleBlock {
   createdAt DateTime @default(now()) @map("created_at")
 
   @@map("schedule_blocks")
+  @@schema("scheduling")
 }

--- a/apps/server/prisma/schema/speciality.prisma
+++ b/apps/server/prisma/schema/speciality.prisma
@@ -6,4 +6,5 @@ model Speciality {
   professionalProfiles ProfessionalProfile[]
 
   @@map("specialties")
+  @@schema("profiles")
 }

--- a/apps/server/prisma/schema/user.prisma
+++ b/apps/server/prisma/schema/user.prisma
@@ -3,6 +3,8 @@ enum UserRole {
   PATIENT
   ADMIN
   MANAGER
+
+  @@schema("users")
 }
 
 enum UserStatus {
@@ -10,6 +12,8 @@ enum UserStatus {
   COMPLETED
   VERIFIED
   BLOCKED
+
+  @@schema("users")
 }
 
 model User {
@@ -44,6 +48,7 @@ model User {
   scheduleBlocks         ScheduleBlock[]
 
   @@map("users")
+  @@schema("users")
 }
 
 model PasswordReset {
@@ -56,6 +61,7 @@ model PasswordReset {
   createdAt DateTime @default(now()) @map("created_at")
 
   @@map("password_resets")
+  @@schema("users")
 }
 
 model Session {
@@ -66,6 +72,7 @@ model Session {
   data      String?  @db.Text
 
   @@map("sessions")
+  @@schema("users")
 }
 
 model EmailVerification {
@@ -78,4 +85,5 @@ model EmailVerification {
   createdAt DateTime @default(now()) @map("created_at")
 
   @@map("email_verifications")
+  @@schema("users")
 }


### PR DESCRIPTION
Adicionado o recurso de multi-schema no Prisma. Agora as tabelas estão devidamente separadas por escopo no banco de dados e visíveis em partes pelo Beekeeper Studio.