### PR TITLE
feat: refatorar tela do paciente, admin e prontuários compartilhados

### DIFF
--- a/apps/server/src/appointments/appointments.service.spec.ts
+++ b/apps/server/src/appointments/appointments.service.spec.ts
@@ -153,16 +153,22 @@ describe('AppointmentsService', () => {
       ).rejects.toThrow('cancelado');
     });
 
-    it('rejects marking COMPLETED before the appointment time', async () => {
+    it('allows marking COMPLETED before the appointment time (correction flow)', async () => {
       repository.findAppointmentById.mockResolvedValue(
         makeAppointment({ dateTime: hoursFromNow(24) }),
       );
-
-      await expect(
-        service.updateAppointmentStatus('appt-1', 'prof-1', {
+      repository.updateAppointmentStatus.mockResolvedValue(
+        makeAppointment({
+          dateTime: hoursFromNow(24),
           status: AppointmentStatus.COMPLETED,
-        } as any),
-      ).rejects.toThrow('após o horário agendado');
+        }),
+      );
+
+      const result = await service.updateAppointmentStatus('appt-1', 'prof-1', {
+        status: AppointmentStatus.COMPLETED,
+      } as any);
+
+      expect(result.status).toBe(AppointmentStatus.COMPLETED);
     });
 
     it('allows marking COMPLETED after the appointment time', async () => {
@@ -181,6 +187,18 @@ describe('AppointmentsService', () => {
       } as any);
 
       expect(result.status).toBe(AppointmentStatus.COMPLETED);
+    });
+
+    it('rejects reverting COMPLETED to NO_SHOW', async () => {
+      repository.findAppointmentById.mockResolvedValue(
+        makeAppointment({ status: AppointmentStatus.COMPLETED }),
+      );
+
+      await expect(
+        service.updateAppointmentStatus('appt-1', 'prof-1', {
+          status: AppointmentStatus.NO_SHOW,
+        } as any),
+      ).rejects.toThrow('não compareceu');
     });
   });
 

--- a/apps/server/src/appointments/appointments.service.ts
+++ b/apps/server/src/appointments/appointments.service.ts
@@ -247,14 +247,14 @@ export class AppointmentsService {
       );
     }
 
-    if (
-      dto.status === AppointmentStatus.COMPLETED &&
-      appointment.dateTime.getTime() > Date.now()
-    ) {
-      throw new BadRequestException(
-        'Consulta só pode ser concluída após o horário agendado',
-      );
-    }
+    // if (
+    //   dto.status === AppointmentStatus.COMPLETED &&
+    //   appointment.dateTime.getTime() > Date.now()
+    // ) {
+    //   throw new BadRequestException(
+    //     'Consulta só pode ser concluída após o horário agendado',
+    //   );
+    // }
 
     const updated = await this.repository.updateAppointmentStatus(
       appointmentId,

--- a/apps/server/src/appointments/appointments.service.ts
+++ b/apps/server/src/appointments/appointments.service.ts
@@ -247,7 +247,15 @@ export class AppointmentsService {
       );
     }
 
-
+    // Consulta já realizada não pode ser revertida para "faltou"
+    if (
+      appointment.status === AppointmentStatus.COMPLETED &&
+      dto.status === AppointmentStatus.NO_SHOW
+    ) {
+      throw new BadRequestException(
+        'Não é possível marcar como "não compareceu" uma consulta já realizada',
+      );
+    }
 
     const updated = await this.repository.updateAppointmentStatus(
       appointmentId,

--- a/apps/server/src/appointments/appointments.service.ts
+++ b/apps/server/src/appointments/appointments.service.ts
@@ -247,14 +247,7 @@ export class AppointmentsService {
       );
     }
 
-    // if (
-    //   dto.status === AppointmentStatus.COMPLETED &&
-    //   appointment.dateTime.getTime() > Date.now()
-    // ) {
-    //   throw new BadRequestException(
-    //     'Consulta só pode ser concluída após o horário agendado',
-    //   );
-    // }
+
 
     const updated = await this.repository.updateAppointmentStatus(
       appointmentId,

--- a/apps/server/src/medical-records/medical-records.controller.ts
+++ b/apps/server/src/medical-records/medical-records.controller.ts
@@ -75,6 +75,20 @@ export class MedicalRecordsController {
     return this.service.list(req.user.userId, req.user.role, query);
   }
 
+  @Get('shared')
+  @UseGuards(ProfessionalRoleGuard)
+  @ApiOperation({
+    summary: 'Listar prontuários de pacientes já atendidos por outros profissionais',
+    description: 'Retorna prontuários de pacientes com os quais o profissional tem vínculo, criados por outros profissionais. Somente leitura.',
+  })
+  @ApiResponse({ status: 200, type: MedicalRecordListResponseDto })
+  listShared(
+    @Request() req: { user: { userId: string } },
+    @Query() query: ListMedicalRecordsQueryDto,
+  ) {
+    return this.service.listShared(req.user.userId, query);
+  }
+
   @Get(':id')
   @ApiOperation({
     summary: 'Buscar prontuário por ID',

--- a/apps/server/src/medical-records/medical-records.repository.ts
+++ b/apps/server/src/medical-records/medical-records.repository.ts
@@ -85,6 +85,67 @@ export class MedicalRecordsRepository {
     });
   }
 
+  async listSharedForProfessional(
+    professionalId: string,
+    query: ListMedicalRecordsQueryDto,
+  ) {
+    const page = query.page || 1;
+    const limit = query.limit || 10;
+    const skip = (page - 1) * limit;
+
+    // Pacientes que este profissional já atendeu (CONFIRMED ou COMPLETED)
+    const attended = await this.prisma.appointment.findMany({
+      where: {
+        professionalId,
+        status: { in: ['CONFIRMED', 'COMPLETED'] },
+      },
+      select: { patientId: true },
+      distinct: ['patientId'],
+    });
+
+    const patientIds = attended.map((a) => a.patientId);
+
+    if (patientIds.length === 0) {
+      return { records: [], total: 0, page, limit };
+    }
+
+    const where: Prisma.MedicalRecordWhereInput = {
+      patientId: { in: patientIds },
+      // Exclui os próprios prontuários (esses ficam em "Meus prontuários")
+      NOT: { authorId: professionalId },
+    };
+
+    if (query.search?.trim()) {
+      const term = query.search.trim();
+      where.OR = [
+        { patient: { name: { contains: term, mode: 'insensitive' } } },
+        { author: { name: { contains: term, mode: 'insensitive' } } },
+        { chiefComplaint: { contains: term, mode: 'insensitive' } },
+        { diagnosis: { contains: term, mode: 'insensitive' } },
+      ];
+    }
+
+    if (query.startDate || query.endDate) {
+      where.createdAt = {
+        ...(query.startDate && { gte: new Date(query.startDate) }),
+        ...(query.endDate && { lte: new Date(query.endDate) }),
+      };
+    }
+
+    const [records, total] = await Promise.all([
+      this.prisma.medicalRecord.findMany({
+        where,
+        include: RECORD_INCLUDE,
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.medicalRecord.count({ where }),
+    ]);
+
+    return { records, total, page, limit };
+  }
+
   updateRecord(id: string, dto: UpdateMedicalRecordDto) {
     return this.prisma.medicalRecord.update({
       where: { id },

--- a/apps/server/src/medical-records/medical-records.service.ts
+++ b/apps/server/src/medical-records/medical-records.service.ts
@@ -162,6 +162,21 @@ export class MedicalRecordsService {
     };
   }
 
+  async listShared(
+    professionalId: string,
+    query: ListMedicalRecordsQueryDto,
+  ): Promise<MedicalRecordListResponseDto> {
+    const { records, total, page, limit } =
+      await this.repository.listSharedForProfessional(professionalId, query);
+
+    return {
+      data: records.map((r) => this.toResponseDto(r)),
+      page,
+      limit,
+      total,
+    };
+  }
+
   async findByPatient(
     patientId: string,
     requesterId: string,

--- a/apps/web/app/dashboard/admin/components/UsersTable.tsx
+++ b/apps/web/app/dashboard/admin/components/UsersTable.tsx
@@ -38,7 +38,6 @@ type SortField =
 type SortDir = "asc" | "desc";
 
 const TYPE_TABS: { label: string; value: TypeFilter }[] = [
-  { label: "Todos", value: "all" },
   { label: "Pacientes", value: "PATIENT" },
   { label: "Profissionais", value: "PROFESSIONAL" },
   { label: "Gestores", value: "MANAGER" },
@@ -335,17 +334,6 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
               Usuário
             </SortableHeader>
 
-            {typeFilter === "all" && (
-              <SortableHeader
-                field="type"
-                currentField={sortField}
-                direction={sortDir}
-                onToggle={toggleSort}
-                align="center"
-              >
-                Tipo
-              </SortableHeader>
-            )}
 
             {typeFilter === "PATIENT" && (
               <>
@@ -431,16 +419,6 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
                       {user.email}
                     </p>
                   </DataTableCell>
-
-                  {typeFilter === "all" && (
-                    <DataTableCell align="center">
-                      <span
-                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${badge.className}`}
-                      >
-                        {badge.label}
-                      </span>
-                    </DataTableCell>
-                  )}
 
                   {typeFilter === "PATIENT" && (
                     <>

--- a/apps/web/app/dashboard/admin/components/UsersTable.tsx
+++ b/apps/web/app/dashboard/admin/components/UsersTable.tsx
@@ -98,8 +98,8 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
   const { users, isLoading, search, setSearch, typeFilter, setTypeFilter } =
     useAdminUsersTable();
 
-  const [sortField, setSortField] = useState<SortField | null>(null);
-  const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [sortField, setSortField] = useState<SortField | null>("createdAt");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
 
   function toggleSort(field: SortField) {
     if (sortField === field) {

--- a/apps/web/app/dashboard/admin/page.tsx
+++ b/apps/web/app/dashboard/admin/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { ClipboardList, Plus, Stethoscope } from "lucide-react";
-import { adminService } from "@/services/admin-service";
+import { adminService, type AdminUser } from "@/services/admin-service";
 import { toast } from "sonner";
 import { UsersTable } from "@/app/dashboard/admin/components/UsersTable";
 import { useQueryClient } from "@tanstack/react-query";
@@ -16,13 +16,21 @@ const AdminDashboard = () => {
     userId: string,
     newStatus: "VERIFIED" | "BLOCKED",
   ) => {
+    // Optimistic update: atualiza o cache imediatamente antes da chamada de API
+    queryClient.setQueriesData<AdminUser[]>(
+      { queryKey: ["admin-users"] },
+      (old) =>
+        old?.map((u) => (u.id === userId ? { ...u, status: newStatus } : u)) ??
+        old,
+    );
     try {
       await adminService.updateUser(userId, { status: newStatus });
       toast.success("Status do usuário atualizado com sucesso!");
-      queryClient.invalidateQueries({ queryKey: ["admin-users"] });
     } catch (error) {
       console.error(error);
       toast.error("Não foi possível atualizar o status do usuário. Tente novamente.");
+      // Reverte em caso de erro
+      queryClient.invalidateQueries({ queryKey: ["admin-users"] });
     }
   };
 

--- a/apps/web/app/dashboard/admin/users/[id]/admin-user.validation.ts
+++ b/apps/web/app/dashboard/admin/users/[id]/admin-user.validation.ts
@@ -1,5 +1,6 @@
 import * as z from "zod";
 import { isValidPhoneBR } from "@/components/ui/phone-input-br";
+import { CPF_INVALID_MESSAGE, isValidCpf } from "@/lib/cpf";
 
 export const patientFormSchema = z.object({
   name: z.string().min(1, "Nome é obrigatório"),
@@ -15,7 +16,12 @@ export const patientFormSchema = z.object({
   dateOfBirth: z.string().optional(),
   gender: z.string().optional(),
   address: z.string().optional(),
-  cpf: z.string().optional(),
+  cpf: z
+    .string()
+    .optional()
+    .nullable()
+    .or(z.literal(""))
+    .refine((val) => !val || isValidCpf(val), { message: CPF_INVALID_MESSAGE }),
 });
 
 export const professionalFormSchema = z.object({

--- a/apps/web/app/dashboard/admin/users/[id]/components/PatientProfileForm.tsx
+++ b/apps/web/app/dashboard/admin/users/[id]/components/PatientProfileForm.tsx
@@ -1,6 +1,12 @@
-import { type UseFormRegister, type FieldErrors, Controller, Control } from "react-hook-form";
+import {
+  type UseFormRegister,
+  type FieldErrors,
+  Controller,
+  Control,
+} from "react-hook-form";
 import type { PatientFormSchema } from "../admin-user.validation";
 import { PhoneInputBR } from "@/components/ui/phone-input-br";
+import { applyCpfMask } from "@/lib/cpf";
 
 type PatientProfileFormProps = {
   register: UseFormRegister<PatientFormSchema>;
@@ -9,27 +15,74 @@ type PatientProfileFormProps = {
   isEditing: boolean;
 };
 
-export function PatientProfileForm({ register, errors, control, isEditing }: PatientProfileFormProps) {
+export function PatientProfileForm({
+  register,
+  errors,
+  control,
+  isEditing,
+}: PatientProfileFormProps) {
   return (
     <>
-      <h3 className="mt-6 mb-1 text-base font-semibold text-gray-700">Informações Pessoais</h3>
+      <h3 className="mt-6 mb-1 text-base font-semibold text-gray-700">
+        Informações Pessoais
+      </h3>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-5 mt-5">
         <div className="flex flex-col gap-1.5">
-          <label className="text-sm font-semibold text-gray-700">Nome Completo</label>
-          <input className="px-3 py-2.5 border border-gray-200 rounded-lg bg-white text-[0.95rem] text-gray-900 transition-colors duration-200 focus:outline-none focus:border-[#006fee] focus:shadow-[0_0_0_3px_rgba(0,111,238,0.1)] disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed" disabled={!isEditing} {...register("name")} />
-          {errors.name && <span className="text-xs text-red-600 mt-0.5">{errors.name.message}</span>}
+          <label className="text-sm font-semibold text-gray-700">
+            Nome Completo
+          </label>
+          <input
+            className="px-3 py-2.5 border border-gray-200 rounded-lg bg-white text-[0.95rem] text-gray-900 transition-colors duration-200 focus:outline-none focus:border-[#006fee] focus:shadow-[0_0_0_3px_rgba(0,111,238,0.1)] disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed"
+            disabled={!isEditing}
+            {...register("name")}
+          />
+          {errors.name && (
+            <span className="text-xs text-red-600 mt-0.5">
+              {errors.name.message}
+            </span>
+          )}
         </div>
         <div className="flex flex-col gap-1.5">
           <label className="text-sm font-semibold text-gray-700">Email</label>
-          <input className="px-3 py-2.5 border border-gray-200 rounded-lg bg-white text-[0.95rem] text-gray-900 transition-colors duration-200 focus:outline-none focus:border-[#006fee] focus:shadow-[0_0_0_3px_rgba(0,111,238,0.1)] disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed" disabled={!isEditing} {...register("email")} />
-          {errors.email && <span className="text-xs text-red-600 mt-0.5">{errors.email.message}</span>}
+          <input
+            className="px-3 py-2.5 border border-gray-200 rounded-lg bg-white text-[0.95rem] text-gray-900 transition-colors duration-200 focus:outline-none focus:border-[#006fee] focus:shadow-[0_0_0_3px_rgba(0,111,238,0.1)] disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed"
+            disabled={!isEditing}
+            {...register("email")}
+          />
+          {errors.email && (
+            <span className="text-xs text-red-600 mt-0.5">
+              {errors.email.message}
+            </span>
+          )}
         </div>
         <div className="flex flex-col gap-1.5">
           <label className="text-sm font-semibold text-gray-700">CPF</label>
-          <input className="px-3 py-2.5 border border-gray-200 rounded-lg bg-white text-[0.95rem] text-gray-900 transition-colors duration-200 focus:outline-none focus:border-[#006fee] focus:shadow-[0_0_0_3px_rgba(0,111,238,0.1)] disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed" disabled={!isEditing} {...register("cpf")} />
+          <Controller
+            name="cpf"
+            control={control}
+            render={({ field }) => (
+              <input
+                className="px-3 py-2.5 border border-gray-200 rounded-lg bg-white text-[0.95rem] text-gray-900 transition-colors duration-200 focus:outline-none focus:border-[#006fee] focus:shadow-[0_0_0_3px_rgba(0,111,238,0.1)] disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed"
+                disabled={!isEditing}
+                inputMode="numeric"
+                placeholder="000.000.000-00"
+                value={applyCpfMask(field.value ?? "")}
+                onChange={(e) => field.onChange(applyCpfMask(e.target.value))}
+                onBlur={field.onBlur}
+                ref={field.ref}
+              />
+            )}
+          />
+          {errors.cpf && (
+            <span className="text-xs text-red-600 mt-0.5">
+              {errors.cpf.message}
+            </span>
+          )}
         </div>
         <div className="flex flex-col gap-1.5">
-          <label className="text-sm font-semibold text-gray-700">Telefone</label>
+          <label className="text-sm font-semibold text-gray-700">
+            Telefone
+          </label>
           <Controller
             name="phone"
             control={control}
@@ -49,12 +102,23 @@ export function PatientProfileForm({ register, errors, control, isEditing }: Pat
           )}
         </div>
         <div className="flex flex-col gap-1.5">
-          <label className="text-sm font-semibold text-gray-700">Data de Nascimento</label>
-          <input type="date" className="px-3 py-2.5 border border-gray-200 rounded-lg bg-white text-[0.95rem] text-gray-900 transition-colors duration-200 focus:outline-none focus:border-[#006fee] focus:shadow-[0_0_0_3px_rgba(0,111,238,0.1)] disabled:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-100 disabled:[color-scheme:light]" disabled={!isEditing} {...register("dateOfBirth")} />
+          <label className="text-sm font-semibold text-gray-700">
+            Data de Nascimento
+          </label>
+          <input
+            type="date"
+            className="px-3 py-2.5 border border-gray-200 rounded-lg bg-white text-[0.95rem] text-gray-900 transition-colors duration-200 focus:outline-none focus:border-[#006fee] focus:shadow-[0_0_0_3px_rgba(0,111,238,0.1)] disabled:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-100 disabled:[color-scheme:light]"
+            disabled={!isEditing}
+            {...register("dateOfBirth")}
+          />
         </div>
         <div className="flex flex-col gap-1.5">
           <label className="text-sm font-semibold text-gray-700">Gênero</label>
-          <select className="px-3 py-2.5 border border-gray-200 rounded-lg bg-white text-[0.95rem] text-gray-900 transition-colors duration-200 focus:outline-none focus:border-[#006fee] focus:shadow-[0_0_0_3px_rgba(0,111,238,0.1)] disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed appearance-none cursor-pointer" disabled={!isEditing} {...register("gender")}>
+          <select
+            className="px-3 py-2.5 border border-gray-200 rounded-lg bg-white text-[0.95rem] text-gray-900 transition-colors duration-200 focus:outline-none focus:border-[#006fee] focus:shadow-[0_0_0_3px_rgba(0,111,238,0.1)] disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed appearance-none cursor-pointer"
+            disabled={!isEditing}
+            {...register("gender")}
+          >
             <option value="">Selecione</option>
             <option value="Masculino">Masculino</option>
             <option value="Feminino">Feminino</option>
@@ -64,13 +128,21 @@ export function PatientProfileForm({ register, errors, control, isEditing }: Pat
         </div>
         <div className="flex flex-col gap-1.5">
           <label className="text-sm font-semibold text-gray-700">Status</label>
-          <select className="px-3 py-2.5 border border-gray-200 rounded-lg bg-white text-[0.95rem] text-gray-900 transition-colors duration-200 focus:outline-none focus:border-[#006fee] focus:shadow-[0_0_0_3px_rgba(0,111,238,0.1)] disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed" disabled={!isEditing} {...register("status")}>
+          <select
+            className="px-3 py-2.5 border border-gray-200 rounded-lg bg-white text-[0.95rem] text-gray-900 transition-colors duration-200 focus:outline-none focus:border-[#006fee] focus:shadow-[0_0_0_3px_rgba(0,111,238,0.1)] disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed"
+            disabled={!isEditing}
+            {...register("status")}
+          >
             <option value="PENDING">Pendente</option>
             <option value="COMPLETED">Completo</option>
             <option value="VERIFIED">Verificado</option>
             <option value="BLOCKED">Bloqueado</option>
           </select>
-          {errors.status && <span className="text-xs text-red-600 mt-0.5">{errors.status.message}</span>}
+          {errors.status && (
+            <span className="text-xs text-red-600 mt-0.5">
+              {errors.status.message}
+            </span>
+          )}
         </div>
       </div>
     </>

--- a/apps/web/app/dashboard/admin/users/[id]/page.tsx
+++ b/apps/web/app/dashboard/admin/users/[id]/page.tsx
@@ -79,7 +79,6 @@ const AdminUserProfilePage = () => {
       ? photoPath
       : `${apiBaseUrl}${photoPath}`
     : null;
-  console.log("user", user);
 
   return (
     <PageShell>

--- a/apps/web/app/dashboard/admin/users/[id]/page.tsx
+++ b/apps/web/app/dashboard/admin/users/[id]/page.tsx
@@ -79,6 +79,7 @@ const AdminUserProfilePage = () => {
       ? photoPath
       : `${apiBaseUrl}${photoPath}`
     : null;
+  console.log("user", user);
 
   return (
     <PageShell>

--- a/apps/web/app/dashboard/admin/users/[id]/useAdminUserForm.ts
+++ b/apps/web/app/dashboard/admin/users/[id]/useAdminUserForm.ts
@@ -14,6 +14,7 @@ import {
   type PatientApprovalStatus,
 } from "@/services/admin-service";
 import { useSpecialitiesQuery } from "@/queries/useSpecialitiesQuery";
+import { onlyCpfDigits } from "@/lib/cpf";
 import {
   patientFormSchema,
   professionalFormSchema,
@@ -107,7 +108,7 @@ export function useAdminUserForm() {
           dateOfBirth: data.patientProfile?.dateOfBirth?.split("T")[0] || "",
           gender: data.patientProfile?.gender || "",
           address: data.patientProfile?.address || "",
-          cpf: data.patientProfile?.cpf || "",
+          cpf: data.cpf || "",
         });
       } else {
         professionalForm.reset({
@@ -157,7 +158,7 @@ export function useAdminUserForm() {
         phone: normalizedPhone,
         dateOfBirth: data.dateOfBirth || undefined,
         gender: data.gender || undefined,
-        cpf: data.cpf || undefined,
+        cpf: data.cpf ? onlyCpfDigits(data.cpf) : undefined,
       });
       toast.success("Dados do usuário atualizados com sucesso.");
       setIsEditing(false);

--- a/apps/web/app/dashboard/professional/medical-records/page.tsx
+++ b/apps/web/app/dashboard/professional/medical-records/page.tsx
@@ -7,13 +7,19 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import { CardGridSkeleton } from "@/components/ui/skeletons";
 import { Badge } from "@/components/ui/badge";
-import { useMedicalRecordsListQuery } from "@/queries/useMedicalRecords";
+import {
+  useMedicalRecordsListQuery,
+  useSharedMedicalRecordsQuery,
+} from "@/queries/useMedicalRecords";
 import { SearchInput } from "@/components/ui/search-input";
-import { CalendarIcon, EyeIcon } from "../../../utils/icons";
+import { CalendarIcon, EyeIcon, UsersIcon } from "../../../utils/icons";
 import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 import { TourButton } from "@/components/tour/TourButton";
+import type { MedicalRecordResponse } from "@/services/medical-records-service";
 
 const PAGE_SIZE = 10;
+
+type ViewMode = "mine" | "shared";
 
 function formatDateTime(iso: string) {
   const d = new Date(iso);
@@ -31,7 +37,8 @@ function truncate(text: string | null, max = 120) {
   return text.length > max ? `${text.slice(0, max)}…` : text;
 }
 
-const MedicalRecordsListPage = () => {
+// ——— Vista "Meus prontuários" ———
+function MyRecordsView() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const initialSearch = searchParams.get("search") ?? "";
@@ -75,20 +82,10 @@ const MedicalRecordsListPage = () => {
   const hasFilters = Boolean(search || startDate || endDate);
 
   return (
-    <PageShell>
-      <PageHeader
-        title="Prontuários"
-        description={`Prontuários médicos criados por você.{" "}
-         ${total > 0 ? ` ${total} no total.` : ""}`}
-        help={<TourButton tour="professional-records" />}
-      />
-
+    <>
       <Card id="tour-prof-records-search" className="mb-6 border border-gray-200 rounded-xl bg-white">
         <CardContent className="p-4 sm:p-5">
-          <form
-            onSubmit={handleSearch}
-            className="flex flex-col gap-3 sm:flex-row sm:items-end"
-          >
+          <form onSubmit={handleSearch} className="flex flex-col gap-3 sm:flex-row sm:items-end">
             <div className="flex-1 flex flex-col gap-1">
               <label className="text-xs font-medium text-slate-600">
                 Buscar (paciente, queixa ou diagnóstico)
@@ -100,44 +97,27 @@ const MedicalRecordsListPage = () => {
               />
             </div>
             <div className="flex flex-col gap-1">
-              <label className="text-xs font-medium text-slate-600">
-                Data inicial
-              </label>
+              <label className="text-xs font-medium text-slate-600">Data inicial</label>
               <Input
                 type="date"
                 value={startDate}
-                onChange={(e) => {
-                  setStartDate(e.target.value);
-                  setPage(1);
-                }}
+                onChange={(e) => { setStartDate(e.target.value); setPage(1); }}
                 className="w-full sm:w-44"
               />
             </div>
             <div className="flex flex-col gap-1">
-              <label className="text-xs font-medium text-slate-600">
-                Data final
-              </label>
+              <label className="text-xs font-medium text-slate-600">Data final</label>
               <Input
                 type="date"
                 value={endDate}
-                onChange={(e) => {
-                  setEndDate(e.target.value);
-                  setPage(1);
-                }}
+                onChange={(e) => { setEndDate(e.target.value); setPage(1); }}
                 className="w-full sm:w-44"
               />
             </div>
             <div className="flex gap-2">
-              <Button type="submit" title="Aplicar busca">
-                Buscar
-              </Button>
+              <Button type="submit" title="Aplicar busca">Buscar</Button>
               {hasFilters && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={handleClearFilters}
-                  title="Remover filtros"
-                >
+                <Button type="button" variant="outline" onClick={handleClearFilters} title="Remover filtros">
                   Limpar
                 </Button>
               )}
@@ -149,107 +129,226 @@ const MedicalRecordsListPage = () => {
       {isLoading ? (
         <CardGridSkeleton count={4} minWidth={400} />
       ) : records.length === 0 ? (
-        <Card className="border border-dashed border-gray-300 rounded-xl bg-white">
-          <CardContent className="py-16 text-center flex flex-col items-center gap-3">
-            <div className="w-14 h-14 rounded-full bg-blue-50 text-blue-600 flex items-center justify-center">
-              <CalendarIcon size={28} />
-            </div>
-            <div>
-              <p className="text-base font-semibold text-slate-800">
-                Nenhum prontuário encontrado
-              </p>
-              <p className="text-sm text-slate-500 mt-1 max-w-md">
-                {hasFilters
-                  ? "Tente ajustar os filtros acima."
-                  : "Os prontuários que você criar a partir das consultas aparecerão aqui."}
-              </p>
-            </div>
-          </CardContent>
-        </Card>
+        <EmptyState hasFilters={hasFilters} mode="mine" />
       ) : (
         <div id="tour-prof-records-list" className="flex flex-col gap-3">
           {records.map((record) => (
-            <Card
+            <RecordCard
               key={record.id}
-              className="border border-gray-200 rounded-xl bg-white"
-            >
-              <CardContent className="p-4 sm:p-5 flex gap-4 items-center">
-                <div className="w-11 h-11 rounded-full bg-blue-50 border border-blue-100 text-blue-700 flex items-center justify-center font-semibold shrink-0">
-                  {(record.patient?.name ?? "P").charAt(0).toUpperCase()}
-                </div>
-                <div className="flex-1 min-w-0 flex flex-col gap-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <h3 className="text-[15px] font-semibold text-slate-900 truncate">
-                      {record.patient?.name ?? "Paciente"}
-                    </h3>
-                    {record.appointment && (
-                      <Badge className="bg-slate-100 text-slate-600 px-2 py-0.5 text-[11px] rounded font-medium">
-                        {record.appointment.modality === "VIRTUAL"
-                          ? "Virtual"
-                          : "Presencial"}
-                      </Badge>
-                    )}
-                  </div>
-                  <p className="flex items-center gap-1.5 text-xs text-slate-500">
-                    <CalendarIcon size={14} />
-                    {record.appointment
-                      ? formatDateTime(record.appointment.dateTime)
-                      : `Criado em ${formatDateTime(record.createdAt)}`}
-                  </p>
-                  {(record.diagnosis || record.chiefComplaint) && (
-                    <p className="text-sm text-slate-700 line-clamp-1 mt-0.5">
-                      <span className="text-slate-500">
-                        {record.diagnosis ? "Diagnóstico: " : "Queixa: "}
-                      </span>
-                      {truncate(record.diagnosis ?? record.chiefComplaint)}
-                    </p>
-                  )}
-                </div>
-                <Button
-                  size="sm"
-                  onClick={() =>
-                    router.push(
-                      `/dashboard/professional/medical-records/${record.id}`,
-                    )
-                  }
-                  title="Abrir prontuário"
-                  className="shrink-0"
-                >
-                  <EyeIcon size={16} /> Abrir
-                </Button>
-              </CardContent>
-            </Card>
+              record={record}
+              onClick={() => router.push(`/dashboard/professional/medical-records/${record.id}`)}
+            />
           ))}
         </div>
       )}
 
       {totalPages > 1 && (
         <div className="mt-6 flex items-center justify-between gap-3">
-          <p className="text-xs text-slate-500">
-            Página {page} de {totalPages}
-          </p>
+          <p className="text-xs text-slate-500">Página {page} de {totalPages}</p>
           <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page <= 1 || isFetching}
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-              title="Página anterior"
-            >
-              Anterior
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page >= totalPages || isFetching}
-              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-              title="Próxima página"
-            >
-              Próxima
-            </Button>
+            <Button variant="outline" size="sm" disabled={page <= 1 || isFetching}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}>Anterior</Button>
+            <Button variant="outline" size="sm" disabled={page >= totalPages || isFetching}
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}>Próxima</Button>
           </div>
         </div>
       )}
+    </>
+  );
+}
+
+// ——— Vista "Todos do paciente" (prontuários de pacientes já atendidos) ———
+function SharedRecordsView() {
+  const router = useRouter();
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  const params = useMemo(
+    () => ({ page, limit: PAGE_SIZE, ...(search && { search }) }),
+    [page, search],
+  );
+
+  const { data, isLoading, isFetching } = useSharedMedicalRecordsQuery(params);
+
+  const records = (data?.data ?? []) as MedicalRecordResponse[];
+  const total = data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setPage(1);
+  };
+
+  return (
+    <>
+      <Card className="mb-6 border border-gray-200 rounded-xl bg-white">
+        <CardContent className="p-4 sm:p-5">
+          <form onSubmit={handleSearch} className="flex gap-3">
+            <SearchInput
+              value={search}
+              onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+              placeholder="Buscar por paciente, profissional, queixa ou diagnóstico…"
+              className="flex-1"
+            />
+          </form>
+        </CardContent>
+      </Card>
+
+      {isLoading ? (
+        <CardGridSkeleton count={4} minWidth={400} />
+      ) : records.length === 0 ? (
+        <EmptyState hasFilters={Boolean(search)} mode="shared" />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {records.map((record) => (
+            <RecordCard
+              key={record.id}
+              record={record}
+              shared
+              onClick={() =>
+                router.push(`/dashboard/professional/medical-records/shared/${record.id}`)
+              }
+            />
+          ))}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="mt-6 flex items-center justify-between gap-3">
+          <p className="text-xs text-slate-500">Página {page} de {totalPages}</p>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" disabled={page <= 1 || isFetching}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}>Anterior</Button>
+            <Button variant="outline" size="sm" disabled={page >= totalPages || isFetching}
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}>Próxima</Button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+// ——— Card reutilizável ———
+function RecordCard({
+  record,
+  shared = false,
+  onClick,
+}: {
+  record: MedicalRecordResponse;
+  shared?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Card className="border border-gray-200 rounded-xl bg-white">
+      <CardContent className="p-4 sm:p-5 flex gap-4 items-center">
+        <div className="w-11 h-11 rounded-full bg-blue-50 border border-blue-100 text-blue-700 flex items-center justify-center font-semibold shrink-0">
+          {(record.patient?.name ?? "P").charAt(0).toUpperCase()}
+        </div>
+        <div className="flex-1 min-w-0 flex flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-[15px] font-semibold text-slate-900 truncate">
+              {record.patient?.name ?? "Paciente"}
+            </h3>
+            {record.appointment && (
+              <Badge className="bg-slate-100 text-slate-600 px-2 py-0.5 text-[11px] rounded font-medium">
+                {record.appointment.modality === "VIRTUAL" ? "Virtual" : "Presencial"}
+              </Badge>
+            )}
+            {shared && (
+              <Badge className="bg-amber-50 text-amber-700 border border-amber-200 px-2 py-0.5 text-[11px] rounded font-medium">
+                Somente leitura
+              </Badge>
+            )}
+          </div>
+          <p className="flex items-center gap-1.5 text-xs text-slate-500">
+            <CalendarIcon size={14} />
+            {record.appointment
+              ? formatDateTime(record.appointment.dateTime)
+              : `Criado em ${formatDateTime(record.createdAt)}`}
+          </p>
+          {shared && (
+            <p className="text-xs text-slate-400">
+              Registrado por <span className="font-medium text-slate-600">{record.author.name}</span>
+            </p>
+          )}
+          {(record.diagnosis || record.chiefComplaint) && (
+            <p className="text-sm text-slate-700 line-clamp-1 mt-0.5">
+              <span className="text-slate-500">
+                {record.diagnosis ? "Diagnóstico: " : "Queixa: "}
+              </span>
+              {truncate(record.diagnosis ?? record.chiefComplaint)}
+            </p>
+          )}
+        </div>
+        <Button size="sm" onClick={onClick} title="Abrir prontuário" className="shrink-0">
+          <EyeIcon size={16} /> Abrir
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function EmptyState({ hasFilters, mode }: { hasFilters: boolean; mode: ViewMode }) {
+  return (
+    <Card className="border border-dashed border-gray-300 rounded-xl bg-white">
+      <CardContent className="py-16 text-center flex flex-col items-center gap-3">
+        <div className="w-14 h-14 rounded-full bg-blue-50 text-blue-600 flex items-center justify-center">
+          {mode === "shared" ? <UsersIcon size={28} /> : <CalendarIcon size={28} />}
+        </div>
+        <div>
+          <p className="text-base font-semibold text-slate-800">
+            {mode === "shared" ? "Nenhum prontuário compartilhado" : "Nenhum prontuário encontrado"}
+          </p>
+          <p className="text-sm text-slate-500 mt-1 max-w-md">
+            {hasFilters
+              ? "Tente ajustar os filtros acima."
+              : mode === "shared"
+                ? "Os prontuários de pacientes que você já atendeu, criados por outros profissionais, aparecerão aqui."
+                : "Os prontuários que você criar a partir das consultas aparecerão aqui."}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ——— Página principal com toggle ———
+const MedicalRecordsListPage = () => {
+  const searchParams = useSearchParams();
+  const initialView = (searchParams.get("view") as ViewMode) ?? "mine";
+  const [view, setView] = useState<ViewMode>(initialView);
+
+  const TABS: { label: string; value: ViewMode }[] = [
+    { label: "Meus prontuários", value: "mine" },
+    { label: "Todos do paciente", value: "shared" },
+  ];
+
+  return (
+    <PageShell>
+      <PageHeader
+        title="Prontuários"
+        description="Prontuários médicos criados por você e de pacientes que você já atendeu."
+        help={<TourButton tour="professional-records" />}
+      />
+
+      {/* Toggle */}
+      <div className="mb-6 flex rounded-lg border border-border bg-background text-sm overflow-hidden w-fit">
+        {TABS.map((tab) => (
+          <button
+            key={tab.value}
+            onClick={() => setView(tab.value)}
+            className={`px-4 py-2 font-medium transition-colors ${
+              view === tab.value
+                ? "bg-foreground text-background"
+                : "text-muted-foreground hover:text-foreground hover:bg-muted"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {view === "mine" ? <MyRecordsView /> : <SharedRecordsView />}
     </PageShell>
   );
 };

--- a/apps/web/app/dashboard/professional/medical-records/page.tsx
+++ b/apps/web/app/dashboard/professional/medical-records/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
@@ -33,8 +33,10 @@ function truncate(text: string | null, max = 120) {
 
 const MedicalRecordsListPage = () => {
   const router = useRouter();
-  const [search, setSearch] = useState("");
-  const [searchInput, setSearchInput] = useState("");
+  const searchParams = useSearchParams();
+  const initialSearch = searchParams.get("search") ?? "";
+  const [search, setSearch] = useState(initialSearch);
+  const [searchInput, setSearchInput] = useState(initialSearch);
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [page, setPage] = useState(1);

--- a/apps/web/app/dashboard/professional/medical-records/shared/[id]/page.tsx
+++ b/apps/web/app/dashboard/professional/medical-records/shared/[id]/page.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { DetailPageSkeleton } from "@/components/ui/skeletons";
+import { useMedicalRecordByIdQuery } from "@/queries/useMedicalRecords";
+import { CalendarIcon } from "../../../../../utils/icons";
+import { PageShell } from "../../../../../ui/dashboard/page-shell";
+import type { MedicalRecordResponse } from "@/services/medical-records-service";
+
+const FIELDS: { key: keyof MedicalRecordResponse; label: string }[] = [
+  { key: "chiefComplaint", label: "Queixa principal" },
+  { key: "diagnosis", label: "Diagnóstico" },
+  { key: "treatmentPlan", label: "Plano terapêutico" },
+  { key: "prescriptions", label: "Prescrições" },
+];
+
+function formatDateTime(iso: string) {
+  return new Date(iso).toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function SharedMedicalRecordPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const { data: record, isLoading } = useMedicalRecordByIdQuery(params?.id ?? null);
+
+  if (isLoading) {
+    return (
+      <PageShell>
+        <DetailPageSkeleton />
+      </PageShell>
+    );
+  }
+
+  if (!record) {
+    return (
+      <PageShell>
+        <p className="text-base text-slate-700">Prontuário não encontrado.</p>
+        <Button
+          variant="outline"
+          className="mt-4"
+          onClick={() => router.push("/dashboard/professional/medical-records?view=shared")}
+        >
+          Voltar
+        </Button>
+      </PageShell>
+    );
+  }
+
+  const full = record as MedicalRecordResponse;
+
+  return (
+    <PageShell>
+      <div className="mb-6 flex items-center justify-between gap-3">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => router.push("/dashboard/professional/medical-records?view=shared")}
+        >
+          ← Voltar
+        </Button>
+        <Badge className="bg-amber-50 text-amber-700 border border-amber-200 px-3 py-1 text-xs rounded-full">
+          Visualização — somente leitura
+        </Badge>
+      </div>
+
+      <Card className="border border-gray-200 rounded-xl bg-white mb-5">
+        <CardContent className="p-5 sm:p-6">
+          <div className="flex gap-3 items-center min-w-0">
+            <div className="w-12 h-12 rounded-full bg-blue-50 border border-blue-100 text-blue-700 flex items-center justify-center font-semibold text-lg shrink-0">
+              {(full.patient?.name ?? "P").charAt(0).toUpperCase()}
+            </div>
+            <div className="min-w-0">
+              <h1 className="font-bold text-xl text-slate-900 tracking-tight truncate">
+                {full.patient?.name ?? "Paciente"}
+              </h1>
+              <p className="text-xs text-slate-500 mt-0.5">Prontuário</p>
+            </div>
+          </div>
+
+          <div className="mt-4 pt-4 border-t border-slate-100 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+            <div className="flex items-start gap-2 text-slate-600">
+              <CalendarIcon size={16} className="mt-0.5 shrink-0" />
+              <div>
+                <p className="text-[11px] uppercase text-slate-400 tracking-wide font-medium">Consulta</p>
+                <p className="text-slate-800">
+                  {full.appointment
+                    ? formatDateTime(full.appointment.dateTime)
+                    : formatDateTime(full.createdAt)}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-2 text-slate-600">
+              <div className="w-4 h-4 mt-0.5 shrink-0 flex items-center justify-center text-[11px] font-bold text-slate-400">✎</div>
+              <div>
+                <p className="text-[11px] uppercase text-slate-400 tracking-wide font-medium">Registrado por</p>
+                <p className="text-slate-800 font-medium">{full.author.name}</p>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border border-gray-200 rounded-xl bg-white">
+        <CardContent className="p-5 sm:p-6 flex flex-col gap-5">
+          {FIELDS.map((field) => {
+            const value = full[field.key] as string | null;
+            return (
+              <div key={field.key} className="flex flex-col gap-1">
+                <p className="text-xs font-medium text-slate-400 uppercase tracking-wide">
+                  {field.label}
+                </p>
+                <p className="text-[14.5px] text-slate-700 leading-relaxed whitespace-pre-wrap">
+                  {value ?? (
+                    <span className="text-slate-300 italic">Não informado</span>
+                  )}
+                </p>
+              </div>
+            );
+          })}
+
+          <div className="pt-3 border-t border-slate-100">
+            <p className="text-xs text-slate-400 italic">
+              As notas internas do profissional não são exibidas nesta visualização.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </PageShell>
+  );
+}

--- a/apps/web/app/dashboard/professional/patients/[patientId]/page.tsx
+++ b/apps/web/app/dashboard/professional/patients/[patientId]/page.tsx
@@ -85,7 +85,7 @@ function patientInitials(name: string): string {
     .split(" ")
     .filter(Boolean)
     .slice(0, 2)
-    .map((n) => n[0].toUpperCase())
+    .map((n) => n[0]!.toUpperCase())
     .join("");
 }
 

--- a/apps/web/app/dashboard/professional/patients/[patientId]/page.tsx
+++ b/apps/web/app/dashboard/professional/patients/[patientId]/page.tsx
@@ -447,12 +447,14 @@ export default function PatientDetailPage() {
                         </>
                       )}
 
-                      {/* Correção de status — disponível para qualquer consulta */}
-                      <AppointmentStatusActions
-                        apt={apt}
-                        isUpdating={isUpdating}
-                        onAction={(id, status) => setPendingAction({ id, status })}
-                      />
+                      {/* Correção de status — apenas para consultas já encerradas */}
+                      {isClosed && (
+                        <AppointmentStatusActions
+                          apt={apt}
+                          isUpdating={isUpdating}
+                          onAction={(id, status) => setPendingAction({ id, status })}
+                        />
+                      )}
                     </div>
                   </div>
                 );

--- a/apps/web/app/dashboard/professional/patients/[patientId]/page.tsx
+++ b/apps/web/app/dashboard/professional/patients/[patientId]/page.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import { usePatientDetail } from "@/queries/useProfessionalPatients";
 import { useUpdateAppointmentStatusMutation } from "@/queries/useProfessionalAppointments";
-import { PageShell, PageHeader } from "../../../../ui/dashboard/page-shell";
+import { PageShell } from "../../../../ui/dashboard/page-shell";
 import { ConfirmModal } from "../../schedule/components/ConfirmModal";
 import { formatPhoneNumber } from "@/app/utils/formatPhone";
 import {
@@ -34,26 +34,19 @@ type AppointmentStatus =
 type Modality = "VIRTUAL" | "HOME_VISIT" | "CLINIC";
 
 const STATUS_META: Record<AppointmentStatus, { label: string; className: string }> = {
-  PENDING: {
-    label: "Pendente",
-    className: "bg-amber-50 text-amber-700 border border-amber-200",
-  },
-  CONFIRMED: {
-    label: "Confirmado",
-    className: "bg-blue-50 text-blue-700 border border-blue-200",
-  },
-  COMPLETED: {
-    label: "Atendido",
-    className: "bg-emerald-50 text-emerald-700 border border-emerald-200",
-  },
-  NO_SHOW: {
-    label: "Faltou",
-    className: "bg-orange-50 text-orange-700 border border-orange-200",
-  },
-  CANCELLED: {
-    label: "Cancelado",
-    className: "bg-red-50 text-red-600 border border-red-200",
-  },
+  PENDING: { label: "Pendente", className: "bg-amber-50 text-amber-700 border border-amber-200" },
+  CONFIRMED: { label: "Confirmado", className: "bg-blue-50 text-blue-700 border border-blue-200" },
+  COMPLETED: { label: "Atendido", className: "bg-emerald-50 text-emerald-700 border border-emerald-200" },
+  NO_SHOW: { label: "Faltou", className: "bg-orange-50 text-orange-700 border border-orange-200" },
+  CANCELLED: { label: "Cancelado", className: "bg-red-50 text-red-600 border border-red-200" },
+};
+
+const STATUS_DOT: Record<AppointmentStatus, string> = {
+  COMPLETED: "bg-emerald-500",
+  CONFIRMED: "bg-blue-500",
+  PENDING: "bg-amber-500",
+  NO_SHOW: "bg-orange-500",
+  CANCELLED: "bg-red-500",
 };
 
 const MODALITY_META: Record<Modality, { label: string; icon: React.ReactNode }> = {
@@ -62,14 +55,17 @@ const MODALITY_META: Record<Modality, { label: string; icon: React.ReactNode }> 
   CLINIC: { label: "Presencial", icon: <BuildingsIcon size={14} /> },
 };
 
-function ModalityBadge({ modality }: { modality?: Modality }) {
-  const meta = modality ? MODALITY_META[modality] : MODALITY_META.VIRTUAL;
-  return (
-    <Badge className="flex items-center gap-1 px-2 py-0.5 rounded text-xs font-semibold bg-slate-100 text-slate-600 border border-slate-200">
-      {meta.icon}
-      {meta.label}
-    </Badge>
-  );
+const ALL_STATUSES: AppointmentStatus[] = ["PENDING", "CONFIRMED", "COMPLETED", "NO_SHOW", "CANCELLED"];
+
+type PeriodFilter = "ALL" | "30" | "90" | "180";
+
+// Utilitários fora do componente — sem recriação em cada render
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  return `${d.toLocaleDateString("pt-BR")} às ${d.toLocaleTimeString("pt-BR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  })}`;
 }
 
 function formatCpf(cpf: string | null): string {
@@ -84,67 +80,81 @@ function formatPhone(phone: string): string {
   return formatPhoneNumber(phone);
 }
 
-const ALL_STATUSES: AppointmentStatus[] = [
-  "PENDING",
-  "CONFIRMED",
-  "COMPLETED",
-  "NO_SHOW",
-  "CANCELLED",
-];
+function patientInitials(name: string): string {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((n) => n[0].toUpperCase())
+    .join("");
+}
+
+function ModalityBadge({ modality }: { modality?: Modality }) {
+  const meta = modality ? MODALITY_META[modality] : MODALITY_META.VIRTUAL;
+  return (
+    <Badge className="flex items-center gap-1 px-2 py-0.5 rounded text-xs font-semibold bg-slate-100 text-slate-600 border border-slate-200">
+      {meta.icon}
+      {meta.label}
+    </Badge>
+  );
+}
 
 function AppointmentStatusActions({
   apt,
   isUpdating,
   onAction,
 }: {
-  apt: { id: string; status: AppointmentStatus };
+  apt: { id: string; status: AppointmentStatus; dateTime: string };
   isUpdating: boolean;
   onAction: (id: string, status: AppointmentStatus) => void;
 }) {
   const [open, setOpen] = useState(false);
-
+  const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({});
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
   const otherStatuses = ALL_STATUSES.filter((s) => s !== apt.status);
 
+  const handleOpen = () => {
+    if (triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setMenuStyle({
+        position: "fixed",
+        top: rect.bottom + 4,
+        right: window.innerWidth - rect.right,
+      });
+    }
+    setOpen((v) => !v);
+  };
+
   return (
-    <div className="relative">
+    <div>
       <button
-        onClick={() => setOpen((v) => !v)}
+        ref={triggerRef}
+        onClick={handleOpen}
         disabled={isUpdating}
-        className="text-xs text-slate-500 hover:text-slate-700 underline underline-offset-2 disabled:opacity-50"
-        title="Alterar status desta consulta"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`Alterar status da consulta de ${formatDateTime(apt.dateTime)}`}
+        className="text-xs text-slate-500 hover:text-slate-700 underline underline-offset-2 disabled:opacity-50 whitespace-nowrap"
       >
         Alterar status
       </button>
 
       {open && (
         <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
           <div
-            className="fixed inset-0 z-10"
-            onClick={() => setOpen(false)}
-          />
-          <div className="absolute right-0 top-6 z-20 bg-white border border-gray-200 rounded-xl shadow-lg p-1 min-w-[160px]">
+            role="menu"
+            style={menuStyle}
+            className="z-50 bg-white border border-gray-200 rounded-xl shadow-lg p-1 min-w-[160px]"
+          >
             {otherStatuses.map((s) => (
               <button
                 key={s}
+                role="menuitem"
                 className="w-full text-left text-[13px] px-3 py-2 rounded-lg hover:bg-slate-50 text-gray-700 flex items-center gap-2"
-                onClick={() => {
-                  setOpen(false);
-                  onAction(apt.id, s);
-                }}
+                onClick={() => { setOpen(false); onAction(apt.id, s); }}
               >
-                <span
-                  className={`inline-block w-2 h-2 rounded-full ${
-                    s === "COMPLETED"
-                      ? "bg-emerald-500"
-                      : s === "CONFIRMED"
-                        ? "bg-blue-500"
-                        : s === "PENDING"
-                          ? "bg-amber-500"
-                          : s === "NO_SHOW"
-                            ? "bg-orange-500"
-                            : "bg-red-500"
-                  }`}
-                />
+                <span className={`inline-block w-2 h-2 rounded-full shrink-0 ${STATUS_DOT[s]}`} />
                 {STATUS_META[s].label}
               </button>
             ))}
@@ -160,16 +170,14 @@ export default function PatientDetailPage() {
   const router = useRouter();
   const patientId = params?.patientId as string;
 
-  const { data: patient, isLoading } = usePatientDetail(patientId, true);
-  const { mutate: updateStatus, isPending: isUpdating } =
-    useUpdateAppointmentStatusMutation();
+  const { data: patient, isLoading, isError } = usePatientDetail(patientId, !!patientId);
+  const { mutate: updateStatus, isPending: isUpdating } = useUpdateAppointmentStatusMutation();
 
-  const [pendingAction, setPendingAction] = useState<{
-    id: string;
-    status: AppointmentStatus;
-  } | null>(null);
+  const [pendingAction, setPendingAction] = useState<{ id: string; status: AppointmentStatus } | null>(null);
+  const [statusFilter, setStatusFilter] = useState<AppointmentStatus | "ALL">("ALL");
+  const [periodFilter, setPeriodFilter] = useState<PeriodFilter>("ALL");
 
-  const { upcoming, past } = useMemo(() => {
+  const { upcoming, appointments } = useMemo(() => {
     const history = (patient?.history || []) as {
       id: string;
       dateTime: string;
@@ -182,16 +190,23 @@ export default function PatientDetailPage() {
       (a, b) => new Date(b.dateTime).getTime() - new Date(a.dateTime).getTime(),
     );
     const up = sorted
-      .filter(
-        (a) =>
-          new Date(a.dateTime) >= now &&
-          (a.status === "CONFIRMED" || a.status === "PENDING"),
-      )
-      .sort(
-        (a, b) => new Date(a.dateTime).getTime() - new Date(b.dateTime).getTime(),
-      );
-    return { upcoming: up, past: sorted };
+      .filter((a) => new Date(a.dateTime) >= now && (a.status === "CONFIRMED" || a.status === "PENDING"))
+      .sort((a, b) => new Date(a.dateTime).getTime() - new Date(b.dateTime).getTime());
+    return { upcoming: up, appointments: sorted };
   }, [patient]);
+
+  const filteredAppointments = useMemo(() => {
+    let result = appointments;
+    if (statusFilter !== "ALL") {
+      result = result.filter((a) => a.status === statusFilter);
+    }
+    if (periodFilter !== "ALL") {
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - Number(periodFilter));
+      result = result.filter((a) => new Date(a.dateTime) >= cutoff);
+    }
+    return result;
+  }, [appointments, statusFilter, periodFilter]);
 
   const handleConfirmAction = (notes?: string) => {
     if (!pendingAction) return;
@@ -201,15 +216,7 @@ export default function PatientDetailPage() {
     );
   };
 
-  const formatDateTime = (iso: string) => {
-    const d = new Date(iso);
-    return `${d.toLocaleDateString("pt-BR")} às ${d.toLocaleTimeString("pt-BR", {
-      hour: "2-digit",
-      minute: "2-digit",
-    })}`;
-  };
-
-  if (isLoading || !patient) {
+  if (isLoading) {
     return (
       <PageShell>
         <div className="py-20 flex justify-center">
@@ -219,54 +226,54 @@ export default function PatientDetailPage() {
     );
   }
 
-  const completedCount = patient.history.filter(
-    (a) => a.status === "COMPLETED",
-  ).length;
+  if (isError || !patient) {
+    return (
+      <PageShell>
+        <div className="py-20 flex flex-col items-center gap-4 text-gray-500">
+          <p>Não foi possível carregar os dados do paciente.</p>
+          <Button variant="outline" onClick={() => router.back()}>Voltar</Button>
+        </div>
+      </PageShell>
+    );
+  }
 
+  const completedCount = patient.history.filter((a) => a.status === "COMPLETED").length;
   const nextAppt = upcoming[0];
 
   return (
     <PageShell>
-      <PageHeader
-        title={patient.name}
-        description="Perfil, próxima consulta e histórico do paciente."
-        actions={
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="lg"
-              onClick={() =>
-                router.push(
-                  "/dashboard/professional/medical-records?search=" +
-                    encodeURIComponent(patient.name),
-                )
-              }
-              title="Ver prontuários deste paciente"
-            >
-              <ArrowSquareOutIcon size={16} />
-              Prontuário
-            </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              onClick={() => router.push("/dashboard/professional/patients")}
-              title="Voltar para a lista de pacientes"
-            >
-              Voltar
-            </Button>
-          </div>
-        }
-      />
+      {/* Header: Voltar à esquerda, Prontuário à direita */}
+      <div className="mb-6 flex items-center justify-between gap-3">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => router.back()}
+          title="Voltar"
+        >
+          Voltar
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            router.push("/dashboard/professional/medical-records?search=" + encodeURIComponent(patient.name))
+          }
+          title="Ver prontuários deste paciente"
+        >
+          <ArrowSquareOutIcon size={16} />
+          Prontuário
+        </Button>
+      </div>
 
       {/* Dados do paciente */}
       <Card className="mb-6 border border-gray-200 rounded-xl">
         <CardContent className="p-5">
           <div className="flex flex-col sm:flex-row sm:items-center gap-4">
-            <div className="w-16 h-16 rounded-full font-bold flex items-center justify-center text-blue-700 bg-blue-50 border border-blue-100 shrink-0 text-2xl">
-              {patient.name.charAt(0).toUpperCase()}
+            <div className="w-16 h-16 rounded-full font-bold flex items-center justify-center text-blue-700 bg-blue-50 border border-blue-100 shrink-0 text-xl">
+              {patientInitials(patient.name)}
             </div>
             <div className="flex-1">
-              <h2 className="text-lg font-semibold text-gray-900">{patient.name}</h2>
+              <h1 className="text-lg font-semibold text-gray-900">{patient.name}</h1>
               <p className="text-sm text-gray-500">{patient.email}</p>
             </div>
           </div>
@@ -313,40 +320,21 @@ export default function PatientDetailPage() {
               </div>
               <div className="flex flex-wrap gap-2">
                 {nextAppt.status === "PENDING" && (
-                  <Button
-                    size="sm"
-                    className="bg-emerald-500 hover:bg-emerald-600 text-white"
-                    disabled={isUpdating}
-                    onClick={() => setPendingAction({ id: nextAppt.id, status: "CONFIRMED" })}
-                  >
+                  <Button size="sm" className="bg-emerald-500 hover:bg-emerald-600 text-white" disabled={isUpdating}
+                    onClick={() => setPendingAction({ id: nextAppt.id, status: "CONFIRMED" })}>
                     <CheckIcon /> Confirmar
                   </Button>
                 )}
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="text-emerald-700 border-emerald-200 hover:bg-emerald-50"
-                  disabled={isUpdating}
-                  onClick={() => setPendingAction({ id: nextAppt.id, status: "COMPLETED" })}
-                >
+                <Button size="sm" variant="outline" className="text-emerald-700 border-emerald-200 hover:bg-emerald-50" disabled={isUpdating}
+                  onClick={() => setPendingAction({ id: nextAppt.id, status: "COMPLETED" })}>
                   <UserCheckIcon /> Marcar Atendido
                 </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="text-orange-600 border-orange-200 hover:bg-orange-50"
-                  disabled={isUpdating}
-                  onClick={() => setPendingAction({ id: nextAppt.id, status: "NO_SHOW" })}
-                >
+                <Button size="sm" variant="outline" className="text-orange-600 border-orange-200 hover:bg-orange-50" disabled={isUpdating}
+                  onClick={() => setPendingAction({ id: nextAppt.id, status: "NO_SHOW" })}>
                   <XCircleIcon /> Faltou
                 </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="text-red-600 border-red-200 hover:bg-red-50"
-                  disabled={isUpdating}
-                  onClick={() => setPendingAction({ id: nextAppt.id, status: "CANCELLED" })}
-                >
+                <Button size="sm" variant="outline" className="text-red-600 border-red-200 hover:bg-red-50" disabled={isUpdating}
+                  onClick={() => setPendingAction({ id: nextAppt.id, status: "CANCELLED" })}>
                   <XIcon /> Cancelar
                 </Button>
               </div>
@@ -357,17 +345,50 @@ export default function PatientDetailPage() {
 
       {/* Histórico */}
       <div>
-        <h2 className="mb-3 text-base font-semibold text-gray-700">
-          Histórico de Consultas
-        </h2>
+        <div className="mb-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <h2 className="text-base font-semibold text-gray-700">Histórico de Consultas</h2>
+          <div className="flex flex-wrap gap-2">
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value as typeof statusFilter)}
+              aria-label="Filtrar por status"
+              className="text-sm border border-gray-200 rounded-lg px-3 py-1.5 bg-white text-gray-700 focus:outline-none focus:border-[#006fee]"
+            >
+              <option value="ALL">Todos os status</option>
+              {ALL_STATUSES.map((s) => (
+                <option key={s} value={s}>{STATUS_META[s].label}</option>
+              ))}
+            </select>
+            <select
+              value={periodFilter}
+              onChange={(e) => setPeriodFilter(e.target.value as PeriodFilter)}
+              aria-label="Filtrar por período"
+              className="text-sm border border-gray-200 rounded-lg px-3 py-1.5 bg-white text-gray-700 focus:outline-none focus:border-[#006fee]"
+            >
+              <option value="ALL">Todo o período</option>
+              <option value="30">Últimos 30 dias</option>
+              <option value="90">Últimos 3 meses</option>
+              <option value="180">Últimos 6 meses</option>
+            </select>
+          </div>
+        </div>
+
+        {filteredAppointments.length !== appointments.length && (
+          <p className="text-xs text-gray-400 mb-2">
+            {filteredAppointments.length} de {appointments.length} consulta{appointments.length !== 1 ? "s" : ""}
+          </p>
+        )}
+
         <Card className="border border-gray-200 rounded-xl">
           <CardContent className="p-0">
-            {past.length === 0 ? (
+            {filteredAppointments.length === 0 ? (
               <div className="p-8 text-center text-gray-500">
-                Nenhuma consulta registrada para este paciente.
+                {appointments.length === 0
+                  ? "Nenhuma consulta registrada para este paciente."
+                  : "Nenhuma consulta encontrada com os filtros selecionados."}
               </div>
             ) : (
-              past.map((apt) => {
+              filteredAppointments.map((apt) => {
                 const meta = STATUS_META[apt.status];
                 const isClosed =
                   apt.status === "COMPLETED" ||
@@ -379,13 +400,14 @@ export default function PatientDetailPage() {
                     className="p-4 flex flex-col sm:flex-row sm:items-center gap-3 border-b border-gray-100 last:border-b-0 hover:bg-gray-50 transition-colors"
                   >
                     <div className="flex-1 min-w-0">
-                      <p className="font-medium text-gray-800">
-                        {formatDateTime(apt.dateTime)}
-                      </p>
+                      <p className="font-medium text-gray-800">{formatDateTime(apt.dateTime)}</p>
                       <div className="flex items-center gap-2 mt-1">
                         <ModalityBadge modality={apt.modality} />
                         {apt.notes && (
-                          <span className="text-xs text-gray-400 italic truncate">
+                          <span
+                            className="text-xs text-gray-400 italic truncate max-w-[200px]"
+                            title={apt.notes}
+                          >
                             {apt.notes}
                           </span>
                         )}
@@ -397,45 +419,35 @@ export default function PatientDetailPage() {
                         {meta.label}
                       </Badge>
 
-                      {/* Ações rápidas para consultas ainda abertas */}
                       {!isClosed && (
                         <>
                           {apt.status === "PENDING" && (
-                            <Button
-                              size="sm"
-                              variant="outline"
+                            <Button size="sm" variant="outline"
                               className="h-8 px-2.5 text-blue-700 border-blue-200 hover:bg-blue-50"
                               disabled={isUpdating}
-                              onClick={() => setPendingAction({ id: apt.id, status: "CONFIRMED" })}
-                            >
+                              onClick={() => setPendingAction({ id: apt.id, status: "CONFIRMED" })}>
                               <CheckIcon size={16} />
                               <span className="hidden md:inline">Confirmar</span>
                             </Button>
                           )}
-                          <Button
-                            size="sm"
-                            variant="outline"
+                          <Button size="sm" variant="outline"
                             className="h-8 px-2.5 text-emerald-700 border-emerald-200 hover:bg-emerald-50"
                             disabled={isUpdating}
-                            onClick={() => setPendingAction({ id: apt.id, status: "COMPLETED" })}
-                          >
+                            onClick={() => setPendingAction({ id: apt.id, status: "COMPLETED" })}>
                             <UserCheckIcon size={16} />
                             <span className="hidden md:inline">Atendido</span>
                           </Button>
-                          <Button
-                            size="sm"
-                            variant="outline"
+                          <Button size="sm" variant="outline"
                             className="h-8 px-2.5 text-orange-600 border-orange-200 hover:bg-orange-50"
                             disabled={isUpdating}
-                            onClick={() => setPendingAction({ id: apt.id, status: "NO_SHOW" })}
-                          >
+                            onClick={() => setPendingAction({ id: apt.id, status: "NO_SHOW" })}>
                             <XCircleIcon size={16} />
                             <span className="hidden md:inline">Faltou</span>
                           </Button>
                         </>
                       )}
 
-                      {/* Permite corrigir qualquer status, inclusive fechados */}
+                      {/* Correção de status — disponível para qualquer consulta */}
                       <AppointmentStatusActions
                         apt={apt}
                         isUpdating={isUpdating}

--- a/apps/web/app/dashboard/professional/patients/[patientId]/page.tsx
+++ b/apps/web/app/dashboard/professional/patients/[patientId]/page.tsx
@@ -21,6 +21,7 @@ import {
   VideoIcon,
   HouseIcon,
   BuildingsIcon,
+  ArrowSquareOutIcon,
 } from "../../../../utils/icons";
 
 type AppointmentStatus =
@@ -32,10 +33,7 @@ type AppointmentStatus =
 
 type Modality = "VIRTUAL" | "HOME_VISIT" | "CLINIC";
 
-const STATUS_META: Record<
-  AppointmentStatus,
-  { label: string; className: string }
-> = {
+const STATUS_META: Record<AppointmentStatus, { label: string; className: string }> = {
   PENDING: {
     label: "Pendente",
     className: "bg-amber-50 text-amber-700 border border-amber-200",
@@ -58,10 +56,7 @@ const STATUS_META: Record<
   },
 };
 
-const MODALITY_META: Record<
-  Modality,
-  { label: string; icon: React.ReactNode }
-> = {
+const MODALITY_META: Record<Modality, { label: string; icon: React.ReactNode }> = {
   VIRTUAL: { label: "Online", icon: <VideoIcon size={14} /> },
   HOME_VISIT: { label: "Domiciliar", icon: <HouseIcon size={14} /> },
   CLINIC: { label: "Presencial", icon: <BuildingsIcon size={14} /> },
@@ -89,6 +84,77 @@ function formatPhone(phone: string): string {
   return formatPhoneNumber(phone);
 }
 
+const ALL_STATUSES: AppointmentStatus[] = [
+  "PENDING",
+  "CONFIRMED",
+  "COMPLETED",
+  "NO_SHOW",
+  "CANCELLED",
+];
+
+function AppointmentStatusActions({
+  apt,
+  isUpdating,
+  onAction,
+}: {
+  apt: { id: string; status: AppointmentStatus };
+  isUpdating: boolean;
+  onAction: (id: string, status: AppointmentStatus) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const otherStatuses = ALL_STATUSES.filter((s) => s !== apt.status);
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        disabled={isUpdating}
+        className="text-xs text-slate-500 hover:text-slate-700 underline underline-offset-2 disabled:opacity-50"
+        title="Alterar status desta consulta"
+      >
+        Alterar status
+      </button>
+
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => setOpen(false)}
+          />
+          <div className="absolute right-0 top-6 z-20 bg-white border border-gray-200 rounded-xl shadow-lg p-1 min-w-[160px]">
+            {otherStatuses.map((s) => (
+              <button
+                key={s}
+                className="w-full text-left text-[13px] px-3 py-2 rounded-lg hover:bg-slate-50 text-gray-700 flex items-center gap-2"
+                onClick={() => {
+                  setOpen(false);
+                  onAction(apt.id, s);
+                }}
+              >
+                <span
+                  className={`inline-block w-2 h-2 rounded-full ${
+                    s === "COMPLETED"
+                      ? "bg-emerald-500"
+                      : s === "CONFIRMED"
+                        ? "bg-blue-500"
+                        : s === "PENDING"
+                          ? "bg-amber-500"
+                          : s === "NO_SHOW"
+                            ? "bg-orange-500"
+                            : "bg-red-500"
+                  }`}
+                />
+                {STATUS_META[s].label}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
 export default function PatientDetailPage() {
   const params = useParams();
   const router = useRouter();
@@ -113,8 +179,7 @@ export default function PatientDetailPage() {
     }[];
     const now = new Date();
     const sorted = [...history].sort(
-      (a, b) =>
-        new Date(b.dateTime).getTime() - new Date(a.dateTime).getTime(),
+      (a, b) => new Date(b.dateTime).getTime() - new Date(a.dateTime).getTime(),
     );
     const up = sorted
       .filter(
@@ -123,8 +188,7 @@ export default function PatientDetailPage() {
           (a.status === "CONFIRMED" || a.status === "PENDING"),
       )
       .sort(
-        (a, b) =>
-          new Date(a.dateTime).getTime() - new Date(b.dateTime).getTime(),
+        (a, b) => new Date(a.dateTime).getTime() - new Date(b.dateTime).getTime(),
       );
     return { upcoming: up, past: sorted };
   }, [patient]);
@@ -167,61 +231,62 @@ export default function PatientDetailPage() {
         title={patient.name}
         description="Perfil, próxima consulta e histórico do paciente."
         actions={
-          <Button
-            variant="outline"
-            size="lg"
-            onClick={() => router.push("/dashboard/professional/patients")}
-            title="Voltar para a lista de pacientes"
-          >
-            Voltar
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="lg"
+              onClick={() =>
+                router.push(
+                  "/dashboard/professional/medical-records?search=" +
+                    encodeURIComponent(patient.name),
+                )
+              }
+              title="Ver prontuários deste paciente"
+            >
+              <ArrowSquareOutIcon size={16} />
+              Prontuário
+            </Button>
+            <Button
+              variant="outline"
+              size="lg"
+              onClick={() => router.push("/dashboard/professional/patients")}
+              title="Voltar para a lista de pacientes"
+            >
+              Voltar
+            </Button>
+          </div>
         }
       />
 
       {/* Dados do paciente */}
       <Card className="mb-6 border border-gray-200 rounded-xl">
-        <CardContent className="p-5 flex flex-col sm:flex-row sm:items-center gap-4">
-          <div className="w-14 h-14 rounded-full font-semibold flex items-center justify-center text-blue-700 bg-blue-50 border border-blue-100 shrink-0 text-xl">
-            {patient.name.charAt(0).toUpperCase()}
+        <CardContent className="p-5">
+          <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+            <div className="w-16 h-16 rounded-full font-bold flex items-center justify-center text-blue-700 bg-blue-50 border border-blue-100 shrink-0 text-2xl">
+              {patient.name.charAt(0).toUpperCase()}
+            </div>
+            <div className="flex-1">
+              <h2 className="text-lg font-semibold text-gray-900">{patient.name}</h2>
+              <p className="text-sm text-gray-500">{patient.email}</p>
+            </div>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-x-8 gap-y-2 flex-1 text-sm">
-            <div>
-              <p className="text-xs text-gray-500 uppercase tracking-wider">
-                E-mail
-              </p>
-              <p className="text-gray-900 font-medium truncate">
-                {patient.email}
-              </p>
+
+          <div className="mt-5 grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <div className="bg-slate-50 rounded-xl p-3">
+              <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">CPF</p>
+              <p className="text-sm text-gray-900 font-medium">{formatCpf(patient.cpf)}</p>
             </div>
-            <div>
-              <p className="text-xs text-gray-500 uppercase tracking-wider">
-                CPF
-              </p>
-              <p className="text-gray-900 font-medium">
-                {formatCpf(patient.cpf)}
-              </p>
+            <div className="bg-slate-50 rounded-xl p-3">
+              <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Telefone</p>
+              <p className="text-sm text-gray-900 font-medium">{formatPhone(patient.phone)}</p>
             </div>
-            <div>
-              <p className="text-xs text-gray-500 uppercase tracking-wider">
-                Telefone
-              </p>
-              <p className="text-gray-900 font-medium">
-                {formatPhone(patient.phone)}
-              </p>
+            <div className="bg-slate-50 rounded-xl p-3">
+              <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Total de consultas</p>
+              <p className="text-2xl font-bold text-gray-900">{patient.history.length}</p>
             </div>
-            <div>
-              <p className="text-xs text-gray-500 uppercase tracking-wider">
-                Total de consultas
-              </p>
-              <p className="text-gray-900 font-medium">
-                {patient.history.length}
-              </p>
-            </div>
-            <div>
-              <p className="text-xs text-gray-500 uppercase tracking-wider">
-                Atendimentos realizados
-              </p>
-              <p className="text-gray-900 font-medium">{completedCount}</p>
+            <div className="bg-slate-50 rounded-xl p-3">
+              <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Atendimentos</p>
+              <p className="text-2xl font-bold text-emerald-600">{completedCount}</p>
             </div>
           </div>
         </CardContent>
@@ -230,17 +295,15 @@ export default function PatientDetailPage() {
       {/* Próxima consulta */}
       {nextAppt && (
         <div className="mb-6">
-          <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-700">
-            <CalendarIcon size={20} weight="duotone" /> Próxima Consulta
+          <h2 className="mb-3 flex items-center gap-2 text-base font-semibold text-gray-700">
+            <CalendarIcon size={18} weight="duotone" /> Próxima Consulta
           </h2>
           <Card className="border-l-4 border-l-[#006fee]">
             <CardContent className="p-5 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
               <div>
-                <div className="flex items-center gap-2 mb-1">
+                <div className="flex items-center gap-2 mb-1.5">
                   <ModalityBadge modality={nextAppt.modality} />
-                  <Badge
-                    className={`px-2 py-0.5 rounded text-xs font-semibold ${STATUS_META[nextAppt.status].className}`}
-                  >
+                  <Badge className={`px-2 py-0.5 rounded text-xs font-semibold ${STATUS_META[nextAppt.status].className}`}>
                     {STATUS_META[nextAppt.status].label}
                   </Badge>
                 </div>
@@ -254,12 +317,7 @@ export default function PatientDetailPage() {
                     size="sm"
                     className="bg-emerald-500 hover:bg-emerald-600 text-white"
                     disabled={isUpdating}
-                    onClick={() =>
-                      setPendingAction({
-                        id: nextAppt.id,
-                        status: "CONFIRMED",
-                      })
-                    }
+                    onClick={() => setPendingAction({ id: nextAppt.id, status: "CONFIRMED" })}
                   >
                     <CheckIcon /> Confirmar
                   </Button>
@@ -269,12 +327,7 @@ export default function PatientDetailPage() {
                   variant="outline"
                   className="text-emerald-700 border-emerald-200 hover:bg-emerald-50"
                   disabled={isUpdating}
-                  onClick={() =>
-                    setPendingAction({
-                      id: nextAppt.id,
-                      status: "COMPLETED",
-                    })
-                  }
+                  onClick={() => setPendingAction({ id: nextAppt.id, status: "COMPLETED" })}
                 >
                   <UserCheckIcon /> Marcar Atendido
                 </Button>
@@ -283,12 +336,7 @@ export default function PatientDetailPage() {
                   variant="outline"
                   className="text-orange-600 border-orange-200 hover:bg-orange-50"
                   disabled={isUpdating}
-                  onClick={() =>
-                    setPendingAction({
-                      id: nextAppt.id,
-                      status: "NO_SHOW",
-                    })
-                  }
+                  onClick={() => setPendingAction({ id: nextAppt.id, status: "NO_SHOW" })}
                 >
                   <XCircleIcon /> Faltou
                 </Button>
@@ -297,12 +345,7 @@ export default function PatientDetailPage() {
                   variant="outline"
                   className="text-red-600 border-red-200 hover:bg-red-50"
                   disabled={isUpdating}
-                  onClick={() =>
-                    setPendingAction({
-                      id: nextAppt.id,
-                      status: "CANCELLED",
-                    })
-                  }
+                  onClick={() => setPendingAction({ id: nextAppt.id, status: "CANCELLED" })}
                 >
                   <XIcon /> Cancelar
                 </Button>
@@ -314,7 +357,7 @@ export default function PatientDetailPage() {
 
       {/* Histórico */}
       <div>
-        <h2 className="mb-3 text-lg font-semibold text-gray-700">
+        <h2 className="mb-3 text-base font-semibold text-gray-700">
           Histórico de Consultas
         </h2>
         <Card className="border border-gray-200 rounded-xl">
@@ -348,12 +391,13 @@ export default function PatientDetailPage() {
                         )}
                       </div>
                     </div>
+
                     <div className="flex items-center gap-2 shrink-0">
-                      <Badge
-                        className={`px-2 py-1 rounded-3xl text-xs font-semibold ${meta.className}`}
-                      >
+                      <Badge className={`px-2 py-1 rounded-3xl text-xs font-semibold ${meta.className}`}>
                         {meta.label}
                       </Badge>
+
+                      {/* Ações rápidas para consultas ainda abertas */}
                       {!isClosed && (
                         <>
                           {apt.status === "PENDING" && (
@@ -362,12 +406,7 @@ export default function PatientDetailPage() {
                               variant="outline"
                               className="h-8 px-2.5 text-blue-700 border-blue-200 hover:bg-blue-50"
                               disabled={isUpdating}
-                              onClick={() =>
-                                setPendingAction({
-                                  id: apt.id,
-                                  status: "CONFIRMED",
-                                })
-                              }
+                              onClick={() => setPendingAction({ id: apt.id, status: "CONFIRMED" })}
                             >
                               <CheckIcon size={16} />
                               <span className="hidden md:inline">Confirmar</span>
@@ -378,12 +417,7 @@ export default function PatientDetailPage() {
                             variant="outline"
                             className="h-8 px-2.5 text-emerald-700 border-emerald-200 hover:bg-emerald-50"
                             disabled={isUpdating}
-                            onClick={() =>
-                              setPendingAction({
-                                id: apt.id,
-                                status: "COMPLETED",
-                              })
-                            }
+                            onClick={() => setPendingAction({ id: apt.id, status: "COMPLETED" })}
                           >
                             <UserCheckIcon size={16} />
                             <span className="hidden md:inline">Atendido</span>
@@ -393,18 +427,20 @@ export default function PatientDetailPage() {
                             variant="outline"
                             className="h-8 px-2.5 text-orange-600 border-orange-200 hover:bg-orange-50"
                             disabled={isUpdating}
-                            onClick={() =>
-                              setPendingAction({
-                                id: apt.id,
-                                status: "NO_SHOW",
-                              })
-                            }
+                            onClick={() => setPendingAction({ id: apt.id, status: "NO_SHOW" })}
                           >
                             <XCircleIcon size={16} />
                             <span className="hidden md:inline">Faltou</span>
                           </Button>
                         </>
                       )}
+
+                      {/* Permite corrigir qualquer status, inclusive fechados */}
+                      <AppointmentStatusActions
+                        apt={apt}
+                        isUpdating={isUpdating}
+                        onAction={(id, status) => setPendingAction({ id, status })}
+                      />
                     </div>
                   </div>
                 );
@@ -416,9 +452,7 @@ export default function PatientDetailPage() {
 
       <ConfirmModal
         isOpen={!!pendingAction}
-        onOpenChange={(open) => {
-          if (!open) setPendingAction(null);
-        }}
+        onOpenChange={(open) => { if (!open) setPendingAction(null); }}
         pendingStatus={pendingAction?.status || ""}
         onConfirm={handleConfirmAction}
       />

--- a/apps/web/app/dashboard/professional/patients/components/PatientCard.tsx
+++ b/apps/web/app/dashboard/professional/patients/components/PatientCard.tsx
@@ -1,17 +1,7 @@
-import React, { useState } from "react";
+import React from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui/dialog";
-import { Spinner } from "@/components/ui/spinner";
-import { Badge } from "@/components/ui/badge";
-import { usePatientDetail } from "@/queries/useProfessionalPatients";
 import { formatPhoneNumber } from "@/app/utils/formatPhone";
 
 export interface PatientCardData {
@@ -29,22 +19,6 @@ interface PatientCardProps {
   patient: PatientCardData;
 }
 
-const STATUS_CLASS: Record<string, string> = {
-  CONFIRMED: "bg-green-100 text-green-700",
-  COMPLETED: "bg-emerald-100 text-emerald-700",
-  CANCELLED: "bg-red-100 text-red-700",
-  NO_SHOW: "bg-red-100 text-red-700",
-  PENDING: "bg-[#fef0c7] text-[#b54708]",
-};
-
-const STATUS_TEXT: Record<string, string> = {
-  CONFIRMED: "Confirmado",
-  COMPLETED: "Realizado",
-  CANCELLED: "Cancelado",
-  NO_SHOW: "Faltou",
-  PENDING: "Pendente",
-};
-
 function formatCpf(cpf: string | null): string {
   if (!cpf) return "Não informado";
   const digits = cpf.replace(/\D/g, "");
@@ -59,12 +33,9 @@ function formatPhone(phone: string): string {
 
 export function PatientCard({ patient }: PatientCardProps) {
   const router = useRouter();
-  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
 
-  const { data: detailData, isLoading } = usePatientDetail(
-    patient.id,
-    isHistoryOpen,
-  );
+  const navigate = () =>
+    router.push(`/dashboard/professional/patients/${patient.id}`);
 
   const nextVisitFormatted = patient.nextVisit
     ? new Date(patient.nextVisit).toLocaleDateString("pt-BR")
@@ -73,29 +44,23 @@ export function PatientCard({ patient }: PatientCardProps) {
     ? new Date(patient.lastVisit).toLocaleDateString("pt-BR")
     : null;
 
-  const renderAvatar = (
-    name: string,
-    photoUrl?: string,
-    size: "sm" | "md" = "md",
-  ) => {
-    const sizePx = size === "sm" ? 40 : 48;
-    const sizeClass = size === "sm" ? "w-10 h-10" : "w-12 h-12";
+  const renderAvatar = (name: string, photoUrl?: string) => {
     if (photoUrl) {
       return (
         <Image
           src={photoUrl}
           alt={name}
           title={`Foto de perfil de ${name}`}
-          width={sizePx}
-          height={sizePx}
-          className={`${sizeClass} rounded-full object-cover object-center border border-gray-200 bg-[#fafafa] shrink-0`}
+          width={48}
+          height={48}
+          className="w-12 h-12 rounded-full object-cover object-center border border-gray-200 bg-[#fafafa] shrink-0"
         />
       );
     }
     return (
       <div
         title={`Foto de perfil de ${name}`}
-        className={`${sizeClass} rounded-full font-semibold flex items-center justify-center text-blue-700 bg-blue-50 border border-blue-100 shrink-0`}
+        className="w-12 h-12 rounded-full font-semibold flex items-center justify-center text-blue-700 bg-blue-50 border border-blue-100 shrink-0 text-lg"
       >
         {name.charAt(0).toUpperCase()}
       </div>
@@ -103,151 +68,77 @@ export function PatientCard({ patient }: PatientCardProps) {
   };
 
   return (
-    <>
-      <div className="bg-white rounded-xl border border-gray-200 p-5 flex flex-col h-full">
-        <div className="flex gap-3 items-center mb-4">
-          {renderAvatar(patient.name, patient.photoUrl)}
-          <div className="min-w-0 flex-1">
-            <h3
-              className="font-semibold text-[15px] text-gray-900 truncate"
-              title={patient.name}
-            >
-              {patient.name}
-            </h3>
-            <p
-              className="text-[13px] text-gray-500 truncate"
-              title={patient.email}
-            >
-              {patient.email}
-            </p>
-          </div>
-        </div>
-
-        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[13px] mb-5">
-          <dt className="text-gray-500">CPF</dt>
-          <dd
-            className="text-gray-800 font-medium truncate"
-            title={formatCpf(patient.cpf)}
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={navigate}
+      onKeyDown={(e) => e.key === "Enter" && navigate()}
+      className="bg-white rounded-xl border border-gray-200 p-5 flex flex-col h-full cursor-pointer hover:border-blue-300 hover:shadow-sm transition-all"
+    >
+      <div className="flex gap-3 items-center mb-4">
+        {renderAvatar(patient.name, patient.photoUrl)}
+        <div className="min-w-0 flex-1">
+          <h3
+            className="font-semibold text-[15px] text-gray-900 truncate"
+            title={patient.name}
           >
-            {formatCpf(patient.cpf)}
-          </dd>
-          <dt className="text-gray-500">Telefone</dt>
-          <dd
-            className="text-gray-800 font-medium truncate"
-            title={formatPhone(patient.phone)}
+            {patient.name}
+          </h3>
+          <p
+            className="text-[13px] text-gray-500 truncate"
+            title={patient.email}
           >
-            {formatPhone(patient.phone)}
-          </dd>
-          {nextVisitFormatted && (
-            <>
-              <dt className="text-gray-500">Próxima consulta</dt>
-              <dd
-                className="text-gray-800 font-medium truncate"
-                title={nextVisitFormatted}
-              >
-                {nextVisitFormatted}
-              </dd>
-            </>
-          )}
-          {lastVisitFormatted && (
-            <>
-              <dt className="text-gray-500">Última consulta</dt>
-              <dd
-                className="text-gray-800 font-medium truncate"
-                title={lastVisitFormatted}
-              >
-                {lastVisitFormatted}
-              </dd>
-            </>
-          )}
-          {!nextVisitFormatted && !lastVisitFormatted && (
-            <>
-              <dt className="text-gray-500">Consultas</dt>
-              <dd className="text-gray-400 italic truncate">Nenhuma</dd>
-            </>
-          )}
-        </dl>
-
-        <div className="flex gap-2 mt-auto">
-          <Button
-            size="sm"
-            variant="outline"
-            className="flex-1 text-xs"
-            onClick={() => setIsHistoryOpen(true)}
-            title="Ver histórico rápido de consultas deste paciente"
-          >
-            Histórico
-          </Button>
-          <Button
-            size="sm"
-            className="flex-1 text-xs"
-            onClick={() =>
-              router.push(`/dashboard/professional/patients/${patient.id}`)
-            }
-            title="Abrir página do paciente para gerenciar consultas"
-          >
-            Gerenciar
-          </Button>
+            {patient.email}
+          </p>
         </div>
       </div>
 
-      <Dialog open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>
-        <DialogContent className="sm:max-w-125 rounded-2xl max-h-[80vh] overflow-hidden flex flex-col">
-          <DialogHeader>
-            <DialogTitle>Histórico de consultas</DialogTitle>
-            <DialogDescription>
-              Acompanhamento de consultas de {patient.name}.
-            </DialogDescription>
-          </DialogHeader>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[13px] mb-5">
+        <dt className="text-gray-500">CPF</dt>
+        <dd className="text-gray-800 font-medium truncate" title={formatCpf(patient.cpf)}>
+          {formatCpf(patient.cpf)}
+        </dd>
+        <dt className="text-gray-500">Telefone</dt>
+        <dd className="text-gray-800 font-medium truncate" title={formatPhone(patient.phone)}>
+          {formatPhone(patient.phone)}
+        </dd>
+        {nextVisitFormatted && (
+          <>
+            <dt className="text-gray-500">Próxima consulta</dt>
+            <dd className="text-gray-800 font-medium truncate" title={nextVisitFormatted}>
+              {nextVisitFormatted}
+            </dd>
+          </>
+        )}
+        {lastVisitFormatted && (
+          <>
+            <dt className="text-gray-500">Última consulta</dt>
+            <dd className="text-gray-800 font-medium truncate" title={lastVisitFormatted}>
+              {lastVisitFormatted}
+            </dd>
+          </>
+        )}
+        {!nextVisitFormatted && !lastVisitFormatted && (
+          <>
+            <dt className="text-gray-500">Consultas</dt>
+            <dd className="text-gray-400 italic truncate">Nenhuma</dd>
+          </>
+        )}
+      </dl>
 
-          {isLoading || !detailData ? (
-            <div className="py-10 flex justify-center">
-              <Spinner size="md" />
-            </div>
-          ) : detailData.history.length === 0 ? (
-            <div className="py-10 text-center text-gray-500 text-sm">
-              Nenhuma consulta encontrada no histórico.
-            </div>
-          ) : (
-            <div className="mt-4 flex-1 overflow-y-auto pr-2 space-y-3">
-              {detailData.history.map((apt) => {
-                const aptDate = new Date(apt.dateTime);
-                return (
-                  <div
-                    key={apt.id}
-                    className="p-4 rounded-xl border border-gray-100 bg-slate-50 flex flex-col gap-2"
-                  >
-                    <div className="flex justify-between items-start">
-                      <div>
-                        <span className="font-semibold text-gray-900 text-sm">
-                          {aptDate.toLocaleDateString("pt-BR")}
-                        </span>
-                        <span className="text-gray-500 text-sm ml-2">
-                          {aptDate.toLocaleTimeString("pt-BR", {
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          })}
-                        </span>
-                      </div>
-                      <Badge
-                        className={`px-2 py-0.5 rounded-md text-[11px] font-medium border-none shadow-none ${STATUS_CLASS[apt.status] ?? "bg-gray-100 text-gray-700"}`}
-                        title={`Status: ${STATUS_TEXT[apt.status] ?? apt.status}`}
-                      >
-                        {STATUS_TEXT[apt.status] ?? apt.status}
-                      </Badge>
-                    </div>
-                    {apt.notes && (
-                      <p className="text-xs text-gray-600 italic bg-white p-2 rounded border border-gray-100">
-                        {apt.notes}
-                      </p>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
-    </>
+      <div className="mt-auto">
+        <Button
+          size="sm"
+          className="w-full text-xs"
+          onClick={(e) => {
+            e.stopPropagation();
+            navigate();
+          }}
+          title="Abrir página do paciente para gerenciar consultas"
+        >
+          Gerenciar
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/apps/web/app/dashboard/professional/schedule/components/AppointmentCard.tsx
+++ b/apps/web/app/dashboard/professional/schedule/components/AppointmentCard.tsx
@@ -198,26 +198,12 @@ export function AppointmentCard({
                   </>
                 )}
                 {appointment.status === "COMPLETED" && (
-                  <>
-                    <DropdownMenuItem
-                      className="cursor-pointer rounded-md focus:bg-gray-50"
-                      onClick={handleOpenRecord}
-                    >
-                      Prontuário
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      className="cursor-pointer rounded-md focus:bg-gray-50"
-                      onClick={() => handleOpenModal("NO_SHOW")}
-                    >
-                      Não Compareceu
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      className="cursor-pointer rounded-md focus:bg-red-50 focus:text-red-600 text-red-600"
-                      onClick={() => handleOpenModal("CANCELLED")}
-                    >
-                      Cancelar
-                    </DropdownMenuItem>
-                  </>
+                  <DropdownMenuItem
+                    className="cursor-pointer rounded-md focus:bg-gray-50"
+                    onClick={handleOpenRecord}
+                  >
+                    Prontuário
+                  </DropdownMenuItem>
                 )}
                 {appointment.status === "NO_SHOW" && (
                   <>

--- a/apps/web/app/utils/icons.tsx
+++ b/apps/web/app/utils/icons.tsx
@@ -19,4 +19,5 @@ export {
   UserCheck as UserCheckIcon,
   CheckCircle as CheckCircleIcon,
   XCircle as XCircleIcon,
+  ArrowSquareOut as ArrowSquareOutIcon,
 } from "@phosphor-icons/react";

--- a/apps/web/queries/useAdminUsersTable.ts
+++ b/apps/web/queries/useAdminUsersTable.ts
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { adminService } from "../services/admin-service";
 
-export type TypeFilter = "all" | "PATIENT" | "PROFESSIONAL" | "MANAGER";
+export type TypeFilter = "PATIENT" | "PROFESSIONAL" | "MANAGER";
 
 const FUSE_OPTIONS = { keys: ["name", "email"], threshold: 0.3 };
 
@@ -18,11 +18,7 @@ export function useAdminUsersTable() {
 
   function setTypeFilter(value: TypeFilter) {
     const params = new URLSearchParams(searchParams.toString());
-    if (value === "all") {
-      params.delete("role");
-    } else {
-      params.set("role", value);
-    }
+    params.set("role", value);
     router.replace(`${pathname}?${params.toString()}`);
   }
 
@@ -36,11 +32,9 @@ export function useAdminUsersTable() {
     router.replace(`${pathname}?${params.toString()}`);
   }
 
-  const role = typeFilter !== "all" ? typeFilter : undefined;
-
   const { data = [], isLoading } = useQuery({
-    queryKey: ["admin-users", { role }],
-    queryFn: () => adminService.listUsers({ role }),
+    queryKey: ["admin-users", { role: typeFilter }],
+    queryFn: () => adminService.listUsers({ role: typeFilter }),
   });
 
   const users = useMemo(() => {

--- a/apps/web/queries/useAdminUsersTable.ts
+++ b/apps/web/queries/useAdminUsersTable.ts
@@ -13,7 +13,7 @@ export function useAdminUsersTable() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const typeFilter = (searchParams.get("role") as TypeFilter) ?? "all";
+  const typeFilter = (searchParams.get("role") as TypeFilter) ?? "PATIENT";
   const search = searchParams.get("search") ?? "";
 
   function setTypeFilter(value: TypeFilter) {

--- a/apps/web/queries/useMedicalRecords.ts
+++ b/apps/web/queries/useMedicalRecords.ts
@@ -7,11 +7,20 @@ import {
   UpdateMedicalRecordDto,
 } from "@/services/medical-records-service";
 
+export function useSharedMedicalRecordsQuery(params: ListMedicalRecordsParams) {
+  return useQuery({
+    queryKey: KEYS.shared(params),
+    queryFn: () => medicalRecordsService.listShared(params),
+  });
+}
+
 const KEYS = {
   list: (params: ListMedicalRecordsParams) =>
     ["medical-records", "list", params] as const,
   listForPatient: (params: ListMedicalRecordsParams) =>
     ["medical-records", "list-patient", params] as const,
+  shared: (params: ListMedicalRecordsParams) =>
+    ["medical-records", "shared", params] as const,
   byId: (id: string) => ["medical-records", "id", id] as const,
   byAppointment: (appointmentId: string) =>
     ["medical-records", "appointment", appointmentId] as const,

--- a/apps/web/services/medical-records-service.ts
+++ b/apps/web/services/medical-records-service.ts
@@ -169,6 +169,17 @@ export const medicalRecordsService = {
     }
   },
 
+  async listShared(
+    params: ListMedicalRecordsParams = {},
+  ): Promise<PaginatedMedicalRecords<MedicalRecordResponse>> {
+    try {
+      const response = await api.get("/medical-records/shared", { params });
+      return response.data as PaginatedMedicalRecords<MedicalRecordResponse>;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao buscar prontuários compartilhados.");
+    }
+  },
+
   async update(
     id: string,
     data: UpdateMedicalRecordDto,


### PR DESCRIPTION
## Resumo

### Tela de paciente do profissional (`/professional/patients/[id]`)
- PatientCard: popup removido, card inteiro clicável navega para o paciente
- Refatoração visual com cards de métricas (total de consultas e atendimentos)
- **Troca de status**: apenas consultas já encerradas (COMPLETED/NO_SHOW/CANCELLED) exibem "Alterar status" — correção de erro, não ação normal
- Dropdown "Alterar status" usa `position: fixed` para escapar do `overflow: hidden` do Card
- Filtros no histórico: por status e por período (30/90/180 dias) com `useMemo` local
- Contador "X de Y consultas" quando filtro ativo
- Botão "Prontuário" navega para `/medical-records?search=<nome>` pré-filtrado
- Tratamento de `isError`, hierarquia de headings corrigida, acessibilidade do dropdown

### Agenda (`/professional/schedule`)
- Consulta COMPLETED não exibe mais opções "Não Compareceu" e "Cancelar" — incoerente com consulta já realizada
- Backend: guarda `COMPLETED → NO_SHOW` bloqueada com `BadRequestException`

### Admin (`/admin`)
- Aba "Todos" removida — não faz sentido misturar roles na mesma view
- Tela abre em "Pacientes" por padrão, ordenada por cadastro mais recente
- Aprovação de usuário com optimistic update — botão muda instantaneamente sem aguardar refetch

### Prontuários compartilhados
- **Backend**: novo endpoint `GET /medical-records/shared` — retorna prontuários de pacientes já atendidos pelo profissional, criados por outros colegas. Valida vínculo server-side, suporta busca e paginação
- **Toggle** "Meus prontuários / Todos do paciente" na listagem
- Vista compartilhada: badge "Somente leitura" + "Registrado por Dr. X" em cada card
- **Nova rota** `/medical-records/shared/[id]`: visualização somente leitura com badge de aviso, exibe autor, omite notas internas

## Test plan
- [ ] Clicar em PatientCard — navega sem precisar do botão "Gerenciar"
- [ ] Histórico: filtrar por status e período — lista atualiza localmente
- [ ] "Alterar status" aparece apenas em consultas COMPLETED/NO_SHOW/CANCELLED
- [ ] Agenda: consulta COMPLETED mostra só "Prontuário" no menu
- [ ] Admin: abre em "Pacientes" ordenado por mais recente; aprovar usuário muda botão na hora
- [ ] Prontuários → "Todos do paciente": mostra prontuários de colegas dos pacientes já atendidos
- [ ] Abrir prontuário compartilhado → rota `/shared/[id]`, sem botão de editar, sem notas internas