### PR TITLE
chore(server): cenário de prontuários no seed + dotenv como dependência

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -40,6 +40,7 @@
     "@scalar/nestjs-api-reference": "^0.3.15",
     "@types/pdfkit": "^0.17.6",
     "bcryptjs": "^3.0.3",
+    "dotenv": "^17.4.2",
     "googleapis": "^171.4.0",
     "nodemailer": "^7.0.12",
     "passport": "^0.7.0",

--- a/apps/server/prisma/seed.ts
+++ b/apps/server/prisma/seed.ts
@@ -288,6 +288,117 @@ async function main() {
   console.log(`  ${appointmentsCreated} Consultas criadas.`);
 
   // ─────────────────────────────────────────
+  // 6.1. CENÁRIO DE TESTE — PRONTUÁRIOS (controle de acesso entre médicos)
+  // ─────────────────────────────────────────
+  // Regra de negócio: um médico pode acessar o prontuário escrito por OUTRO
+  // médico do mesmo paciente (continuidade do cuidado), MAS apenas se ele
+  // próprio tiver vínculo de consulta (CONFIRMED/COMPLETED) com esse paciente.
+  // Sem vínculo → acesso negado (403).
+  //
+  // Este cenário monta os dois lados da regra:
+  //   • doctorA e doctorB: ambos atenderam o MESMO paciente e cada um tem um
+  //     prontuário próprio → devem conseguir ver o prontuário um do outro.
+  //   • doctorNoLink: NÃO tem nenhuma consulta com o paciente → deve receber
+  //     403 ao tentar acessar qualquer um desses prontuários.
+  console.log('⏳ Criando cenário de prontuários (controle de acesso entre médicos)...');
+
+  const sharedPatient = patients[0]; // Marcos de Almeida
+  const doctorA = professionals[0]; // Dr. Roberto Souza (Cardiologia) — tem vínculo
+  const doctorB = professionals[1]; // Dra. Ana Costa (Pediatria) — tem vínculo
+  const doctorNoLink = professionals[8]; // Dr. Tiago Freitas — SEM vínculo com o paciente
+
+  const recordScenarios = [
+    {
+      doctor: doctorA,
+      daysDiff: -25,
+      modality: AppointmentModality.CLINIC,
+      record: {
+        chiefComplaint: 'Dor torácica e palpitações há 1 semana.',
+        diagnosis: 'Arritmia cardíaca leve (extrassístoles).',
+        treatmentPlan: 'Reduzir cafeína, monitorar pressão arterial e retorno em 30 dias.',
+        prescriptions: 'Propranolol 40mg — 1 comprimido ao dia.',
+        internalNotes:
+          'Prontuário do Dr. Roberto (Cardiologia). Confidencial — anotação interna do cardiologista.',
+      },
+    },
+    {
+      doctor: doctorB,
+      daysDiff: -18,
+      modality: AppointmentModality.VIRTUAL,
+      record: {
+        chiefComplaint: 'Acompanhamento de quadro alérgico respiratório.',
+        diagnosis: 'Rinite alérgica sazonal.',
+        treatmentPlan: 'Anti-histamínico e controle ambiental de poeira.',
+        prescriptions: 'Loratadina 10mg — 1 comprimido ao dia por 15 dias.',
+        internalNotes:
+          'Prontuário da Dra. Ana (Pediatria). Confidencial — anotação interna da pediatra.',
+      },
+    },
+  ];
+
+  let recordsCreated = 0;
+  for (let i = 0; i < recordScenarios.length; i++) {
+    const { doctor, daysDiff, modality, record } = recordScenarios[i];
+
+    const apptId = generateUUID('33333333', i);
+    const recordId = generateUUID('44444444', i);
+
+    await prisma.appointment.upsert({
+      where: { id: apptId },
+      update: {
+        status: AppointmentStatus.COMPLETED,
+        modality,
+        dateTime: getRelativeDate(daysDiff),
+      },
+      create: {
+        id: apptId,
+        patientId: sharedPatient.id,
+        professionalId: doctor.id,
+        status: AppointmentStatus.COMPLETED,
+        modality,
+        dateTime: getRelativeDate(daysDiff),
+        notes: 'Consulta com prontuário registrado (cenário de teste de acesso).',
+      },
+    });
+
+    await prisma.medicalRecord.upsert({
+      where: { id: recordId },
+      update: { ...record },
+      create: {
+        id: recordId,
+        appointmentId: apptId,
+        patientId: sharedPatient.id,
+        authorId: doctor.id,
+        ...record,
+      },
+    });
+    recordsCreated++;
+  }
+
+  // Confirma que o médico "sem vínculo" realmente não tem consulta com o paciente.
+  const noLinkCount = await prisma.appointment.count({
+    where: {
+      professionalId: doctorNoLink.id,
+      patientId: sharedPatient.id,
+      status: { in: [AppointmentStatus.CONFIRMED, AppointmentStatus.COMPLETED] },
+    },
+  });
+
+  console.log(`  ${recordsCreated} prontuários criados.`);
+  console.log('  ── Cenário de teste de acesso a prontuários ──');
+  console.log(`     Paciente: ${sharedPatient.name} (${sharedPatient.email})`);
+  console.log(
+    `     ✅ ${doctorA.name} (${doctorA.email}) — autor de 1 prontuário e COM vínculo → vê o prontuário de ${doctorB.name}`,
+  );
+  console.log(
+    `     ✅ ${doctorB.name} (${doctorB.email}) — autora de 1 prontuário e COM vínculo → vê o prontuário de ${doctorA.name}`,
+  );
+  console.log(
+    `     ❌ ${doctorNoLink.name} (${doctorNoLink.email}) — SEM vínculo (${noLinkCount} consultas) → deve receber 403`,
+  );
+  console.log('     Senha de todos os usuários: Senha123!');
+
+  // ─────────────────────────────────────────
   // 7. QUESTIONÁRIO DE VULNERABILIDADE
   // ─────────────────────────────────────────
   console.log('⏳ Criando Questionário de Vulnerabilidade...');

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "@scalar/nestjs-api-reference": "^0.3.15",
         "@types/pdfkit": "^0.17.6",
         "bcryptjs": "^3.0.3",
+        "dotenv": "^17.4.2",
         "googleapis": "^171.4.0",
         "nodemailer": "^7.0.12",
         "passport": "^0.7.0",
@@ -266,6 +267,18 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "apps/server/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "apps/server/node_modules/eslint-scope": {
       "version": "5.1.1",


### PR DESCRIPTION
## O que muda

### 1. Cenário de prontuários no seed (teste de controle de acesso entre médicos)
Adiciona ao `prisma/seed.ts` um cenário que exercita a regra de acesso a prontuários:

- **Mesmo paciente** (Marcos de Almeida) atendido por **dois médicos diferentes**, cada um com seu próprio prontuário (autor e conteúdo distintos).
- Um **terceiro médico sem vínculo** com o paciente, para validar o bloqueio.

| Médico | Vínculo | Esperado |
|---|---|---|
| Dr. Roberto Souza (`roberto.souza@lifemed.com`) | sim | ✅ vê o prontuário da Dra. Ana |
| Dra. Ana Costa (`ana.costa@lifemed.com`) | sim | ✅ vê o prontuário do Dr. Roberto |
| Dr. Tiago Freitas (`tiago.freitas@lifemed.com`) | não | ❌ 403 |

Senha de todos: `Senha123!`. O seed imprime esse resumo ao rodar. Idempotente (upserts com UUIDs fixos).

> A regra já está implementada em `medical-records.service.ts` (`authorizeAndSerialize`): um médico vê o prontuário de outro do mesmo paciente apenas se tiver consulta `CONFIRMED`/`COMPLETED` com ele. Este cenário facilita testar manualmente os dois lados.

### 2. Fix de build: dotenv como dependência do servidor
`prisma.config.ts` faz `import "dotenv/config"`, mas `dotenv` não estava declarado em `apps/server`. Localmente funcionava por hoisting do monorepo; no Render (install limpo) o build quebrava com `Cannot find module 'dotenv/config'`. Agora declarado explicitamente.

## Validação
- `npx prisma db seed` executado com sucesso (via `prisma.config.ts`, confirmando o dotenv).
- Regra de acesso simulada contra o banco: PERMITIDO / PERMITIDO / 403, conforme esperado.
