### PR TITLE
fix: adicionar DIRECT_URL para migrações Prisma com Supabase

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -10,7 +10,14 @@
 # one found in a remote Prisma Postgres URL, does not contain any sensitive information.
 
 JWT_SECRET=super_secret_key
+
+# Em desenvolvimento local: ambas as variáveis podem ter o mesmo valor.
+# Em produção com Supabase: DATABASE_URL usa o pooler (Transaction mode) e
+# DIRECT_URL usa a conexão direta — necessário para o prisma migrate deploy.
+# Pooler:  postgresql://postgres.xxx:[password]@aws-1-us-west-2.pooler.supabase.com:5432/postgres
+# Direto:  postgresql://postgres:[password]@db.xxx.supabase.co:5432/postgres
 DATABASE_URL="postgresql://postgres:root@localhost:5432/life-med?sslmode=disable"
+DIRECT_URL="postgresql://postgres:root@localhost:5432/life-med?sslmode=disable"
 
 # Google Calendar / Meet integration
 # Run `apps/server/scripts/google-oauth-bootstrap.ts` once to obtain a refresh token.

--- a/apps/server/prisma/schema/base.prisma
+++ b/apps/server/prisma/schema/base.prisma
@@ -3,6 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }


### PR DESCRIPTION
## Problema

O deploy no Render falha em `prisma migrate deploy` com:

```
FATAL: (ENOTFOUND) tenant/user postgres.xxx not found
```

O Supabase expõe dois endpoints:
- **Pooler** (`pooler.supabase.com:5432`) — PgBouncer em Transaction mode, usado para queries da aplicação em produção
- **Direto** (`db.xxx.supabase.co:5432`) — conexão direta ao Postgres, necessária para migrações

O PgBouncer em Transaction mode não suporta o protocolo que o Prisma usa para `migrate deploy`, causando o ENOTFOUND ao tentar resolver o tenant.

## Solução

Adiciona `directUrl = env("DIRECT_URL")` no datasource do schema Prisma. O Prisma usa `DATABASE_URL` para runtime (queries) e `DIRECT_URL` para migrações.

## O que fazer no Render

Adicionar a variável `DIRECT_URL` no painel de Environment Variables do serviço:

- **`DATABASE_URL`** → connection string do pooler (já existente)
  `postgresql://postgres.xxx:[password]@aws-1-us-west-2.pooler.supabase.com:5432/postgres`

- **`DIRECT_URL`** → connection string direta (nova)
  `postgresql://postgres:[password]@db.xxx.supabase.co:5432/postgres`

Ambas as strings estão disponíveis no painel do Supabase em **Project Settings → Database → Connection String**.