### PR TITLE
fix: exigir aprovação manual mesmo para paciente vulnerável

### DIFF
--- a/apps/server/src/questionnaire/questionnaire.service.spec.ts
+++ b/apps/server/src/questionnaire/questionnaire.service.spec.ts
@@ -3,7 +3,11 @@ import {
   ConflictException,
   NotFoundException,
 } from '@nestjs/common';
-import { QuestionnaireAnsweredBy, UserRole } from '@prisma/client';
+import {
+  PatientApprovalStatus,
+  QuestionnaireAnsweredBy,
+  UserRole,
+} from '@prisma/client';
 import { QuestionnaireRepository } from './questionnaire.repository';
 import { QuestionnaireService } from './questionnaire.service';
 
@@ -151,6 +155,46 @@ describe('QuestionnaireService', () => {
 
       expect(repository.persistResponse).toHaveBeenCalledWith(
         expect.objectContaining({ totalScore: 4, isVulnerable: true }),
+      );
+    });
+
+    it('keeps approval PENDING even when the patient is vulnerable', async () => {
+      repository.persistResponse.mockResolvedValue(
+        makePersistedResponse({ totalScore: 7, isVulnerable: true }),
+      );
+
+      await service.submitSelf(patientUserId, {
+        answers: [
+          { questionId: 'q1', optionId: 'q1-b' }, // 4
+          { questionId: 'q2', optionId: 'q2-b' }, // 3
+        ],
+      } as any);
+
+      expect(repository.persistResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isVulnerable: true,
+          approvalStatus: PatientApprovalStatus.PENDING,
+        }),
+      );
+    });
+
+    it('keeps approval PENDING when the patient is not vulnerable', async () => {
+      repository.persistResponse.mockResolvedValue(
+        makePersistedResponse({ totalScore: 1, isVulnerable: false }),
+      );
+
+      await service.submitSelf(patientUserId, {
+        answers: [
+          { questionId: 'q1', optionId: 'q1-a' }, // 1
+          { questionId: 'q2', optionId: 'q2-a' }, // 0
+        ],
+      } as any);
+
+      expect(repository.persistResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isVulnerable: false,
+          approvalStatus: PatientApprovalStatus.PENDING,
+        }),
       );
     });
   });

--- a/apps/server/src/questionnaire/questionnaire.service.ts
+++ b/apps/server/src/questionnaire/questionnaire.service.ts
@@ -220,9 +220,11 @@ export class QuestionnaireService {
     }
 
     const isVulnerable = totalScore >= active.vulnerabilityThreshold;
-    const approvalStatus = isVulnerable
-      ? PatientApprovalStatus.APPROVED
-      : PatientApprovalStatus.PENDING;
+    // Regra de negócio: responder o questionário nunca aprova o paciente
+    // automaticamente. Independente da pontuação (mesmo atingindo o limiar de
+    // vulnerabilidade), o cadastro fica PENDING aguardando aprovação manual de
+    // um gestor/admin. O `isVulnerable` é apenas informativo para o gestor.
+    const approvalStatus = PatientApprovalStatus.PENDING;
 
     const created = await this.repository.persistResponse({
       dto,


### PR DESCRIPTION
## Problema

A regra de negócio diz que, após responder o questionário de vulnerabilidade, o paciente só deve acessar o sistema **se for aprovado** por um gestor.

Porém, ao responder o questionário e **atingir a pontuação de vulnerabilidade**, o paciente era marcado como `APPROVED` automaticamente. O fluxo logo após o envio redirecionava para a tela de espera (parecia correto), mas no **login seguinte** o paciente entrava no dashboard sem nunca ter sido aprovado.

## Causa raiz

Em `apps/server/src/questionnaire/questionnaire.service.ts` (`persistResponse`):

```ts
const approvalStatus = isVulnerable
  ? PatientApprovalStatus.APPROVED   // ❌ vulnerável virava aprovado automático
  : PatientApprovalStatus.PENDING;
```

Esse `approvalStatus` era persistido no `patientProfile` e refletido no cookie `patient-approval-status`, que o middleware (`proxy.ts`) usa para liberar as rotas.

## Correção

Responder o questionário agora **sempre** deixa o cadastro `PENDING`, independente da pontuação. O `isVulnerable` continua sendo calculado e persistido, apenas como informação para o gestor.

```ts
const approvalStatus = PatientApprovalStatus.PENDING;
```

## Testes

- Adicionados 2 casos em `questionnaire.service.spec.ts` garantindo `PENDING` para pacientes vulneráveis e não vulneráveis.
- Suíte completa de `questionnaire.service` passando (14/14).
- Validado manualmente: após responder o questionário, o re-login mantém o paciente na tela de espera até aprovação.

## Nota

PR direcionado para `fix/manager-registration-flow` (base da branch) para manter o diff limpo, contendo apenas esta correção.