### PR TITLE
feat(server): padronizar paginação nos endpoints de listagem

### DIFF
--- a/apps/server/src/admin/dto/list-admin-users-query-dto.ts
+++ b/apps/server/src/admin/dto/list-admin-users-query-dto.ts
@@ -1,10 +1,11 @@
 import { IsEnum, IsOptional, IsString } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { UserRole, UserStatus } from '@prisma/client';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
 
 const toUpper = ({ value }: { value: string }): string => value?.toUpperCase();
 
-export class ListAdminUsersQueryDto {
+export class ListAdminUsersQueryDto extends PaginationQueryDto {
   @IsOptional()
   @Transform(toUpper)
   @IsEnum(UserRole)

--- a/apps/server/src/appointments/appointments.repository.ts
+++ b/apps/server/src/appointments/appointments.repository.ts
@@ -255,7 +255,7 @@ export class AppointmentsRepository {
 
     const where = {
       ...ownerFilter,
-      ...(query.status && { status: query.status }),
+      ...(query.status?.length && { status: { in: query.status } }),
       ...(query.startDate || query.endDate
         ? {
             dateTime: {

--- a/apps/server/src/appointments/appointments.service.spec.ts
+++ b/apps/server/src/appointments/appointments.service.spec.ts
@@ -51,7 +51,7 @@ describe('AppointmentsService', () => {
   const makeAppointment = (overrides: Record<string, unknown> = {}) => ({
     id: 'appt-1',
     dateTime: hoursFromNow(48),
-    status: AppointmentStatus.SCHEDULED,
+    status: AppointmentStatus.CONFIRMED,
     notes: null,
     modality: 'IN_PERSON',
     googleEventId: null,
@@ -123,7 +123,9 @@ describe('AppointmentsService', () => {
         'https://meet.google.com/abc-defg-hij',
         'event-1',
       );
-      expect(mailService.sendAppointmentCreatedPatientEmail).toHaveBeenCalledWith(
+      expect(
+        mailService.sendAppointmentCreatedPatientEmail,
+      ).toHaveBeenCalledWith(
         { name: appointment.patient.name, email: appointment.patient.email },
         expect.objectContaining({
           modality: 'VIRTUAL',
@@ -161,7 +163,9 @@ describe('AppointmentsService', () => {
 
       expect(meetService.createMeetEvent).not.toHaveBeenCalled();
       expect(repository.updateMeetData).not.toHaveBeenCalled();
-      expect(mailService.sendAppointmentCreatedPatientEmail).toHaveBeenCalledWith(
+      expect(
+        mailService.sendAppointmentCreatedPatientEmail,
+      ).toHaveBeenCalledWith(
         { name: appointment.patient.name, email: appointment.patient.email },
         expect.objectContaining({
           modality: 'CLINIC',
@@ -192,7 +196,9 @@ describe('AppointmentsService', () => {
       });
 
       expect(repository.updateMeetData).not.toHaveBeenCalled();
-      expect(mailService.sendAppointmentCreatedPatientEmail).toHaveBeenCalledWith(
+      expect(
+        mailService.sendAppointmentCreatedPatientEmail,
+      ).toHaveBeenCalledWith(
         { name: appointment.patient.name, email: appointment.patient.email },
         expect.objectContaining({
           modality: 'VIRTUAL',
@@ -247,7 +253,9 @@ describe('AppointmentsService', () => {
         'appt-1',
         'Imprevisto',
       );
-      expect(mailService.sendAppointmentCancelledEmail).toHaveBeenCalledTimes(2);
+      expect(mailService.sendAppointmentCancelledEmail).toHaveBeenCalledTimes(
+        2,
+      );
       expect(result.status).toBe(AppointmentStatus.CANCELLED);
     });
 

--- a/apps/server/src/appointments/appointments.service.ts
+++ b/apps/server/src/appointments/appointments.service.ts
@@ -7,6 +7,7 @@ import {
   Inject,
 } from '@nestjs/common';
 import { AppointmentsRepository } from './appointments.repository';
+import { buildMeta } from '../common/dto/paginated-response.dto';
 import { MailService } from '../mail/mail.service';
 import { MEET_SERVICE } from '../common/interfaces/MeetEventInterfaces';
 import type { MeetService } from '../common/interfaces/MeetEventInterfaces';
@@ -85,9 +86,7 @@ export class AppointmentsService {
 
     return {
       data: appointments.map((a) => this.mapToResponseDto(a)),
-      page,
-      limit,
-      total,
+      meta: buildMeta(total, page, limit),
     };
   }
 
@@ -100,9 +99,7 @@ export class AppointmentsService {
 
     return {
       data: appointments.map((a) => this.mapToResponseDto(a)),
-      page,
-      limit,
-      total,
+      meta: buildMeta(total, page, limit),
     };
   }
 

--- a/apps/server/src/appointments/dto/appointment-response.dto.ts
+++ b/apps/server/src/appointments/dto/appointment-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AppointmentModality } from '@prisma/client';
+import { PaginationMetaDto } from '../../common/dto/paginated-response.dto';
 
 export class ProfessionalResponseDto {
   @ApiProperty({
@@ -120,12 +121,6 @@ export class AppointmentListResponseDto {
   })
   data!: AppointmentResponseDto[];
 
-  @ApiProperty({ example: 1, description: 'Página atual' })
-  page!: number;
-
-  @ApiProperty({ example: 10, description: 'Registros por página' })
-  limit!: number;
-
-  @ApiProperty({ example: 5, description: 'Total de registros' })
-  total!: number;
+  @ApiProperty({ type: PaginationMetaDto, description: 'Metadados de paginação' })
+  meta!: PaginationMetaDto;
 }

--- a/apps/server/src/appointments/dto/list-appointments-query.dto.ts
+++ b/apps/server/src/appointments/dto/list-appointments-query.dto.ts
@@ -1,25 +1,33 @@
-import {
-  IsOptional,
-  IsEnum,
-  IsDateString,
-  IsNumber,
-  Min,
-  Max,
-} from 'class-validator';
+import { IsOptional, IsEnum, IsDateString, IsArray } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 import { AppointmentStatus } from '@prisma/client';
-import { Type } from 'class-transformer';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
 
-export class ListAppointmentsQueryDto {
+export class ListAppointmentsQueryDto extends PaginationQueryDto {
   @ApiProperty({
     enum: AppointmentStatus,
+    isArray: true,
     example: 'CONFIRMED',
-    description: 'Filtrar por status do agendamento',
+    description:
+      'Filtrar por status do agendamento. Aceita um único valor ' +
+      '(?status=CONFIRMED) ou vários separados por vírgula ' +
+      '(?status=PENDING,CONFIRMED).',
     required: false,
   })
-  @IsEnum(AppointmentStatus, { message: 'Status inválido' })
+  // Normaliza "PENDING,CONFIRMED" (ou repetição do param) em array; um único
+  // valor vira array de um elemento. Assim `status: { in: [...] }` no
+  // repositório cobre tanto filtro simples quanto por múltiplos status (aba
+  // "Próximas" do paciente = PENDING + CONFIRMED).
+  @Transform(({ value }) => {
+    if (value === undefined || value === null || value === '') return undefined;
+    const list = Array.isArray(value) ? value : String(value).split(',');
+    return list.map((item) => String(item).trim()).filter(Boolean);
+  })
+  @IsArray()
+  @IsEnum(AppointmentStatus, { each: true, message: 'Status inválido' })
   @IsOptional()
-  status?: AppointmentStatus;
+  status?: AppointmentStatus[];
 
   @ApiProperty({
     example: '2024-06-01',
@@ -38,28 +46,4 @@ export class ListAppointmentsQueryDto {
   @IsDateString({}, { message: 'Data final inválida' })
   @IsOptional()
   endDate?: string;
-
-  @ApiProperty({
-    example: 1,
-    description: 'Página da paginação (começa em 1, máximo 1000)',
-    required: false,
-  })
-  @Type(() => Number)
-  @IsNumber({}, { message: 'Página deve ser um número' })
-  @Min(1, { message: 'Página deve ser no mínimo 1' })
-  @Max(1000, { message: 'Página máxima é 1000' })
-  @IsOptional()
-  page?: number = 1;
-
-  @ApiProperty({
-    example: 10,
-    description: 'Quantidade de registros por página (1-100, padrão 10)',
-    required: false,
-  })
-  @Type(() => Number)
-  @IsNumber({}, { message: 'Limit deve ser um número' })
-  @Min(1, { message: 'Limit deve ser no mínimo 1' })
-  @Max(100, { message: 'Limit máximo é 100 registros' })
-  @IsOptional()
-  limit?: number = 10;
 }

--- a/apps/server/src/common/dto/paginated-response.dto.ts
+++ b/apps/server/src/common/dto/paginated-response.dto.ts
@@ -1,0 +1,98 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Metadados de paginação incluídos em toda resposta paginada.
+ */
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+/**
+ * Envelope padrão de resposta paginada da API.
+ *
+ * Contrato unificado usado por TODOS os endpoints paginados:
+ *   { data: T[], meta: { page, limit, total, totalPages } }
+ */
+export interface PaginatedResult<T> {
+  data: T[];
+  meta: PaginationMeta;
+}
+
+/**
+ * Classe de metadados para documentação Swagger.
+ */
+export class PaginationMetaDto implements PaginationMeta {
+  @ApiProperty({ example: 1, description: 'Página atual' })
+  page!: number;
+
+  @ApiProperty({ example: 10, description: 'Registros por página' })
+  limit!: number;
+
+  @ApiProperty({ example: 42, description: 'Total de registros' })
+  total!: number;
+
+  @ApiProperty({ example: 5, description: 'Total de páginas' })
+  totalPages!: number;
+}
+
+/**
+ * Monta os metadados de paginação a partir do total e dos parâmetros da query.
+ * `totalPages` é no mínimo 1 mesmo quando não há registros, para simplificar a UI.
+ */
+export function buildMeta(
+  total: number,
+  page: number,
+  limit: number,
+): PaginationMeta {
+  return {
+    page,
+    limit,
+    total,
+    totalPages: Math.max(1, Math.ceil(total / limit)),
+  };
+}
+
+/**
+ * Delegate mínimo de um model Prisma: expõe `findMany` e `count`.
+ * Genérico sobre o próprio delegate para preservar a inferência de tipos do
+ * Prisma (args e retorno de `findMany`).
+ */
+interface PrismaModelDelegate {
+  findMany(args: unknown): Promise<unknown>;
+  count(args: unknown): Promise<number>;
+}
+
+type FindManyArgs<D extends PrismaModelDelegate> = Parameters<D['findMany']>[0];
+type FindManyRow<D extends PrismaModelDelegate> =
+  Awaited<ReturnType<D['findMany']>> extends (infer R)[] ? R : never;
+
+/**
+ * Executa `findMany` + `count` em paralelo aplicando skip/take e retorna o
+ * envelope paginado padrão. Elimina a duplicação de `Promise.all([findMany, count])`
+ * espalhada pelos repositories.
+ *
+ * @example
+ *   return paginate(this.prisma.user, { where, include, orderBy }, page, limit);
+ */
+export async function paginate<D extends PrismaModelDelegate>(
+  delegate: D,
+  args: FindManyArgs<D>,
+  page: number,
+  limit: number,
+): Promise<PaginatedResult<FindManyRow<D>>> {
+  const findArgs = args as { where?: unknown };
+
+  const [data, total] = await Promise.all([
+    delegate.findMany({
+      ...findArgs,
+      skip: (page - 1) * limit,
+      take: limit,
+    }) as Promise<FindManyRow<D>[]>,
+    delegate.count({ where: findArgs.where }),
+  ]);
+
+  return { data, meta: buildMeta(total, page, limit) };
+}

--- a/apps/server/src/common/dto/pagination-query.dto.ts
+++ b/apps/server/src/common/dto/pagination-query.dto.ts
@@ -1,0 +1,36 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+/**
+ * Base DTO de paginação (offset-based).
+ *
+ * DTOs de listagem devem estender esta classe e adicionar apenas seus próprios
+ * filtros (search, status, datas, etc). Assim `page`/`limit` ficam centralizados
+ * em um único lugar, com validação e defaults consistentes em toda a API.
+ */
+export class PaginationQueryDto {
+  @ApiPropertyOptional({
+    example: 1,
+    default: 1,
+    description: 'Página da paginação (começa em 1, máximo 1000)',
+  })
+  @Type(() => Number)
+  @IsInt({ message: 'Página deve ser um número inteiro' })
+  @Min(1, { message: 'Página deve ser no mínimo 1' })
+  @Max(1000, { message: 'Página máxima é 1000' })
+  @IsOptional()
+  page: number = 1;
+
+  @ApiPropertyOptional({
+    example: 10,
+    default: 10,
+    description: 'Quantidade de registros por página (1-100, padrão 10)',
+  })
+  @Type(() => Number)
+  @IsInt({ message: 'Limit deve ser um número inteiro' })
+  @Min(1, { message: 'Limit deve ser no mínimo 1' })
+  @Max(100, { message: 'Limit máximo é 100 registros' })
+  @IsOptional()
+  limit: number = 10;
+}

--- a/apps/server/src/manager/dtos/list-manager-appointments-query.dto.ts
+++ b/apps/server/src/manager/dtos/list-manager-appointments-query.dto.ts
@@ -1,7 +1,8 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional } from 'class-validator';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
 
-export class ListManagerAppointmentsQueryDto {
+export class ListManagerAppointmentsQueryDto extends PaginationQueryDto {
   @ApiPropertyOptional({
     enum: ['vulnerabilityScore'],
     description: 'Campo usado para ordenar os agendamentos',

--- a/apps/server/src/manager/manager.controller.ts
+++ b/apps/server/src/manager/manager.controller.ts
@@ -28,6 +28,7 @@ import { UpdatePatientDto } from '../patients/dto/update-patient.dto';
 import { UpdatePatientApprovalStatusDto } from '../patients/dto/update-patient-approval-status.dto';
 import { CancelAppointmentDto } from '../appointments/dto/cancel-appointment-patient.dto';
 import { ListManagerAppointmentsQueryDto } from './dtos/list-manager-appointments-query.dto';
+import { ListPatientsQueryDto } from '../patients/dto/list-patients-query.dto';
 
 @ApiTags('Manager')
 @ApiBearerAuth('access-token')
@@ -106,8 +107,8 @@ export class ManagerController {
   @ApiResponse({ status: 200, description: 'Lista de pacientes.' })
   @ApiResponse({ status: 401, description: 'Não autenticado.' })
   @ApiResponse({ status: 403, description: 'Acesso negado — somente MANAGER.' })
-  async listPatients(@Query('search') search?: string) {
-    return this.patientsService.listPatients(search);
+  async listPatients(@Query() query: ListPatientsQueryDto) {
+    return this.patientsService.listPatients(query);
   }
 
   @Get('patients/:patientId')

--- a/apps/server/src/manager/manager.repository.ts
+++ b/apps/server/src/manager/manager.repository.ts
@@ -1,6 +1,59 @@
 import { Injectable } from '@nestjs/common';
-import { AppointmentStatus } from '@prisma/client';
+import { AppointmentStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { ListManagerAppointmentsQueryDto } from './dtos/list-manager-appointments-query.dto';
+import {
+  buildMeta,
+  PaginatedResult,
+} from '../common/dto/paginated-response.dto';
+
+const MANAGER_APPOINTMENT_SELECT = {
+  id: true,
+  dateTime: true,
+  status: true,
+  notes: true,
+  modality: true,
+  meetLink: true,
+  createdAt: true,
+  patient: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      patientProfile: {
+        select: {
+          questionnaire: {
+            select: {
+              totalScore: true,
+              isVulnerable: true,
+            },
+          },
+        },
+      },
+    },
+  },
+  professional: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+  scheduledByManager: {
+    select: {
+      user: { select: { name: true } },
+    },
+  },
+  cancelledByManager: {
+    select: {
+      user: { select: { name: true } },
+    },
+  },
+} satisfies Prisma.AppointmentSelect;
+
+export type ManagerAppointmentRow = Prisma.AppointmentGetPayload<{
+  select: typeof MANAGER_APPOINTMENT_SELECT;
+}>;
 
 @Injectable()
 export class ManagerRepository {
@@ -36,53 +89,56 @@ export class ManagerRepository {
     });
   }
 
-  findAllAppointmentsForManagerAndAdmin() {
-    return this.prisma.appointment.findMany({
-      select: {
-        id: true,
-        dateTime: true,
-        status: true,
-        notes: true,
-        modality: true,
-        meetLink: true,
-        createdAt: true,
+  async findAllAppointmentsForManagerAndAdmin(
+    query: ListManagerAppointmentsQueryDto,
+  ): Promise<PaginatedResult<ManagerAppointmentRow>> {
+    const { page, limit } = query;
+    const orderBy = this.buildAppointmentsOrderBy(query);
+
+    const [data, total] = await Promise.all([
+      this.prisma.appointment.findMany({
+        select: MANAGER_APPOINTMENT_SELECT,
+        orderBy,
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.appointment.count(),
+    ]);
+
+    return { data, meta: buildMeta(total, page, limit) };
+  }
+
+  /**
+   * Ordenação por vulnerabilidade resolvida no banco (não em memória), para
+   * funcionar corretamente através de todas as páginas.
+   *
+   * Ordena pela nota do questionário do paciente (relação to-one) e usa
+   * `dateTime desc` como critério de desempate — o mesmo comportamento do antigo
+   * sort em memória. Pacientes sem questionário (totalScore NULL) seguem a
+   * colocação padrão do PostgreSQL (NULLs por último em asc), preservando a
+   * ordenação consistente entre páginas.
+   */
+  private buildAppointmentsOrderBy(
+    query: ListManagerAppointmentsQueryDto,
+  ): Prisma.AppointmentOrderByWithRelationInput[] {
+    if (query.sortBy !== 'vulnerabilityScore') {
+      return [{ dateTime: 'desc' }];
+    }
+
+    const direction: Prisma.SortOrder = query.order === 'desc' ? 'desc' : 'asc';
+
+    return [
+      {
         patient: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            patientProfile: {
-              select: {
-                questionnaire: {
-                  select: {
-                    totalScore: true,
-                    isVulnerable: true,
-                  },
-                },
-              },
+          patientProfile: {
+            questionnaire: {
+              totalScore: direction,
             },
           },
         },
-        professional: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-          },
-        },
-        scheduledByManager: {
-          select: {
-            user: { select: { name: true } },
-          },
-        },
-        cancelledByManager: {
-          select: {
-            user: { select: { name: true } },
-          },
-        },
       },
-      orderBy: { dateTime: 'desc' },
-    });
+      { dateTime: 'desc' },
+    ];
   }
 
   findProfessionalWithSpecialities(id: string) {

--- a/apps/server/src/manager/manager.service.spec.ts
+++ b/apps/server/src/manager/manager.service.spec.ts
@@ -83,7 +83,7 @@ describe('ManagerService', () => {
     });
   });
 
-  describe('listAppointments vulnerability sorting', () => {
+  describe('listAppointments', () => {
     const makeAppt = (
       id: string,
       dateTime: Date,
@@ -110,45 +110,46 @@ describe('ManagerService', () => {
       cancelledByManager: null,
     });
 
-    it('keeps insertion order when not sorting by vulnerability', async () => {
-      repository.findAllAppointmentsForManagerAndAdmin.mockResolvedValue([
-        makeAppt('a', new Date('2026-01-01'), 2),
-        makeAppt('b', new Date('2026-02-01'), 8),
-      ]);
+    const meta = { page: 1, limit: 10, total: 2, totalPages: 1 };
 
-      const result = await service.listAppointments({} as any);
-
-      expect(result.map((r) => r.id)).toEqual(['a', 'b']);
-      expect(result[1].isVulnerable).toBe(true);
-    });
-
-    it('sorts by score descending and pushes null scores to the end', async () => {
-      repository.findAllAppointmentsForManagerAndAdmin.mockResolvedValue([
-        makeAppt('low', new Date('2026-01-01'), 2),
-        makeAppt('none', new Date('2026-01-01'), null),
-        makeAppt('high', new Date('2026-01-01'), 9),
-      ]);
+    it('returns the { data, meta } envelope and maps rows', async () => {
+      repository.findAllAppointmentsForManagerAndAdmin.mockResolvedValue({
+        data: [
+          makeAppt('a', new Date('2026-01-01'), 2),
+          makeAppt('b', new Date('2026-02-01'), 8),
+        ],
+        meta,
+      });
 
       const result = await service.listAppointments({
-        sortBy: 'vulnerabilityScore',
-        order: 'desc',
+        page: 1,
+        limit: 10,
       } as any);
 
-      expect(result.map((r) => r.id)).toEqual(['high', 'low', 'none']);
+      expect(result.data.map((r) => r.id)).toEqual(['a', 'b']);
+      expect(result.data[1].isVulnerable).toBe(true);
+      expect(result.meta).toEqual(meta);
     });
 
-    it('sorts ascending when order is asc', async () => {
-      repository.findAllAppointmentsForManagerAndAdmin.mockResolvedValue([
-        makeAppt('high', new Date('2026-01-01'), 9),
-        makeAppt('low', new Date('2026-01-01'), 2),
-      ]);
+    it('preserves the DB ordering (sorting now happens in the repository)', async () => {
+      // A ordenação por vulnerabilityScore é feita no Prisma orderBy; o service
+      // apenas repassa a ordem já resolvida pelo banco através de todas as páginas.
+      repository.findAllAppointmentsForManagerAndAdmin.mockResolvedValue({
+        data: [
+          makeAppt('high', new Date('2026-01-01'), 9),
+          makeAppt('low', new Date('2026-01-01'), 2),
+          makeAppt('none', new Date('2026-01-01'), null),
+        ],
+        meta: { ...meta, total: 3 },
+      });
 
-      const result = await service.listAppointments({
-        sortBy: 'vulnerabilityScore',
-        order: 'asc',
-      } as any);
+      const query = { sortBy: 'vulnerabilityScore', order: 'desc' } as any;
+      const result = await service.listAppointments(query);
 
-      expect(result.map((r) => r.id)).toEqual(['low', 'high']);
+      expect(result.data.map((r) => r.id)).toEqual(['high', 'low', 'none']);
+      expect(
+        repository.findAllAppointmentsForManagerAndAdmin,
+      ).toHaveBeenCalledWith(query);
     });
   });
 

--- a/apps/server/src/manager/manager.service.ts
+++ b/apps/server/src/manager/manager.service.ts
@@ -1,10 +1,6 @@
-import {
-  Injectable,
-  BadRequestException,
-  NotFoundException,
-} from '@nestjs/common';
-import { ManagerRepository } from './manager.repository';
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
 import { AppointmentStatus, UserRole } from '@prisma/client';
+import { ManagerRepository } from './manager.repository';
 import { ListManagerAppointmentsQueryDto } from './dtos/list-manager-appointments-query.dto';
 
 @Injectable()
@@ -16,8 +12,7 @@ export class ManagerService {
     appointmentId: string,
     reason?: string,
   ) {
-    const appointment =
-      await this.repository.findAppointmentById(appointmentId);
+    const appointment = await this.repository.findAppointmentById(appointmentId);
 
     if (!appointment) {
       throw new NotFoundException('Consulta não encontrada');
@@ -27,8 +22,9 @@ export class ManagerService {
       throw new BadRequestException('Consulta já está cancelada');
     }
 
-    const manager =
-      await this.repository.findManagerProfileByUserId(managerUserId);
+    const manager = await this.repository.findManagerProfileByUserId(
+      managerUserId,
+    );
 
     if (!manager) {
       throw new NotFoundException('Perfil de gestor não encontrado');
@@ -46,49 +42,39 @@ export class ManagerService {
   }
 
   async listAppointments(query: ListManagerAppointmentsQueryDto) {
-    const appointments =
-      await this.repository.findAllAppointmentsForManagerAndAdmin();
+    const { data, meta } =
+      await this.repository.findAllAppointmentsForManagerAndAdmin(query);
 
-    const response = appointments.map((appointment) => ({
-      id: appointment.id,
-      dateTime: appointment.dateTime,
-      status: appointment.status,
-      notes: appointment.notes,
-      modality: appointment.modality,
-      meetLink: appointment.meetLink,
-      createdAt: appointment.createdAt,
-      patient: {
-        id: appointment.patient.id,
-        name: appointment.patient.name,
-        email: appointment.patient.email,
-      },
-      professional: appointment.professional,
-      scheduledByManager: appointment.scheduledByManager,
-      cancelledByManager: appointment.cancelledByManager,
-      totalScore:
-        appointment.patient.patientProfile?.questionnaire?.totalScore ?? null,
-      isVulnerable:
-        appointment.patient.patientProfile?.questionnaire?.isVulnerable ?? null,
-    }));
+    return {
+      data: data.map((appt) => {
+        const questionnaire = appt.patient.patientProfile?.questionnaire;
 
-    if (query.sortBy !== 'vulnerabilityScore') {
-      return response;
-    }
-
-    const direction = query.order === 'desc' ? -1 : 1;
-
-    return response.sort((left, right) => {
-      if (left.totalScore === null && right.totalScore === null) {
-        return right.dateTime.getTime() - left.dateTime.getTime();
-      }
-      if (left.totalScore === null) return 1;
-      if (right.totalScore === null) return -1;
-
-      const scoreDifference = (left.totalScore - right.totalScore) * direction;
-      return (
-        scoreDifference || right.dateTime.getTime() - left.dateTime.getTime()
-      );
-    });
+        return {
+          id: appt.id,
+          dateTime: appt.dateTime,
+          status: appt.status,
+          notes: appt.notes,
+          modality: appt.modality,
+          meetLink: appt.meetLink,
+          createdAt: appt.createdAt,
+          patient: {
+            id: appt.patient.id,
+            name: appt.patient.name,
+            email: appt.patient.email,
+          },
+          professional: {
+            id: appt.professional.id,
+            name: appt.professional.name,
+            email: appt.professional.email,
+          },
+          scheduledByManagerName: appt.scheduledByManager?.user.name ?? null,
+          cancelledByManagerName: appt.cancelledByManager?.user.name ?? null,
+          vulnerabilityScore: questionnaire?.totalScore ?? null,
+          isVulnerable: questionnaire?.isVulnerable ?? false,
+        };
+      }),
+      meta,
+    };
   }
 
   async getProfessionalAvailability(professionalId: string) {

--- a/apps/server/src/medical-records/dto/list-medical-records-query.dto.ts
+++ b/apps/server/src/medical-records/dto/list-medical-records-query.dto.ts
@@ -1,16 +1,8 @@
-import {
-  IsOptional,
-  IsUUID,
-  IsDateString,
-  IsNumber,
-  IsString,
-  Min,
-  Max,
-} from 'class-validator';
+import { IsOptional, IsUUID, IsDateString, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
 
-export class ListMedicalRecordsQueryDto {
+export class ListMedicalRecordsQueryDto extends PaginationQueryDto {
   @ApiProperty({
     description: 'Filtrar pelo ID do paciente',
     required: false,
@@ -54,20 +46,4 @@ export class ListMedicalRecordsQueryDto {
   @IsDateString({}, { message: 'Data final inválida' })
   @IsOptional()
   endDate?: string;
-
-  @ApiProperty({ example: 1, required: false })
-  @Type(() => Number)
-  @IsNumber({}, { message: 'Página deve ser um número' })
-  @Min(1, { message: 'Página deve ser no mínimo 1' })
-  @Max(1000, { message: 'Página máxima é 1000' })
-  @IsOptional()
-  page?: number = 1;
-
-  @ApiProperty({ example: 10, required: false })
-  @Type(() => Number)
-  @IsNumber({}, { message: 'Limit deve ser um número' })
-  @Min(1, { message: 'Limit deve ser no mínimo 1' })
-  @Max(100, { message: 'Limit máximo é 100 registros' })
-  @IsOptional()
-  limit?: number = 10;
 }

--- a/apps/server/src/medical-records/dto/medical-record-response.dto.ts
+++ b/apps/server/src/medical-records/dto/medical-record-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { PaginationMetaDto } from '../../common/dto/paginated-response.dto';
 
 export class MedicalRecordAuthorDto {
   @ApiProperty() id!: string;
@@ -55,15 +56,13 @@ export class MedicalRecordPatientResponseDto {
 export class MedicalRecordListResponseDto {
   @ApiProperty({ type: [MedicalRecordResponseDto] })
   data!: MedicalRecordResponseDto[];
-  @ApiProperty({ example: 1 }) page!: number;
-  @ApiProperty({ example: 10 }) limit!: number;
-  @ApiProperty({ example: 0 }) total!: number;
+  @ApiProperty({ type: PaginationMetaDto })
+  meta!: PaginationMetaDto;
 }
 
 export class MedicalRecordPatientListResponseDto {
   @ApiProperty({ type: [MedicalRecordPatientResponseDto] })
   data!: MedicalRecordPatientResponseDto[];
-  @ApiProperty({ example: 1 }) page!: number;
-  @ApiProperty({ example: 10 }) limit!: number;
-  @ApiProperty({ example: 0 }) total!: number;
+  @ApiProperty({ type: PaginationMetaDto })
+  meta!: PaginationMetaDto;
 }

--- a/apps/server/src/medical-records/medical-records.controller.ts
+++ b/apps/server/src/medical-records/medical-records.controller.ts
@@ -134,13 +134,14 @@ export class MedicalRecordsController {
     description: 'Requer vínculo de consulta com o paciente.',
   })
   @ApiParam({ name: 'patientId', description: 'ID do paciente' })
-  @ApiResponse({ status: 200, type: [MedicalRecordResponseDto] })
+  @ApiResponse({ status: 200, type: MedicalRecordListResponseDto })
   @ApiResponse({ status: 403, description: 'Sem vínculo com este paciente.' })
   findByPatient(
     @Request() req: { user: { userId: string } },
     @Param('patientId') patientId: string,
+    @Query() query: ListMedicalRecordsQueryDto,
   ) {
-    return this.service.findByPatient(patientId, req.user.userId);
+    return this.service.findByPatient(patientId, req.user.userId, query);
   }
 
   @Get('appointment/:appointmentId/pdf')

--- a/apps/server/src/medical-records/medical-records.repository.ts
+++ b/apps/server/src/medical-records/medical-records.repository.ts
@@ -77,12 +77,21 @@ export class MedicalRecordsRepository {
     return { records, total, page, limit };
   }
 
-  findByPatient(patientId: string) {
-    return this.prisma.medicalRecord.findMany({
-      where: { patientId },
-      include: RECORD_INCLUDE,
-      orderBy: { createdAt: 'desc' },
-    });
+  async findByPatient(patientId: string, page: number, limit: number) {
+    const where: Prisma.MedicalRecordWhereInput = { patientId };
+
+    const [records, total] = await Promise.all([
+      this.prisma.medicalRecord.findMany({
+        where,
+        include: RECORD_INCLUDE,
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.medicalRecord.count({ where }),
+    ]);
+
+    return { records, total, page, limit };
   }
 
   async listSharedForProfessional(

--- a/apps/server/src/medical-records/medical-records.service.spec.ts
+++ b/apps/server/src/medical-records/medical-records.service.spec.ts
@@ -207,7 +207,10 @@ describe('MedicalRecordsService', () => {
       repository.hasValidPriorAppointment.mockResolvedValue(false);
 
       await expect(
-        service.findByPatient('patient-1', 'prof-1'),
+        service.findByPatient('patient-1', 'prof-1', {
+          page: 1,
+          limit: 10,
+        } as any),
       ).rejects.toBeInstanceOf(ForbiddenException);
 
       expect(repository.hasValidPriorAppointment).toHaveBeenCalledWith(

--- a/apps/server/src/medical-records/medical-records.service.ts
+++ b/apps/server/src/medical-records/medical-records.service.ts
@@ -19,6 +19,7 @@ import {
   MedicalRecordPdfService,
   PatientMedicalRecordPdfInput,
 } from './medical-record-pdf.service';
+import { buildMeta } from '../common/dto/paginated-response.dto';
 
 type MedicalRecordWithRelations = Prisma.MedicalRecordGetPayload<{
   include: {
@@ -148,17 +149,13 @@ export class MedicalRecordsService {
     if (requesterRole === UserRole.PATIENT) {
       return {
         data: records.map((r) => this.toPatientResponseDto(r)),
-        page,
-        limit,
-        total,
+        meta: buildMeta(total, page, limit),
       };
     }
 
     return {
       data: records.map((r) => this.toResponseDto(r)),
-      page,
-      limit,
-      total,
+      meta: buildMeta(total, page, limit),
     };
   }
 
@@ -171,16 +168,15 @@ export class MedicalRecordsService {
 
     return {
       data: records.map((r) => this.toResponseDto(r)),
-      page,
-      limit,
-      total,
+      meta: buildMeta(total, page, limit),
     };
   }
 
   async findByPatient(
     patientId: string,
     requesterId: string,
-  ): Promise<MedicalRecordResponseDto[]> {
+    query: ListMedicalRecordsQueryDto,
+  ): Promise<MedicalRecordListResponseDto> {
     const hasLink = await this.hasPriorAppointment(requesterId, patientId);
 
     if (!hasLink) {
@@ -189,9 +185,13 @@ export class MedicalRecordsService {
       );
     }
 
-    const records = await this.repository.findByPatient(patientId);
+    const { records, total, page, limit } =
+      await this.repository.findByPatient(patientId, query.page, query.limit);
 
-    return records.map((r) => this.toResponseDto(r));
+    return {
+      data: records.map((r) => this.toResponseDto(r)),
+      meta: buildMeta(total, page, limit),
+    };
   }
 
   async update(

--- a/apps/server/src/patients/dto/list-patients-query.dto.ts
+++ b/apps/server/src/patients/dto/list-patients-query.dto.ts
@@ -1,0 +1,12 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+
+export class ListPatientsQueryDto extends PaginationQueryDto {
+  @ApiPropertyOptional({
+    description: 'Busca textual por nome ou CPF do paciente',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+}

--- a/apps/server/src/patients/patients.repository.ts
+++ b/apps/server/src/patients/patients.repository.ts
@@ -8,8 +8,10 @@ import {
 } from '@prisma/client';
 import { CreatePatientDto } from './dto/create-patient.dto';
 import { ExportAppointmentsQueryDto } from './dto/export-appointments-query.dto';
+import { ListPatientsQueryDto } from './dto/list-patients-query.dto';
 import { UpdatePatientDto } from './dto/update-patient.dto';
 import { PrismaService } from '../prisma/prisma.service';
+import { paginate } from '../common/dto/paginated-response.dto';
 
 @Injectable()
 export class PatientsRepository {
@@ -156,30 +158,39 @@ export class PatientsRepository {
     });
   }
 
-  listPatients(search?: string) {
-    return this.prisma.user.findMany({
-      where: {
-        role: UserRole.PATIENT,
-        ...(search && {
-          OR: [
-            { name: { contains: search, mode: 'insensitive' } },
-            { cpf: { contains: search } },
-          ],
-        }),
-      },
-      include: {
-        patientProfile: {
-          include: {
-            questionnaire: {
-              include: {
-                answers: { include: { question: true, option: true } },
+  listPatients(query: ListPatientsQueryDto) {
+    const { search, page, limit } = query;
+
+    const where: Prisma.UserWhereInput = {
+      role: UserRole.PATIENT,
+      ...(search && {
+        OR: [
+          { name: { contains: search, mode: 'insensitive' } },
+          { cpf: { contains: search } },
+        ],
+      }),
+    };
+
+    return paginate(
+      this.prisma.user,
+      {
+        where,
+        include: {
+          patientProfile: {
+            include: {
+              questionnaire: {
+                include: {
+                  answers: { include: { question: true, option: true } },
+                },
               },
             },
           },
         },
+        orderBy: { createdAt: 'desc' },
       },
-      orderBy: { createdAt: 'desc' },
-    });
+      page,
+      limit,
+    );
   }
 
   findPatientWithQuestionnaire(patientId: string) {

--- a/apps/server/src/patients/patients.service.ts
+++ b/apps/server/src/patients/patients.service.ts
@@ -17,6 +17,7 @@ import { AppointmentReportItemDto } from '../reports/dto/appointment-made.dto';
 import { ExportAppointmentsQueryDto } from './dto/export-appointments-query.dto';
 import { CreatePatientDto } from './dto/create-patient.dto';
 import { UpdatePatientDto } from './dto/update-patient.dto';
+import { ListPatientsQueryDto } from './dto/list-patients-query.dto';
 import PDFKit from 'pdfkit';
 
 type PDFDocumentType = PDFKit.PDFDocument;
@@ -210,8 +211,8 @@ export class PatientsService {
     };
   }
 
-  async listPatients(search?: string) {
-    return this.repository.listPatients(search);
+  async listPatients(query: ListPatientsQueryDto) {
+    return this.repository.listPatients(query);
   }
 
   async getPatient(patientId: string) {

--- a/apps/server/src/professional/professional.controller.ts
+++ b/apps/server/src/professional/professional.controller.ts
@@ -25,6 +25,7 @@ import { CreateScheduleBlockDto } from './dto/schedule-block.dto';
 import { ProfessionalRoleGuard } from './guards/professional-role.guard';
 import { EmailVerifiedGuard } from '../auth/guards/email-verified.guard';
 import { QuestionnaireCompletionGuard } from '../questionnaire/questionnaire-completion.guard';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 
 @ApiTags('Professional')
 @ApiBearerAuth('access-token')
@@ -35,11 +36,11 @@ export class ProfessionalController {
 
   @Get()
   @UseGuards(AuthGuard('jwt'), EmailVerifiedGuard)
-  @ApiOperation({ summary: 'Listar todos os profissionais' })
+  @ApiOperation({ summary: 'Listar todos os profissionais (paginado)' })
   @ApiResponse({ status: 200, description: 'Lista de profissionais.' })
   @ApiResponse({ status: 401, description: 'Não autenticado.' })
-  listAll() {
-    return this.professionalService.listAll();
+  listAll(@Query() query: PaginationQueryDto) {
+    return this.professionalService.listAll(query);
   }
 
   @Get('settings')
@@ -124,8 +125,8 @@ export class ProfessionalController {
     status: 403,
     description: 'Acesso negado — somente PROFESSIONAL.',
   })
-  getPatients(@Req() req) {
-    return this.professionalService.getPatients(req.user.id as string);
+  getPatients(@Req() req, @Query() query: PaginationQueryDto) {
+    return this.professionalService.getPatients(req.user.id as string, query);
   }
 
   @Get('patients/:id')
@@ -137,10 +138,15 @@ export class ProfessionalController {
   })
   @ApiResponse({ status: 200, description: 'Detalhes e histórico.' })
   @ApiResponse({ status: 404, description: 'Paciente não encontrado.' })
-  getPatientDetail(@Req() req, @Param('id') patientId: string) {
+  getPatientDetail(
+    @Req() req,
+    @Param('id') patientId: string,
+    @Query() query: PaginationQueryDto,
+  ) {
     return this.professionalService.getPatientDetail(
       req.user.id as string,
       patientId,
+      query,
     );
   }
 

--- a/apps/server/src/professional/professional.repository.ts
+++ b/apps/server/src/professional/professional.repository.ts
@@ -98,24 +98,53 @@ export class ProfessionalRepository {
     });
   }
 
-  findAppointmentsWithPatients(userId: string) {
+  /**
+   * Página de pacientes distintos que já tiveram consulta com este profissional,
+   * ordenados por nome. A paginação é feita sobre a lista de pacientes (não de
+   * consultas), garantindo `total`/`totalPages` corretos por paciente.
+   */
+  async findAttendedPatientsPage(
+    professionalId: string,
+    page: number,
+    limit: number,
+  ) {
+    const where: Prisma.UserWhereInput = {
+      role: 'PATIENT',
+      appointmentsAsPatient: { some: { professionalId } },
+    };
+
+    const [patients, total] = await Promise.all([
+      this.prisma.user.findMany({
+        where,
+        orderBy: { name: 'asc' },
+        skip: (page - 1) * limit,
+        take: limit,
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          cpf: true,
+          patientProfile: { select: { phone: true } },
+        },
+      }),
+      this.prisma.user.count({ where }),
+    ]);
+
+    return { patients, total };
+  }
+
+  /**
+   * Consultas (dateTime/status) de um conjunto de pacientes com este profissional,
+   * usadas para calcular última/próxima visita da página atual.
+   */
+  findAppointmentsForPatients(professionalId: string, patientIds: string[]) {
     return this.prisma.appointment.findMany({
-      where: { professionalId: userId },
+      where: { professionalId, patientId: { in: patientIds } },
       orderBy: { dateTime: 'desc' },
       select: {
         dateTime: true,
         status: true,
-        patient: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            cpf: true,
-            patientProfile: {
-              select: { phone: true },
-            },
-          },
-        },
+        patientId: true,
       },
     });
   }
@@ -135,27 +164,52 @@ export class ProfessionalRepository {
     });
   }
 
-  findPatientAppointments(professionalId: string, patientId: string) {
-    return this.prisma.appointment.findMany({
-      where: { professionalId, patientId },
-      orderBy: { dateTime: 'desc' },
-    });
+  async findPatientAppointments(
+    professionalId: string,
+    patientId: string,
+    page: number,
+    limit: number,
+  ) {
+    const where: Prisma.AppointmentWhereInput = { professionalId, patientId };
+
+    const [appointments, total] = await Promise.all([
+      this.prisma.appointment.findMany({
+        where,
+        orderBy: { dateTime: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.appointment.count({ where }),
+    ]);
+
+    return { appointments, total };
   }
 
-  listAllProfessionals() {
-    return this.prisma.user.findMany({
-      where: { role: 'PROFESSIONAL' },
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        status: true,
-        professionalProfile: {
-          include: { specialities: true },
-        },
-        address: true,
+  async listAllProfessionals(page: number, limit: number) {
+    const where = { role: 'PROFESSIONAL' as const };
+    const select = {
+      id: true,
+      name: true,
+      email: true,
+      status: true,
+      professionalProfile: {
+        include: { specialities: true },
       },
-    });
+      address: true,
+    };
+
+    const [data, total] = await Promise.all([
+      this.prisma.user.findMany({
+        where,
+        select,
+        orderBy: { name: 'asc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.user.count({ where }),
+    ]);
+
+    return { data, total };
   }
 
   updateSettings(userId: string, dto: UpdateProfessionalSettingsDto) {

--- a/apps/server/src/professional/professional.service.spec.ts
+++ b/apps/server/src/professional/professional.service.spec.ts
@@ -12,7 +12,8 @@ describe('ProfessionalService', () => {
     findDailyAppointments: jest.fn(),
     findScheduleBlocksByDate: jest.fn(),
     countDistinctAttendedPatients: jest.fn(),
-    findAppointmentsWithPatients: jest.fn(),
+    findAttendedPatientsPage: jest.fn(),
+    findAppointmentsForPatients: jest.fn(),
     updateSettings: jest.fn(),
     findScheduleBlockById: jest.fn(),
     deleteScheduleBlock: jest.fn(),
@@ -99,62 +100,92 @@ describe('ProfessionalService', () => {
   });
 
   describe('getPatients aggregation', () => {
-    it('dedups patients and computes last/next visit correctly', async () => {
+    const pageQuery = { page: 1, limit: 10 } as any;
+
+    it('computes last/next visit per patient and returns { data, meta }', async () => {
       const now = Date.now();
       const past = new Date(now - 86400000); // ontem
       const future = new Date(now + 86400000); // amanhã
 
-      repository.findAppointmentsWithPatients.mockResolvedValue([
-        {
-          dateTime: past,
-          status: AppointmentStatus.COMPLETED,
-          patient: {
+      repository.findAttendedPatientsPage.mockResolvedValue({
+        patients: [
+          {
             id: 'pat-1',
             name: 'João',
             email: 'joao@x.com',
             cpf: null,
             patientProfile: { phone: '111' },
           },
-        },
+        ],
+        total: 1,
+      });
+      repository.findAppointmentsForPatients.mockResolvedValue([
         {
           dateTime: future,
           status: AppointmentStatus.CONFIRMED,
-          patient: {
-            id: 'pat-1',
-            name: 'João',
-            email: 'joao@x.com',
-            cpf: null,
-            patientProfile: { phone: '111' },
-          },
+          patientId: 'pat-1',
+        },
+        {
+          dateTime: past,
+          status: AppointmentStatus.COMPLETED,
+          patientId: 'pat-1',
         },
       ]);
 
-      const result = await service.getPatients('u-1');
+      const result = await service.getPatients('u-1', pageQuery);
 
-      expect(result).toHaveLength(1);
-      expect(result[0].lastVisit).toBe(past.toISOString());
-      expect(result[0].nextVisit).toBe(future.toISOString());
-      expect(result[0].phone).toBe('111');
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].lastVisit).toBe(past.toISOString());
+      expect(result.data[0].nextVisit).toBe(future.toISOString());
+      expect(result.data[0].phone).toBe('111');
+      expect(result.meta).toEqual({
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+      });
+      expect(repository.findAppointmentsForPatients).toHaveBeenCalledWith('u-1', [
+        'pat-1',
+      ]);
     });
 
     it('falls back to "Não informado" when phone is missing', async () => {
-      repository.findAppointmentsWithPatients.mockResolvedValue([
-        {
-          dateTime: new Date(Date.now() - 1000),
-          status: AppointmentStatus.COMPLETED,
-          patient: {
+      repository.findAttendedPatientsPage.mockResolvedValue({
+        patients: [
+          {
             id: 'pat-2',
             name: 'Maria',
             email: 'maria@x.com',
             cpf: null,
             patientProfile: null,
           },
+        ],
+        total: 1,
+      });
+      repository.findAppointmentsForPatients.mockResolvedValue([
+        {
+          dateTime: new Date(Date.now() - 1000),
+          status: AppointmentStatus.COMPLETED,
+          patientId: 'pat-2',
         },
       ]);
 
-      const result = await service.getPatients('u-1');
+      const result = await service.getPatients('u-1', pageQuery);
 
-      expect(result[0].phone).toBe('Não informado');
+      expect(result.data[0].phone).toBe('Não informado');
+    });
+
+    it('returns an empty page without querying appointments', async () => {
+      repository.findAttendedPatientsPage.mockResolvedValue({
+        patients: [],
+        total: 0,
+      });
+
+      const result = await service.getPatients('u-1', pageQuery);
+
+      expect(result.data).toEqual([]);
+      expect(result.meta.total).toBe(0);
+      expect(repository.findAppointmentsForPatients).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/professional/professional.service.ts
+++ b/apps/server/src/professional/professional.service.ts
@@ -12,6 +12,8 @@ import { MailService } from '../mail/mail.service';
 import { MEET_SERVICE } from '../common/interfaces/MeetEventInterfaces';
 import type { MeetService } from '../common/interfaces/MeetEventInterfaces';
 import { APPOINTMENT_DURATION_MINUTES } from '../appointments/appointment.constants';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { buildMeta } from '../common/dto/paginated-response.dto';
 
 @Injectable()
 export class ProfessionalService {
@@ -93,31 +95,30 @@ export class ProfessionalService {
     };
   }
 
-  async getPatients(userId: string) {
-    const appointments =
-      await this.repository.findAppointmentsWithPatients(userId);
+  async getPatients(userId: string, query: PaginationQueryDto) {
+    const { page, limit } = query;
+
+    const { patients, total } =
+      await this.repository.findAttendedPatientsPage(userId, page, limit);
+
+    if (patients.length === 0) {
+      return { data: [], meta: buildMeta(total, page, limit) };
+    }
+
+    const patientIds = patients.map((p) => p.id);
+    const appointments = await this.repository.findAppointmentsForPatients(
+      userId,
+      patientIds,
+    );
 
     const now = new Date();
-    const uniquePatients = new Map<
+    const visits = new Map<
       string,
-      {
-        id: string;
-        name: string;
-        email: string;
-        cpf: string | null;
-        phone: string;
-        lastVisit: string | null;
-        nextVisit: string | null;
-      }
+      { lastVisit: string | null; nextVisit: string | null }
     >();
 
     for (const appt of appointments) {
-      const existing = uniquePatients.get(appt.patient.id) ?? {
-        id: appt.patient.id,
-        name: appt.patient.name,
-        email: appt.patient.email,
-        cpf: appt.patient.cpf ?? null,
-        phone: appt.patient.patientProfile?.phone || 'Não informado',
+      const existing = visits.get(appt.patientId) ?? {
         lastVisit: null as string | null,
         nextVisit: null as string | null,
       };
@@ -143,23 +144,48 @@ export class ProfessionalService {
         }
       }
 
-      uniquePatients.set(appt.patient.id, existing);
+      visits.set(appt.patientId, existing);
     }
 
-    return Array.from(uniquePatients.values());
+    const data = patients.map((patient) => {
+      const patientVisits = visits.get(patient.id) ?? {
+        lastVisit: null,
+        nextVisit: null,
+      };
+
+      return {
+        id: patient.id,
+        name: patient.name,
+        email: patient.email,
+        cpf: patient.cpf ?? null,
+        phone: patient.patientProfile?.phone || 'Não informado',
+        lastVisit: patientVisits.lastVisit,
+        nextVisit: patientVisits.nextVisit,
+      };
+    });
+
+    return { data, meta: buildMeta(total, page, limit) };
   }
 
-  async getPatientDetail(professionalId: string, patientId: string) {
+  async getPatientDetail(
+    professionalId: string,
+    patientId: string,
+    query: PaginationQueryDto,
+  ) {
     const patient = await this.repository.findPatientSummary(patientId);
 
     if (!patient) {
       throw new NotFoundException('Paciente não encontrado');
     }
 
-    const appointments = await this.repository.findPatientAppointments(
-      professionalId,
-      patientId,
-    );
+    const { page, limit } = query;
+    const { appointments, total } =
+      await this.repository.findPatientAppointments(
+        professionalId,
+        patientId,
+        page,
+        limit,
+      );
 
     return {
       id: patient.id,
@@ -167,18 +193,26 @@ export class ProfessionalService {
       email: patient.email,
       cpf: patient.cpf ?? null,
       phone: patient.patientProfile?.phone || 'Não informado',
-      history: appointments.map((apt) => ({
-        id: apt.id,
-        dateTime: apt.dateTime,
-        status: apt.status,
-        modality: apt.modality,
-        notes: apt.notes,
-      })),
+      history: {
+        data: appointments.map((apt) => ({
+          id: apt.id,
+          dateTime: apt.dateTime,
+          status: apt.status,
+          modality: apt.modality,
+          notes: apt.notes,
+        })),
+        meta: buildMeta(total, page, limit),
+      },
     };
   }
 
-  async listAll() {
-    return this.repository.listAllProfessionals();
+  async listAll(query: PaginationQueryDto) {
+    const { page, limit } = query;
+    const { data, total } = await this.repository.listAllProfessionals(
+      page,
+      limit,
+    );
+    return { data, meta: buildMeta(total, page, limit) };
   }
 
   async updateSettings(userId: string, dto: UpdateProfessionalSettingsDto) {

--- a/apps/server/src/users/users.repository.ts
+++ b/apps/server/src/users/users.repository.ts
@@ -3,6 +3,7 @@ import { Prisma, UserRole } from '@prisma/client';
 import { ListAdminUsersQueryDto } from 'src/admin/dto/list-admin-users-query-dto';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { paginate } from '../common/dto/paginated-response.dto';
 
 @Injectable()
 export class UsersRepository {
@@ -137,23 +138,31 @@ export class UsersRepository {
   }
 
   findAllUsers(query: ListAdminUsersQueryDto) {
-    return this.prisma.user.findMany({
-      where: {
-        role: query.role ?? { in: ['PATIENT', 'PROFESSIONAL', 'MANAGER'] },
-        ...(query.status && { status: query.status }),
-        ...(query.search && {
-          OR: [
-            { name: { contains: query.search, mode: 'insensitive' } },
-            { email: { contains: query.search, mode: 'insensitive' } },
-          ],
-        }),
+    const where: Prisma.UserWhereInput = {
+      role: query.role ?? { in: ['PATIENT', 'PROFESSIONAL', 'MANAGER'] },
+      ...(query.status && { status: query.status }),
+      ...(query.search && {
+        OR: [
+          { name: { contains: query.search, mode: 'insensitive' } },
+          { email: { contains: query.search, mode: 'insensitive' } },
+        ],
+      }),
+    };
+
+    return paginate(
+      this.prisma.user,
+      {
+        where,
+        omit: { password: true },
+        include: {
+          patientProfile: true,
+          professionalProfile: { include: { specialities: true } },
+        },
+        orderBy: { [query.sortBy ?? 'name']: query.sortOrder ?? 'asc' },
       },
-      include: {
-        patientProfile: true,
-        professionalProfile: { include: { specialities: true } },
-      },
-      orderBy: { [query.sortBy ?? 'name']: query.sortOrder ?? 'asc' },
-    });
+      query.page,
+      query.limit,
+    );
   }
 
   findAllProfessionals() {


### PR DESCRIPTION
## Resumo
- Contrato unificado `{ data, meta: { page, limit, total, totalPages } }` em todos os endpoints de listagem
- DTOs/helpers compartilhados em `src/common/dto/` (`PaginationQueryDto`, `paginate()`, `buildMeta()`)
- Migrados: `/admin/users`, `/manager/appointments` (+ fix do sort por vulnerabilidade via `orderBy` do Prisma), `/manager/patients`, `/medical-records` (list/shared/by-patient), `/professional` (listAll), `/professional/patients`, `/appointments/my-appointments` e `/professional-appointments` (com suporte a múltiplos valores de `status`)
- Endpoints mantidos sem paginação (bounded): specialities, cidades, questionário, disponibilidade, exports de relatório

Closes #218

## Test plan
- [x] `npx tsc --noEmit` limpo
- [x] `npm run build` limpo
- [x] 150/150 testes passando (`npx jest`)