### PR TITLE
feat(web): componente reutilizável de paginação e telas afetadas

### DIFF
--- a/apps/web/app/dashboard/admin/components/UsersTable.tsx
+++ b/apps/web/app/dashboard/admin/components/UsersTable.tsx
@@ -15,12 +15,15 @@ import {
   DataTableHeader,
   DataTableMobileItem,
   DataTableMobileList,
+  DataTablePageSizeSelector,
+  DataTablePagination,
   DataTableRow,
   DataTableToolbar,
   SortableHeader,
 } from "@/components/ui/data-table";
 import { AdminUser } from "../../../../services/admin-service";
 import { useAdminUsersTable, TypeFilter } from "@/queries/useAdminUsersTable";
+import { usePagination } from "@/hooks/usePagination";
 import { useIsMobile, useMounted } from "@/hooks/useIsMobile";
 import { TableSkeleton } from "@/components/ui/skeletons";
 import { Eye, Check, Ban, Pencil, Users } from "lucide-react";
@@ -149,6 +152,11 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
     });
   }, [users, sortField, sortDir]);
 
+  const pagination = usePagination(sortedUsers, {
+    initialPageSize: 10,
+    resetKeys: [search, typeFilter, sortField, sortDir],
+  });
+
   const stopClick = (e: React.MouseEvent) => e.stopPropagation();
 
   return (
@@ -186,6 +194,13 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
             className="h-9 text-sm"
           />
         </div>
+        {sortedUsers.length > 0 && (
+          <DataTablePageSizeSelector
+            pageSize={pagination.pageSize}
+            onPageSizeChange={pagination.setPageSize}
+            className="ml-auto"
+          />
+        )}
       </DataTableToolbar>
       </div>
 
@@ -203,7 +218,7 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
         />
       ) : isMobile ? (
         <DataTableMobileList>
-          {sortedUsers.map((user) => {
+          {pagination.pageItems.map((user) => {
             const badge = TYPE_BADGE[user.role];
             const speciality = getSpeciality(user);
             return (
@@ -404,8 +419,7 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
             <DataTableHeadCell align="center">Ações</DataTableHeadCell>
           </DataTableHead>
           <DataTableBody>
-            {sortedUsers.map((user) => {
-              const badge = TYPE_BADGE[user.role];
+            {pagination.pageItems.map((user) => {
               const speciality = getSpeciality(user);
               return (
                 <DataTableRow
@@ -531,6 +545,20 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
             })}
           </DataTableBody>
         </DataTable>
+      )}
+
+      {mounted && !isLoading && sortedUsers.length > 0 && (
+        <DataTablePagination
+          page={pagination.page}
+          totalPages={pagination.totalPages}
+          from={pagination.from}
+          to={pagination.to}
+          totalItems={pagination.totalItems}
+          hasPrev={pagination.hasPrev}
+          hasNext={pagination.hasNext}
+          onPageChange={pagination.setPage}
+          itemLabel="usuários"
+        />
       )}
       </div>
     </DataTableCard>

--- a/apps/web/app/dashboard/manager/appointments/new/page.tsx
+++ b/apps/web/app/dashboard/manager/appointments/new/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Spinner } from "@/components/ui/spinner";
-import { managerService } from "../../../../../services/manager-service";
-import { toast } from "sonner";
+import {
+  DataTablePageSizeSelector,
+  DataTablePagination,
+} from "@/components/ui/data-table";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { usePagination } from "@/hooks/usePagination";
 import { PageShell, PageHeader } from "../../../../ui/dashboard/page-shell";
 import { TourButton } from "@/components/tour/TourButton";
 import { SearchBar } from "../../../patient/search/components/SearchBar";
@@ -13,6 +16,7 @@ import { EmptySearch } from "../../../patient/search/components/EmptySearch";
 import { ProfessionalData, SeeProfileModal } from "../../../patient/search/components/SeeProfileModal";
 import { ManagerBookingModal } from "./components/ManagerBookingModal";
 import { useListPatientsQuery } from "@/queries/useListPatientsQuery";
+import { useProfessionalsQuery } from "@/queries/useProfessionalsQuery";
 import { AddressData } from "../../../patient/search/components/addressMaps";
 import {
   getAvailableLocations,
@@ -39,7 +43,7 @@ type Professional = {
 const NewApointmentPage = () => {
   const isMobile = useIsMobile();
   const { data: patients = [] } = useListPatientsQuery();
-  const [professionals, setProfessionals] = useState<Professional[]>([]);
+  const { data: professionals = [], isLoading } = useProfessionalsQuery();
   const [search, setSearch] = useState("");
   const [selectedSpecialty, setSelectedSpecialty] = useState("Todas");
   const [selectedLocation, setSelectedLocation] = useState("Todas");
@@ -47,22 +51,6 @@ const NewApointmentPage = () => {
     useState<Professional | null>(null);
   const [bookingProfessional, setBookingProfessional] =
     useState<Professional | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    const load = async () => {
-      try {
-        setIsLoading(true);
-        const data = await managerService.listProfessionals();
-        setProfessionals(data);
-      } catch {
-        toast.error("Erro ao carregar profissionais.");
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    load();
-  }, []);
 
   const visibleProfessionals = professionals.filter(
     (p) => p.status !== "PENDING" && p.status !== "BLOCKED",
@@ -72,30 +60,36 @@ const NewApointmentPage = () => {
     [professionals],
   );
 
-  const filtered = visibleProfessionals
-    .filter((p) => {
-      const term = search.toLowerCase();
-      const matchesSearch =
-        p.name.toLowerCase().includes(term) ||
-        (p.professionalProfile?.specialities?.[0]?.name || "").toLowerCase().includes(term);
+  const filtered = visibleProfessionals.filter((p) => {
+    const term = search.toLowerCase();
+    const matchesSearch =
+      p.name.toLowerCase().includes(term) ||
+      (p.professionalProfile?.specialities?.[0]?.name || "")
+        .toLowerCase()
+        .includes(term);
 
-      const matchesSpecialty =
-        selectedSpecialty === "Todas" ||
-        (p.professionalProfile?.specialities?.[0]?.name || "")
-          .toLowerCase()
-          .includes(selectedSpecialty.toLowerCase());
+    const matchesSpecialty =
+      selectedSpecialty === "Todas" ||
+      (p.professionalProfile?.specialities?.[0]?.name || "")
+        .toLowerCase()
+        .includes(selectedSpecialty.toLowerCase());
 
-      const matchesLocation =
-        selectedLocation === "Todas" ||
-        (p.address?.city && p.address?.state
-          ? getLocationValue({
-              city: p.address.city.trim(),
-              state: p.address.state.trim(),
-            }) === selectedLocation
-          : false);
+    const matchesLocation =
+      selectedLocation === "Todas" ||
+      (p.address?.city && p.address?.state
+        ? getLocationValue({
+            city: p.address.city.trim(),
+            state: p.address.state.trim(),
+          }) === selectedLocation
+        : false);
 
-      return matchesSearch && matchesSpecialty && matchesLocation;
-    });
+    return matchesSearch && matchesSpecialty && matchesLocation;
+  });
+
+  const pagination = usePagination(filtered, {
+    initialPageSize: 10,
+    resetKeys: [search, selectedSpecialty, selectedLocation],
+  });
 
   return (
     <PageShell>
@@ -126,18 +120,39 @@ const NewApointmentPage = () => {
       ) : filtered.length === 0 ? (
         <EmptySearch />
       ) : (
-        <div
-          className={`grid gap-4 ${isMobile ? "grid-cols-1" : "grid-cols-1 lg:grid-cols-2"}`}
-        >
-          {filtered.map((prof) => (
-            <DoctorCard
-              key={prof.id}
-              professional={prof}
-              onViewProfile={() => setSelectedProfessional(prof)}
-              onBook={() => setBookingProfessional(prof)}
+        <>
+          <div className="mb-4 flex justify-end">
+            <DataTablePageSizeSelector
+              pageSize={pagination.pageSize}
+              onPageSizeChange={pagination.setPageSize}
             />
-          ))}
-        </div>
+          </div>
+          <div
+            className={`grid gap-4 ${isMobile ? "grid-cols-1" : "grid-cols-1 lg:grid-cols-2"}`}
+          >
+            {pagination.pageItems.map((prof) => (
+              <DoctorCard
+                key={prof.id}
+                professional={prof}
+                onViewProfile={() => setSelectedProfessional(prof)}
+                onBook={() => setBookingProfessional(prof)}
+              />
+            ))}
+          </div>
+          <div className="mt-4 overflow-hidden rounded-xl border border-border bg-card">
+            <DataTablePagination
+              page={pagination.page}
+              totalPages={pagination.totalPages}
+              from={pagination.from}
+              to={pagination.to}
+              totalItems={pagination.totalItems}
+              hasPrev={pagination.hasPrev}
+              hasNext={pagination.hasNext}
+              onPageChange={pagination.setPage}
+              itemLabel="profissionais"
+            />
+          </div>
+        </>
       )}
       </div>
 

--- a/apps/web/app/dashboard/manager/patients/page.tsx
+++ b/apps/web/app/dashboard/manager/patients/page.tsx
@@ -25,6 +25,7 @@ import {
   DataTableHeadCell,
   DataTableMobileItem,
   DataTableMobileList,
+  DataTablePageSizeSelector,
   DataTablePagination,
   DataTableRow,
   SortableHeader,
@@ -242,6 +243,12 @@ export default function PatientsPage() {
             </span>
           </p>
         )}
+        <div className="mt-3 flex justify-end">
+          <DataTablePageSizeSelector
+            pageSize={pagination.pageSize}
+            onPageSizeChange={pagination.setPageSize}
+          />
+        </div>
       </div>
 
       <div id="tour-mgr-patients-table">
@@ -331,8 +338,6 @@ export default function PatientsPage() {
               hasPrev={pagination.hasPrev}
               hasNext={pagination.hasNext}
               onPageChange={pagination.setPage}
-              pageSize={pagination.pageSize}
-              onPageSizeChange={pagination.setPageSize}
               itemLabel="pacientes"
             />
           </DataTableCard>
@@ -463,8 +468,6 @@ export default function PatientsPage() {
               hasPrev={pagination.hasPrev}
               hasNext={pagination.hasNext}
               onPageChange={pagination.setPage}
-              pageSize={pagination.pageSize}
-              onPageSizeChange={pagination.setPageSize}
               itemLabel="pacientes"
             />
           </DataTableCard>

--- a/apps/web/app/dashboard/patient/appointments/components/AppointmentTabs.tsx
+++ b/apps/web/app/dashboard/patient/appointments/components/AppointmentTabs.tsx
@@ -1,27 +1,15 @@
-import { TABS, TabKey, Appointment } from "../appointments.types";
+import { TABS, TabKey } from "../appointments.types";
 
 type AppointmentTabsProps = {
   activeTab: TabKey;
-  appointments: Appointment[];
+  /** Total de consultas por aba (vindo do `meta.total` do servidor). */
+  counts: Record<TabKey, number>;
   onTabChange: (tab: TabKey) => void;
-};
-
-const getTabCount = (appointments: Appointment[], tab: TabKey) => {
-  switch (tab) {
-    case "upcoming":
-      return appointments.filter(
-        (a) => a.status === "CONFIRMED" || a.status === "PENDING",
-      ).length;
-    case "past":
-      return appointments.filter((a) => a.status === "COMPLETED").length;
-    case "cancelled":
-      return appointments.filter((a) => a.status === "CANCELLED").length;
-  }
 };
 
 export function AppointmentTabs({
   activeTab,
-  appointments,
+  counts,
   onTabChange,
 }: AppointmentTabsProps) {
   return (
@@ -45,7 +33,7 @@ export function AppointmentTabs({
                 : "ml-1.5 px-2 py-0.5 rounded-full bg-gray-100 text-xs font-semibold"
             }
           >
-            {getTabCount(appointments, tab.key)}
+            {counts[tab.key]}
           </span>
         </button>
       ))}

--- a/apps/web/app/dashboard/patient/appointments/page.tsx
+++ b/apps/web/app/dashboard/patient/appointments/page.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  DataTablePageSizeSelector,
+  DataTablePagination,
+} from "@/components/ui/data-table";
 import { CardGridSkeleton } from "@/components/ui/skeletons";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useServerPagination } from "@/hooks/useServerPagination";
 import { SearchIcon } from "../../../utils/icons";
 import { Appointment, TabKey } from "./appointments.types";
 import { AppointmentTabs } from "./components/AppointmentTabs";
@@ -14,10 +19,12 @@ import { EmptyAppointments } from "./components/EmptyAppointments";
 import { AppointmentDetailsModal } from "./components/AppointmentDetailsModal";
 import { patientsService } from "@/services/patients-service";
 import { CancelConfirmDialog } from "./components/CancelConfirmDialog";
+import { AppointmentResponse } from "@/services/appointments-service";
 import {
-  appointmentsService,
-  AppointmentResponse,
-} from "@/services/appointments-service";
+  useMyAppointmentsQuery,
+  useMyAppointmentsCounts,
+} from "@/queries/useMyAppointmentsQuery";
+import { useCancelAppointmentMutation } from "@/queries/useCancelAppointmentMutation";
 import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 import { TourButton } from "@/components/tour/TourButton";
 
@@ -37,57 +44,46 @@ function mapApiToAppointment(appt: AppointmentResponse): Appointment {
   };
 }
 
-const getFilteredAppointments = (appointments: Appointment[], tab: TabKey) => {
-  switch (tab) {
-    case "upcoming":
-      return appointments.filter(
-        (a) => a.status === "CONFIRMED" || a.status === "PENDING",
-      );
-    case "past":
-      return appointments.filter((a) => a.status === "COMPLETED");
-    case "cancelled":
-      return appointments.filter((a) => a.status === "CANCELLED");
-  }
+// Cada aba mapeia para os status que a compõem no servidor. "Próximas" combina
+// PENDING + CONFIRMED, por isso o backend aceita múltiplos status por vírgula.
+const TAB_STATUSES: Record<TabKey, string[]> = {
+  upcoming: ["PENDING", "CONFIRMED"],
+  past: ["COMPLETED"],
+  cancelled: ["CANCELLED"],
 };
 
 const AppointmentsPage = () => {
   const router = useRouter();
   const isMobile = useIsMobile();
   const [activeTab, setActiveTab] = useState<TabKey>("upcoming");
-  const [appointments, setAppointments] = useState<Appointment[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [isDownloadingReport, setIsDownloadingReport] = useState(false);
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
   const [appointmentToCancel, setAppointmentToCancel] = useState<string | null>(
     null,
   );
-  const [isCancelling, setIsCancelling] = useState(false);
   const [selectedAppointment, setSelectedAppointment] =
     useState<Appointment | null>(null);
   const [isDetailsModalOpen, setIsDetailsModalOpen] = useState(false);
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        setIsLoading(true);
-        const result = await appointmentsService.listMyAppointments({
-          limit: 100,
-        });
-        if (result) {
-          setAppointments(result.data.map(mapApiToAppointment));
-        }
-      } catch (error) {
-        const msg =
-          error instanceof Error
-            ? error.message
-            : "Erro ao carregar consultas.";
-        toast.error(msg);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    load();
-  }, []);
+  const { page, pageSize, resetToFirstPage, getPaginationProps } =
+    useServerPagination();
+
+  const { data, isLoading, isFetching } = useMyAppointmentsQuery({
+    status: TAB_STATUSES[activeTab],
+    page,
+    limit: pageSize,
+  });
+
+  const tabCounts = useMyAppointmentsCounts(TAB_STATUSES);
+
+  const cancelMutation = useCancelAppointmentMutation();
+  const isCancelling = cancelMutation.isPending;
+
+  function handleTabChange(tab: TabKey) {
+    setActiveTab(tab);
+    // A paginação é por aba (server-side), então voltamos à página 1 ao trocar.
+    resetToFirstPage();
+  }
 
   const handleCancelClick = (id: string) => {
     setAppointmentToCancel(id);
@@ -99,40 +95,32 @@ const AppointmentsPage = () => {
     setIsDetailsModalOpen(true);
   };
 
-  const confirmCancel = async (reason?: string) => {
+  const confirmCancel = (reason?: string) => {
     if (!appointmentToCancel) return;
 
-    try {
-      setIsCancelling(true);
-      await appointmentsService.cancel(appointmentToCancel, { reason });
-      setAppointments((prev) =>
-        prev.map((a) =>
-          a.id === appointmentToCancel
-            ? { ...a, status: "CANCELLED" as const }
-            : a,
-        ),
-      );
-      toast.success("Consulta cancelada com sucesso.");
-      setIsCancelModalOpen(false);
-    } catch (error) {
-      const msg =
-        error instanceof Error ? error.message : "Erro ao cancelar consulta.";
-      toast.error(msg);
-    } finally {
-      setIsCancelling(false);
-      setAppointmentToCancel(null);
-    }
+    cancelMutation.mutate(
+      { id: appointmentToCancel, data: { reason } },
+      {
+        onSuccess: () => {
+          toast.success("Consulta cancelada com sucesso.");
+          setIsCancelModalOpen(false);
+        },
+        onError: (error) => {
+          const msg =
+            error instanceof Error
+              ? error.message
+              : "Erro ao cancelar consulta.";
+          toast.error(msg);
+        },
+        onSettled: () => setAppointmentToCancel(null),
+      },
+    );
   };
 
-  const filtered = getFilteredAppointments(appointments, activeTab).sort(
-    (a, b) => {
-      const dateA = new Date(a.dateTime).getTime();
-      const dateB = new Date(b.dateTime).getTime();
-      return activeTab === "past" ? dateB - dateA : dateA - dateB;
-    },
-  );
+  const filtered = (data?.data ?? []).map(mapApiToAppointment);
+  const totalForTab = data?.meta.total ?? 0;
 
-  const hasReportData = filtered.length > 0;
+  const hasReportData = totalForTab > 0;
 
   const handleDownloadReport = async () => {
     try {
@@ -198,8 +186,8 @@ const AppointmentsPage = () => {
       <div id="tour-appt-tabs">
         <AppointmentTabs
           activeTab={activeTab}
-          appointments={appointments}
-          onTabChange={setActiveTab}
+          counts={tabCounts}
+          onTabChange={handleTabChange}
         />
       </div>
 
@@ -214,6 +202,12 @@ const AppointmentsPage = () => {
           >
             {isDownloadingReport ? "Gerando relatório..." : reportButtonLabel}
           </Button>
+        </div>
+      )}
+
+      {!isLoading && totalForTab > 0 && (
+        <div className="mb-4 flex justify-end">
+          <DataTablePageSizeSelector {...getPaginationProps(data?.meta)} />
         </div>
       )}
 
@@ -240,6 +234,16 @@ const AppointmentsPage = () => {
           </div>
         )}
       </div>
+
+      {!isLoading && totalForTab > 0 && (
+        <div className="mt-4 overflow-hidden rounded-xl border border-border bg-card">
+          <DataTablePagination
+            {...getPaginationProps(data?.meta)}
+            itemLabel="consultas"
+            busy={isFetching}
+          />
+        </div>
+      )}
 
       {isMobile && (
         <div className="mt-6">

--- a/apps/web/app/dashboard/patient/medical-records/page.tsx
+++ b/apps/web/app/dashboard/patient/medical-records/page.tsx
@@ -4,14 +4,12 @@ import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { CardGridSkeleton } from "@/components/ui/skeletons";
+import { Spinner } from "@/components/ui/spinner";
 import { Badge } from "@/components/ui/badge";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { useMedicalRecordsListForPatientQuery } from "@/queries/useMedicalRecords";
 import { CalendarIcon, EyeIcon } from "../../../utils/icons";
-import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 import { SearchInput } from "@/components/ui/search-input";
-import { TourButton } from "@/components/tour/TourButton";
-import { useIsMobile } from "@/hooks/useIsMobile";
 
 const PAGE_SIZE = 10;
 
@@ -50,7 +48,7 @@ const PatientMedicalRecordsPage = () => {
     useMedicalRecordsListForPatientQuery(params);
 
   const records = data?.data ?? [];
-  const total = data?.total ?? 0;
+  const total = data?.meta.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const handleSearch = (e: React.FormEvent) => {
@@ -62,17 +60,24 @@ const PatientMedicalRecordsPage = () => {
   const hasFilters = Boolean(search);
 
   return (
-    <PageShell>
-      <PageHeader
-        title="Meus Prontuários"
-        description={`Histórico dos prontuários das suas consultas.${total > 0 ? ` ${total} no total.` : ""}`}
-        help={<TourButton tour="patient-records" iconOnly={isMobile} />}
-      />
+    <section
+      className={`w-full min-h-screen mx-auto bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
+    >
+      <div className="mb-8">
+        <h1
+          className={`font-bold text-gray-900 tracking-tight ${isMobile ? "text-2xl" : "text-4xl"}`}
+        >
+          Meus Prontuários
+        </h1>
+        <p
+          className={`mt-1 text-gray-500 ${isMobile ? "text-sm" : "text-base"}`}
+        >
+          Histórico dos prontuários das suas consultas.
+          {total > 0 && ` ${total} no total.`}
+        </p>
+      </div>
 
-      <Card
-        id="tour-records-search"
-        className="mb-6 border border-gray-200 rounded-xl bg-white"
-      >
+      <Card className="mb-6 border border-gray-200 rounded-xl bg-white">
         <CardContent className="p-4 sm:p-5">
           <form
             onSubmit={handleSearch}
@@ -109,9 +114,10 @@ const PatientMedicalRecordsPage = () => {
         </CardContent>
       </Card>
 
-      <div id="tour-records-list">
       {isLoading ? (
-        <CardGridSkeleton count={4} minWidth={400} />
+        <div className="py-16 flex justify-center">
+          <Spinner size="lg" />
+        </div>
       ) : records.length === 0 ? (
         <Card className="border border-dashed border-gray-300 rounded-xl bg-white">
           <CardContent className="py-16 text-center flex flex-col items-center gap-3">
@@ -184,7 +190,6 @@ const PatientMedicalRecordsPage = () => {
           ))}
         </div>
       )}
-      </div>
 
       {totalPages > 1 && (
         <div className="mt-6 flex items-center justify-between gap-3">
@@ -211,7 +216,7 @@ const PatientMedicalRecordsPage = () => {
           </div>
         </div>
       )}
-    </PageShell>
+    </section>
   );
 };
 

--- a/apps/web/app/dashboard/professional/medical-records/page.tsx
+++ b/apps/web/app/dashboard/professional/medical-records/page.tsx
@@ -5,19 +5,22 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  DataTablePageSizeSelector,
+  DataTablePagination,
+} from "@/components/ui/data-table";
 import { CardGridSkeleton } from "@/components/ui/skeletons";
 import { Badge } from "@/components/ui/badge";
 import {
   useMedicalRecordsListQuery,
   useSharedMedicalRecordsQuery,
 } from "@/queries/useMedicalRecords";
+import { useServerPagination } from "@/hooks/useServerPagination";
 import { SearchInput } from "@/components/ui/search-input";
 import { CalendarIcon, EyeIcon, UsersIcon } from "../../../utils/icons";
 import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 import { TourButton } from "@/components/tour/TourButton";
 import type { MedicalRecordResponse } from "@/services/medical-records-service";
-
-const PAGE_SIZE = 10;
 
 type ViewMode = "mine" | "shared";
 
@@ -46,29 +49,27 @@ function MyRecordsView() {
   const [searchInput, setSearchInput] = useState(initialSearch);
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
-  const [page, setPage] = useState(1);
+  const { queryParams, resetToFirstPage, getPaginationProps } =
+    useServerPagination({ syncUrl: true, paramPrefix: "mine_" });
 
   const params = useMemo(
     () => ({
-      page,
-      limit: PAGE_SIZE,
+      ...queryParams,
       ...(search && { search }),
       ...(startDate && { startDate }),
       ...(endDate && { endDate }),
     }),
-    [page, search, startDate, endDate],
+    [queryParams, search, startDate, endDate],
   );
 
   const { data, isLoading, isFetching } = useMedicalRecordsListQuery(params);
 
   const records = data?.data ?? [];
-  const total = data?.total ?? 0;
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     setSearch(searchInput.trim());
-    setPage(1);
+    resetToFirstPage();
   };
 
   const handleClearFilters = () => {
@@ -76,7 +77,7 @@ function MyRecordsView() {
     setSearch("");
     setStartDate("");
     setEndDate("");
-    setPage(1);
+    resetToFirstPage();
   };
 
   const hasFilters = Boolean(search || startDate || endDate);
@@ -101,7 +102,7 @@ function MyRecordsView() {
               <Input
                 type="date"
                 value={startDate}
-                onChange={(e) => { setStartDate(e.target.value); setPage(1); }}
+                onChange={(e) => { setStartDate(e.target.value); resetToFirstPage(); }}
                 className="w-full sm:w-44"
               />
             </div>
@@ -110,7 +111,7 @@ function MyRecordsView() {
               <Input
                 type="date"
                 value={endDate}
-                onChange={(e) => { setEndDate(e.target.value); setPage(1); }}
+                onChange={(e) => { setEndDate(e.target.value); resetToFirstPage(); }}
                 className="w-full sm:w-44"
               />
             </div>
@@ -125,6 +126,12 @@ function MyRecordsView() {
           </form>
         </CardContent>
       </Card>
+
+      {!isLoading && records.length > 0 && (
+        <div className="mb-4 flex justify-end">
+          <DataTablePageSizeSelector {...getPaginationProps(data?.meta)} />
+        </div>
+      )}
 
       {isLoading ? (
         <CardGridSkeleton count={4} minWidth={400} />
@@ -142,15 +149,13 @@ function MyRecordsView() {
         </div>
       )}
 
-      {totalPages > 1 && (
-        <div className="mt-6 flex items-center justify-between gap-3">
-          <p className="text-xs text-slate-500">Página {page} de {totalPages}</p>
-          <div className="flex gap-2">
-            <Button variant="outline" size="sm" disabled={page <= 1 || isFetching}
-              onClick={() => setPage((p) => Math.max(1, p - 1))}>Anterior</Button>
-            <Button variant="outline" size="sm" disabled={page >= totalPages || isFetching}
-              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}>Próxima</Button>
-          </div>
+      {records.length > 0 && (
+        <div className="mt-4 overflow-hidden rounded-xl border border-border bg-card">
+          <DataTablePagination
+            {...getPaginationProps(data?.meta)}
+            itemLabel="prontuários"
+            busy={isFetching}
+          />
         </div>
       )}
     </>
@@ -161,22 +166,21 @@ function MyRecordsView() {
 function SharedRecordsView() {
   const router = useRouter();
   const [search, setSearch] = useState("");
-  const [page, setPage] = useState(1);
+  const { queryParams, resetToFirstPage, getPaginationProps } =
+    useServerPagination({ syncUrl: true, paramPrefix: "shared_" });
 
   const params = useMemo(
-    () => ({ page, limit: PAGE_SIZE, ...(search && { search }) }),
-    [page, search],
+    () => ({ ...queryParams, ...(search && { search }) }),
+    [queryParams, search],
   );
 
   const { data, isLoading, isFetching } = useSharedMedicalRecordsQuery(params);
 
   const records = (data?.data ?? []) as MedicalRecordResponse[];
-  const total = data?.total ?? 0;
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    setPage(1);
+    resetToFirstPage();
   };
 
   return (
@@ -186,13 +190,19 @@ function SharedRecordsView() {
           <form onSubmit={handleSearch} className="flex gap-3">
             <SearchInput
               value={search}
-              onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+              onChange={(e) => { setSearch(e.target.value); resetToFirstPage(); }}
               placeholder="Buscar por paciente, profissional, queixa ou diagnóstico…"
               className="flex-1"
             />
           </form>
         </CardContent>
       </Card>
+
+      {!isLoading && records.length > 0 && (
+        <div className="mb-4 flex justify-end">
+          <DataTablePageSizeSelector {...getPaginationProps(data?.meta)} />
+        </div>
+      )}
 
       {isLoading ? (
         <CardGridSkeleton count={4} minWidth={400} />
@@ -213,15 +223,13 @@ function SharedRecordsView() {
         </div>
       )}
 
-      {totalPages > 1 && (
-        <div className="mt-6 flex items-center justify-between gap-3">
-          <p className="text-xs text-slate-500">Página {page} de {totalPages}</p>
-          <div className="flex gap-2">
-            <Button variant="outline" size="sm" disabled={page <= 1 || isFetching}
-              onClick={() => setPage((p) => Math.max(1, p - 1))}>Anterior</Button>
-            <Button variant="outline" size="sm" disabled={page >= totalPages || isFetching}
-              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}>Próxima</Button>
-          </div>
+      {records.length > 0 && (
+        <div className="mt-4 overflow-hidden rounded-xl border border-border bg-card">
+          <DataTablePagination
+            {...getPaginationProps(data?.meta)}
+            itemLabel="prontuários"
+            busy={isFetching}
+          />
         </div>
       )}
     </>

--- a/apps/web/app/dashboard/professional/page.tsx
+++ b/apps/web/app/dashboard/professional/page.tsx
@@ -15,6 +15,8 @@ import {
   UsersIcon,
   XIcon,
   VideoIcon,
+  HouseIcon,
+  BuildingsIcon,
   UserCheckIcon,
   XCircleIcon,
 } from "../../utils/icons";
@@ -28,14 +30,70 @@ import {
 import { ConfirmModal } from "./schedule/components/ConfirmModal";
 import { PageShell, PageHeader } from "../../ui/dashboard/page-shell";
 import { TourButton } from "@/components/tour/TourButton";
-import { ModalityBadge } from "./components/ModalityBadge";
-import { STATUS_META } from "./components/appointment-meta";
-import type {
-  AppointmentResponse,
-  AppointmentStatus,
-} from "@/services/appointments-service";
 
-type Appointment = AppointmentResponse;
+type AppointmentStatus =
+  | "PENDING"
+  | "CONFIRMED"
+  | "CANCELLED"
+  | "COMPLETED"
+  | "NO_SHOW";
+
+type Modality = "VIRTUAL" | "HOME_VISIT" | "CLINIC";
+
+type Appointment = {
+  id: string;
+  dateTime: string;
+  status: AppointmentStatus;
+  modality?: Modality;
+  notes?: string;
+  meetLink?: string | null;
+  patient: { id: string; name: string; email?: string; phone?: string | null };
+};
+
+const STATUS_META: Record<
+  AppointmentStatus,
+  { label: string; className: string }
+> = {
+  PENDING: {
+    label: "Pendente",
+    className: "bg-amber-50 text-amber-700 border border-amber-200",
+  },
+  CONFIRMED: {
+    label: "Confirmado",
+    className: "bg-blue-50 text-blue-700 border border-blue-200",
+  },
+  COMPLETED: {
+    label: "Atendido",
+    className: "bg-emerald-50 text-emerald-700 border border-emerald-200",
+  },
+  NO_SHOW: {
+    label: "Faltou",
+    className: "bg-orange-50 text-orange-700 border border-orange-200",
+  },
+  CANCELLED: {
+    label: "Cancelado",
+    className: "bg-red-50 text-red-600 border border-red-200",
+  },
+};
+
+const MODALITY_META: Record<
+  Modality,
+  { label: string; icon: React.ReactNode }
+> = {
+  VIRTUAL: { label: "Online", icon: <VideoIcon size={14} /> },
+  HOME_VISIT: { label: "Domiciliar", icon: <HouseIcon size={14} /> },
+  CLINIC: { label: "Presencial", icon: <BuildingsIcon size={14} /> },
+};
+
+function ModalityBadge({ modality }: { modality?: Modality }) {
+  const meta = modality ? MODALITY_META[modality] : MODALITY_META.VIRTUAL;
+  return (
+    <Badge className="flex items-center gap-1 px-2 py-0.5 rounded text-xs font-semibold bg-slate-100 text-slate-600 border border-slate-200">
+      {meta.icon}
+      {meta.label}
+    </Badge>
+  );
+}
 
 const ProfessionalDashboard = () => {
   const router = useRouter();
@@ -93,7 +151,7 @@ const ProfessionalDashboard = () => {
     }, [scheduleData]);
 
   const pendingRequests = (pendingData?.data || []) as Appointment[];
-  const pendingTotal = pendingData?.total ?? 0;
+  const pendingTotal = pendingData?.meta.total ?? 0;
 
   const formatTime = (isoString: string) =>
     new Date(isoString).toLocaleTimeString("pt-BR", {
@@ -318,7 +376,7 @@ const ProfessionalDashboard = () => {
                         </div>
                         <div className="flex items-center gap-2 shrink-0">
                           <Badge
-                            className={`px-2 py-1 rounded-3xl text-xs font-semibold ${meta.badgeClassName}`}
+                            className={`px-2 py-1 rounded-3xl text-xs font-semibold ${meta.className}`}
                           >
                             {meta.label}
                           </Badge>
@@ -366,23 +424,14 @@ const ProfessionalDashboard = () => {
 
         {/* Solicitações */}
         <div id="tour-prof-requests" className="flex flex-col gap-4">
-          <div className="mb-2 flex justify-between items-center gap-2">
-            <h2 className="flex items-center gap-2 text-lg font-semibold text-gray-700 min-w-0">
-              <span className="truncate">Solicitações</span>
-              {pendingTotal > 0 && (
-                <Badge className="px-2 py-1 rounded-3xl text-xs font-semibold bg-yellow-100 text-yellow-700 shrink-0">
-                  {pendingTotal} Novas
-                </Badge>
-              )}
+          <div className="mb-2 flex justify-between items-center">
+            <h2 className="flex items-center gap-2 text-lg font-semibold text-gray-700">
+              Solicitações
             </h2>
-            {pendingTotal > pendingRequests.length && (
-              <Link
-                href="/dashboard/professional/requests"
-                title="Ver todas as solicitações pendentes"
-                className="text-xs font-medium text-[#006fee] hover:text-[#0058c2] shrink-0 whitespace-nowrap"
-              >
-                Ver todas
-              </Link>
+            {pendingTotal > 0 && (
+              <Badge className="px-2 py-1 rounded-3xl text-xs font-semibold bg-yellow-100 text-yellow-700">
+                {pendingTotal} Novas
+              </Badge>
             )}
           </div>
           <div className="flex flex-col gap-3">
@@ -440,6 +489,15 @@ const ProfessionalDashboard = () => {
               ))
             )}
           </div>
+          {pendingTotal > pendingRequests.length && (
+            <Link
+              href="/dashboard/professional/requests"
+              title="Ver todas as solicitações pendentes"
+              className="text-sm font-medium text-[#006fee] hover:underline self-end"
+            >
+              Ver todas
+            </Link>
+          )}
           <Card className="mt-4 border border-[#cce7ff] rounded-lg bg-[#f0f9ff]">
             <CardContent>
               <h4 className="text-lg font-semibold text-gray-700">

--- a/apps/web/app/dashboard/professional/requests/page.tsx
+++ b/apps/web/app/dashboard/professional/requests/page.tsx
@@ -3,6 +3,10 @@
 import React, { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  DataTablePageSizeSelector,
+  DataTablePagination,
+} from "@/components/ui/data-table";
 import { Spinner } from "@/components/ui/spinner";
 import { toast } from "sonner";
 import { format } from "date-fns";
@@ -11,6 +15,7 @@ import {
   useProfessionalAppointmentsQuery,
   useUpdateAppointmentStatusMutation,
 } from "@/queries/useProfessionalAppointments";
+import { useServerPagination } from "@/hooks/useServerPagination";
 import { ConfirmModal } from "../schedule/components/ConfirmModal";
 import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 import { ModalityBadge } from "../components/ModalityBadge";
@@ -21,21 +26,22 @@ import type {
 
 type PendingAppointment = AppointmentResponse & { status: "PENDING" };
 
-const PAGE_SIZE = 20;
-
 const PendingRequestsPage = () => {
-  const [page, setPage] = useState(1);
+  const { queryParams, getPaginationProps } = useServerPagination({
+    initialPageSize: 20,
+    syncUrl: true,
+  });
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState<{
     id: string;
     status: AppointmentStatus;
   } | null>(null);
 
-  const { data, isLoading, isError } = useProfessionalAppointmentsQuery({
-    status: "PENDING",
-    page,
-    limit: PAGE_SIZE,
-  });
+  const { data, isLoading, isError, isFetching } =
+    useProfessionalAppointmentsQuery({
+      status: "PENDING",
+      ...queryParams,
+    });
 
   const { mutate: updateStatus, isPending: isUpdating } =
     useUpdateAppointmentStatusMutation();
@@ -45,8 +51,6 @@ const PendingRequestsPage = () => {
   }, [isError]);
 
   const requests = (data?.data || []) as PendingAppointment[];
-  const total = data?.total ?? 0;
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const formatFullDateTime = (isoString: string) =>
     format(new Date(isoString), "dd/MM 'às' HH:mm");
@@ -75,6 +79,12 @@ const PendingRequestsPage = () => {
         title="Solicitações Pendentes"
         description="Todas as consultas aguardando sua confirmação, ordenadas por data."
       />
+
+      {!isLoading && requests.length > 0 && (
+        <div className="mb-4 flex justify-end">
+          <DataTablePageSizeSelector {...getPaginationProps(data?.meta)} />
+        </div>
+      )}
 
       {isLoading ? (
         <div className="flex justify-center py-16">
@@ -135,29 +145,13 @@ const PendingRequestsPage = () => {
         </div>
       )}
 
-      {totalPages > 1 && (
-        <div className="mt-6 flex items-center justify-between gap-3">
-          <p className="text-xs text-slate-500">
-            Página {page} de {totalPages}
-          </p>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page <= 1}
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-            >
-              Anterior
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page >= totalPages}
-              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-            >
-              Próxima
-            </Button>
-          </div>
+      {requests.length > 0 && (
+        <div className="mt-4 overflow-hidden rounded-xl border border-border bg-card">
+          <DataTablePagination
+            {...getPaginationProps(data?.meta)}
+            itemLabel="solicitações"
+            busy={isFetching}
+          />
         </div>
       )}
 

--- a/apps/web/components/appointments/ManagementAppointmentsView.tsx
+++ b/apps/web/components/appointments/ManagementAppointmentsView.tsx
@@ -29,6 +29,7 @@ import {
   DataTableHeadCell,
   DataTableMobileItem,
   DataTableMobileList,
+  DataTablePageSizeSelector,
   DataTablePagination,
   DataTableRow,
   SortableHeader,
@@ -155,8 +156,6 @@ export function ManagementAppointmentsView({
       hasPrev={pagination.hasPrev}
       hasNext={pagination.hasNext}
       onPageChange={pagination.setPage}
-      pageSize={pagination.pageSize}
-      onPageSizeChange={pagination.setPageSize}
       itemLabel="consultas"
     />
   );
@@ -327,6 +326,11 @@ export function ManagementAppointmentsView({
                   {scoreSortIcon}
                 </button>
               )}
+              <DataTablePageSizeSelector
+                pageSize={pagination.pageSize}
+                onPageSizeChange={pagination.setPageSize}
+                className="h-10 sm:ml-1"
+              />
             </div>
           </div>
 

--- a/apps/web/components/ui/data-table.tsx
+++ b/apps/web/components/ui/data-table.tsx
@@ -284,21 +284,13 @@ export function DataTableMobileItem({
 
 const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 
-export function DataTablePagination({
-  page,
-  totalPages,
-  from,
-  to,
-  totalItems,
-  hasPrev,
-  hasNext,
-  onPageChange,
-  pageSize,
-  onPageSizeChange,
-  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
-  itemLabel = "itens",
-  className,
-}: {
+/**
+ * Props compartilhadas entre o seletor "Por página" (topo) e o rodapé de
+ * paginação. Vêm do mesmo lugar — `getPaginationProps(meta)` do
+ * `useServerPagination` ou do `usePagination` — então cada peça pega o que
+ * precisa e ignora o resto (o spread `{...props}` funciona nos dois).
+ */
+type PaginationCoreProps = {
   page: number;
   totalPages: number;
   from: number;
@@ -312,12 +304,81 @@ export function DataTablePagination({
   pageSizeOptions?: number[];
   itemLabel?: string;
   className?: string;
-}) {
-  const showPageSize =
-    typeof pageSize === "number" && typeof onPageSizeChange === "function";
+};
 
-  // Nada para mostrar: sem múltiplas páginas e sem seletor de tamanho.
-  if (totalPages <= 1 && !showPageSize) return null;
+/**
+ * Seletor "Por página", pensado para ficar no TOPO da tela (perto do título /
+ * busca / filtros), separado do rodapé. Renderiza `null` quando não há como
+ * trocar o tamanho da página (sem `onPageSizeChange`). Aceita o mesmo objeto de
+ * props do rodapé — os campos extras são ignorados.
+ */
+export function DataTablePageSizeSelector({
+  pageSize,
+  onPageSizeChange,
+  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
+  className,
+}: Pick<
+  PaginationCoreProps,
+  "pageSize" | "onPageSizeChange" | "pageSizeOptions" | "className"
+>) {
+  if (typeof pageSize !== "number" || typeof onPageSizeChange !== "function") {
+    return null;
+  }
+
+  return (
+    <label
+      className={cn(
+        "flex items-center gap-2 text-xs text-muted-foreground",
+        className,
+      )}
+    >
+      <span className="whitespace-nowrap">Por página</span>
+      <select
+        value={pageSize}
+        onChange={(event) => onPageSizeChange(Number(event.target.value))}
+        aria-label="Itens por página"
+        className="h-9 rounded-lg border border-border bg-card px-2 text-xs font-medium text-foreground transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-sky-500"
+      >
+        {pageSizeOptions.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+/**
+ * Rodapé de paginação: contador "Mostrando X–Y de N" + botões Anterior/Próxima.
+ * O seletor "Por página" foi movido para `DataTablePageSizeSelector` (topo da
+ * tela) — este componente NÃO renderiza mais o seletor.
+ */
+export function DataTablePagination({
+  page,
+  totalPages,
+  from,
+  to,
+  totalItems,
+  hasPrev,
+  hasNext,
+  onPageChange,
+  itemLabel = "itens",
+  busy = false,
+  className,
+}: Omit<
+  PaginationCoreProps,
+  "pageSize" | "onPageSizeChange" | "pageSizeOptions"
+> & {
+  /**
+   * Fetch em andamento (paginação server-side). Desabilita prev/próxima para
+   * evitar cliques duplos disparando requests sobrepostos. Sem efeito na
+   * paginação client-side, onde a troca de página é síncrona.
+   */
+  busy?: boolean;
+}) {
+  // Sem múltiplas páginas não há nada para mostrar no rodapé.
+  if (totalPages <= 1) return null;
 
   return (
     <div
@@ -326,67 +387,45 @@ export function DataTablePagination({
         className,
       )}
     >
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
-        <p className="text-xs text-muted-foreground">
-          Mostrando{" "}
-          <span className="font-medium text-foreground">
-            {from}–{to}
-          </span>{" "}
-          de <span className="font-medium text-foreground">{totalItems}</span>{" "}
-          {itemLabel}
-        </p>
+      <p className="text-xs text-muted-foreground">
+        Mostrando{" "}
+        <span className="font-medium text-foreground">
+          {from}–{to}
+        </span>{" "}
+        de <span className="font-medium text-foreground">{totalItems}</span>{" "}
+        {itemLabel}
+      </p>
 
-        {showPageSize && (
-          <label className="flex items-center gap-2 text-xs text-muted-foreground">
-            <span>Por página</span>
-            <select
-              value={pageSize}
-              onChange={(event) => onPageSizeChange(Number(event.target.value))}
-              aria-label="Itens por página"
-              className="h-8 rounded-lg border border-border bg-card px-2 text-xs font-medium text-foreground transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-sky-500"
-            >
-              {pageSizeOptions.map((option) => (
-                <option key={option} value={option}>
-                  {option}
-                </option>
-              ))}
-            </select>
-          </label>
-        )}
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={() => onPageChange(page - 1)}
+          disabled={!hasPrev || busy}
+          title="Página anterior"
+          aria-label="Página anterior"
+          className="inline-flex h-8 items-center gap-1 rounded-lg border border-border bg-card px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          <span className="hidden sm:inline">Anterior</span>
+        </button>
+
+        <span className="px-3 text-xs text-muted-foreground">
+          Página <span className="font-medium text-foreground">{page}</span> de{" "}
+          <span className="font-medium text-foreground">{totalPages}</span>
+        </span>
+
+        <button
+          type="button"
+          onClick={() => onPageChange(page + 1)}
+          disabled={!hasNext || busy}
+          title="Próxima página"
+          aria-label="Próxima página"
+          className="inline-flex h-8 items-center gap-1 rounded-lg border border-border bg-card px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <span className="hidden sm:inline">Próxima</span>
+          <ChevronRight className="h-4 w-4" />
+        </button>
       </div>
-
-      {totalPages > 1 && (
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => onPageChange(page - 1)}
-            disabled={!hasPrev}
-            title="Página anterior"
-            aria-label="Página anterior"
-            className="inline-flex h-8 items-center gap-1 rounded-lg border border-border bg-card px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            <ChevronLeft className="h-4 w-4" />
-            <span className="hidden sm:inline">Anterior</span>
-          </button>
-
-          <span className="px-3 text-xs text-muted-foreground">
-            Página <span className="font-medium text-foreground">{page}</span> de{" "}
-            <span className="font-medium text-foreground">{totalPages}</span>
-          </span>
-
-          <button
-            type="button"
-            onClick={() => onPageChange(page + 1)}
-            disabled={!hasNext}
-            title="Próxima página"
-            aria-label="Próxima página"
-            className="inline-flex h-8 items-center gap-1 rounded-lg border border-border bg-card px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            <span className="hidden sm:inline">Próxima</span>
-            <ChevronRight className="h-4 w-4" />
-          </button>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/hooks/useServerPagination.ts
+++ b/apps/web/hooks/useServerPagination.ts
@@ -1,0 +1,125 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import {
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  type PaginationMeta,
+} from "@/lib/pagination";
+
+type UseServerPaginationOptions = {
+  initialPageSize?: number;
+  /**
+   * Sincroniza `page`/`limit` na URL (?page=&limit=). Use em telas de listagem
+   * cheias, para que a página sobreviva a refresh/voltar. Deixe `false` em
+   * abas/toggles internos que já disputam a query string.
+   */
+  syncUrl?: boolean;
+  /** Prefixo dos params na URL, para telas com mais de uma lista paginada. */
+  paramPrefix?: string;
+};
+
+/**
+ * Estado de paginação server-side: controla `page`/`limit` e, junto com o
+ * `meta` devolvido pela API, entrega exatamente as props que
+ * `DataTablePagination` espera (from/to/hasPrev/hasNext). Não faz fetch — o
+ * `page`/`limit` alimentam a query (TanStack) e o `meta` da resposta volta pra
+ * `getPaginationProps`.
+ */
+export function useServerPagination({
+  initialPageSize = DEFAULT_PAGE_SIZE,
+  syncUrl = false,
+  paramPrefix = "",
+}: UseServerPaginationOptions = {}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const pageKey = `${paramPrefix}page`;
+  const limitKey = `${paramPrefix}limit`;
+
+  const urlPage = Number(searchParams.get(pageKey));
+  const urlLimit = Number(searchParams.get(limitKey));
+
+  const [localPage, setLocalPage] = useState(1);
+  const [localPageSize, setLocalPageSize] = useState(initialPageSize);
+
+  const page = syncUrl && urlPage >= 1 ? urlPage : localPage;
+  const rawLimit = syncUrl && urlLimit >= 1 ? urlLimit : localPageSize;
+  const pageSize = Math.min(rawLimit, MAX_PAGE_SIZE);
+
+  function writeUrl(next: { page?: number; limit?: number }) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next.page !== undefined) params.set(pageKey, String(next.page));
+    if (next.limit !== undefined) params.set(limitKey, String(next.limit));
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  }
+
+  function setPage(nextPage: number) {
+    if (syncUrl) {
+      writeUrl({ page: nextPage });
+    } else {
+      setLocalPage(nextPage);
+    }
+  }
+
+  function setPageSize(nextSize: number) {
+    // Trocar o tamanho da página sempre volta para a primeira página, senão o
+    // usuário pode cair numa página inexistente.
+    if (syncUrl) {
+      writeUrl({ page: 1, limit: nextSize });
+    } else {
+      setLocalPageSize(nextSize);
+      setLocalPage(1);
+    }
+  }
+
+  /**
+   * Reinicia para a página 1. Chame quando um filtro/busca muda (o número de
+   * páginas encolhe e a página atual pode deixar de existir).
+   */
+  function resetToFirstPage() {
+    setPage(1);
+  }
+
+  /**
+   * Traduz o `meta` da API nas props do componente `DataTablePagination`.
+   * Passe direto: `<DataTablePagination {...getPaginationProps(data?.meta)} />`.
+   */
+  function getPaginationProps(meta: PaginationMeta | undefined) {
+    const total = meta?.total ?? 0;
+    const totalPages = meta?.totalPages ?? 1;
+    const from = total === 0 ? 0 : (page - 1) * pageSize + 1;
+    const to = Math.min(page * pageSize, total);
+
+    return {
+      page,
+      totalPages,
+      from,
+      to,
+      totalItems: total,
+      hasPrev: page > 1,
+      hasNext: page < totalPages,
+      onPageChange: setPage,
+      pageSize,
+      onPageSizeChange: setPageSize,
+    };
+  }
+
+  const queryParams = useMemo(
+    () => ({ page, limit: pageSize }),
+    [page, pageSize],
+  );
+
+  return {
+    page,
+    pageSize,
+    setPage,
+    setPageSize,
+    resetToFirstPage,
+    /** `{ page, limit }` pronto para espalhar nos params da query. */
+    queryParams,
+    getPaginationProps,
+  };
+}

--- a/apps/web/lib/pagination.ts
+++ b/apps/web/lib/pagination.ts
@@ -1,0 +1,43 @@
+/**
+ * Contrato padrão de paginação server-side.
+ *
+ * Todo endpoint paginado da API responde com este envelope:
+ *
+ *   { data: T[], meta: { page, limit, total, totalPages } }
+ *
+ * `totalPages` é sempre >= 1 (mesmo com `total = 0`), então nunca precisamos
+ * recalcular `Math.ceil(total / limit)` no front — basta ler de `meta`.
+ */
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface Paginated<T> {
+  data: T[];
+  meta: PaginationMeta;
+}
+
+export interface PaginationParams {
+  page?: number;
+  limit?: number;
+}
+
+/** Opções de tamanho de página padrão em toda a aplicação (máx. 100 na API). */
+export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
+
+export const DEFAULT_PAGE_SIZE = 10;
+
+/**
+ * Limite máximo aceito pela API (ver list-*-query.dto.ts no server). Usado por
+ * telas que ainda filtram/ordenam a lista inteira no cliente e precisam puxar o
+ * máximo de registros de uma vez, sem paginação real.
+ */
+export const MAX_PAGE_SIZE = 100;
+
+/** Envelope vazio, útil como fallback enquanto a query carrega. */
+export function emptyPage<T>(limit: number = DEFAULT_PAGE_SIZE): Paginated<T> {
+  return { data: [], meta: { page: 1, limit, total: 0, totalPages: 1 } };
+}

--- a/apps/web/queries/useCancelAppointmentMutation.ts
+++ b/apps/web/queries/useCancelAppointmentMutation.ts
@@ -1,8 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   appointmentsService,
-  AppointmentListResponse,
-  AppointmentResponse,
   CancelAppointmentDto,
 } from "../services/appointments-service";
 
@@ -16,16 +14,11 @@ export function useCancelAppointmentMutation() {
     onSuccess: (updated) => {
       if (!updated) return;
 
-      queryClient.setQueryData<AppointmentListResponse>(["my-appointments"], (old) => {
-        if (!old) return old;
-        return {
-          ...old,
-          data: old.data.map((a: AppointmentResponse) =>
-            a.id === updated.id ? updated : a,
-          ),
-        };
-      });
-
+      // A lista "Minhas consultas" agora é paginada e filtrada por aba/status
+      // (cache com chave variável), então invalidamos o prefixo em vez de
+      // remendar uma entrada específica. Cancelar move o item entre abas, o que
+      // muda os totais — reconsultar é o caminho correto.
+      void queryClient.invalidateQueries({ queryKey: ["my-appointments"] });
       void queryClient.invalidateQueries({ queryKey: ["appointments"] });
     },
   });

--- a/apps/web/queries/useMedicalRecords.ts
+++ b/apps/web/queries/useMedicalRecords.ts
@@ -11,6 +11,7 @@ export function useSharedMedicalRecordsQuery(params: ListMedicalRecordsParams) {
   return useQuery({
     queryKey: KEYS.shared(params),
     queryFn: () => medicalRecordsService.listShared(params),
+    placeholderData: (previousData) => previousData,
   });
 }
 
@@ -32,6 +33,7 @@ export function useMedicalRecordsListQuery(params: ListMedicalRecordsParams) {
   return useQuery({
     queryKey: KEYS.list(params),
     queryFn: () => medicalRecordsService.list(params),
+    placeholderData: (previousData) => previousData,
   });
 }
 
@@ -41,6 +43,7 @@ export function useMedicalRecordsListForPatientQuery(
   return useQuery({
     queryKey: KEYS.listForPatient(params),
     queryFn: () => medicalRecordsService.listForPatient(params),
+    placeholderData: (previousData) => previousData,
   });
 }
 

--- a/apps/web/queries/useMyAppointmentsQuery.ts
+++ b/apps/web/queries/useMyAppointmentsQuery.ts
@@ -1,15 +1,48 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery } from "@tanstack/react-query";
 import { appointmentsService } from "../services/appointments-service";
 
-export function useMyAppointmentsQuery(params?: {
-  status?: string;
+type MyAppointmentsParams = {
+  status?: string | string[];
   startDate?: string;
   endDate?: string;
   page?: number;
   limit?: number;
-}) {
+};
+
+export function useMyAppointmentsQuery(params?: MyAppointmentsParams) {
   return useQuery({
-    queryKey: ["my-appointments"],
+    queryKey: ["my-appointments", params ?? {}],
     queryFn: () => appointmentsService.listMyAppointments(params),
+    placeholderData: (previousData) => previousData,
   });
+}
+
+/**
+ * Totais por conjunto de status, para os badges das abas. Cada consulta pede
+ * `limit: 1` e lê apenas `meta.total` — barato e cacheado pelo TanStack. Recebe
+ * um mapa `chave -> status[]` e devolve `chave -> total`.
+ */
+export function useMyAppointmentsCounts<K extends string>(
+  statusByKey: Record<K, string[]>,
+) {
+  const entries = Object.entries(statusByKey) as [K, string[]][];
+
+  const results = useQueries({
+    queries: entries.map(([key, status]) => ({
+      queryKey: ["my-appointments-count", key, status],
+      queryFn: () =>
+        appointmentsService.listMyAppointments({ status, page: 1, limit: 1 }),
+      placeholderData: (previous: Awaited<
+        ReturnType<typeof appointmentsService.listMyAppointments>
+      > | undefined) => previous,
+    })),
+  });
+
+  return entries.reduce(
+    (acc, [key], index) => {
+      acc[key] = results[index]?.data?.meta.total ?? 0;
+      return acc;
+    },
+    {} as Record<K, number>,
+  );
 }

--- a/apps/web/services/admin-service.ts
+++ b/apps/web/services/admin-service.ts
@@ -1,6 +1,7 @@
 import { api } from "../lib/api";
 import { AxiosError } from "axios";
 import { API_ROUTES } from "../constants/api-routes";
+import { MAX_PAGE_SIZE, type Paginated } from "../lib/pagination";
 
 export type PatientApprovalStatus = "APPROVED" | "PENDING" | "REJECTED";
 
@@ -49,8 +50,13 @@ const handleError = (error: unknown, fallback: string): never => {
 export const adminService = {
   async listUsers(params?: AdminUsersParams): Promise<AdminUser[]> {
     try {
-      const response = await api.get(API_ROUTES.ADMIN.USERS, { params });
-      return response.data;
+      const response = await api.get(API_ROUTES.ADMIN.USERS, {
+        params: { limit: MAX_PAGE_SIZE, ...params },
+      });
+      // A tabela de usuários filtra/ordena tudo no cliente (busca fuzzy, abas
+      // por role). Desembrulhamos o envelope { data, meta } e devolvemos o array.
+      const payload = response.data as Paginated<AdminUser>;
+      return payload.data;
     } catch (error) {
       return handleError(error, "Erro ao listar usuários.");
     }
@@ -59,9 +65,10 @@ export const adminService = {
   async listProfessionals(): Promise<AdminUser[]> {
     try {
       const response = await api.get(API_ROUTES.ADMIN.USERS, {
-        params: { role: "PROFESSIONAL" },
+        params: { role: "PROFESSIONAL", limit: MAX_PAGE_SIZE },
       });
-      return response.data;
+      const payload = response.data as Paginated<AdminUser>;
+      return payload.data;
     } catch (error) {
       return handleError(error, "Erro ao listar profissionais.");
     }

--- a/apps/web/services/appointments-service.ts
+++ b/apps/web/services/appointments-service.ts
@@ -1,5 +1,6 @@
 import { api } from "../lib/api";
 import { AxiosError } from "axios";
+import type { Paginated } from "../lib/pagination";
 
 export interface CreateAppointmentPatientDto {
   professionalId: string;
@@ -57,12 +58,7 @@ export interface AppointmentResponse {
   };
 }
 
-export interface AppointmentListResponse {
-  data: AppointmentResponse[];
-  page: number;
-  limit: number;
-  total: number;
-}
+export type AppointmentListResponse = Paginated<AppointmentResponse>;
 
 function extractErrorMessage(error: unknown, fallback: string): never {
   if (error instanceof AxiosError && error.response) {
@@ -96,15 +92,23 @@ export const appointmentsService = {
   },
 
   async listMyAppointments(params?: {
-    status?: string;
+    status?: string | string[];
     startDate?: string;
     endDate?: string;
     page?: number;
     limit?: number;
   }) {
     try {
+      // O backend aceita `status` único ou múltiplos separados por vírgula
+      // (?status=PENDING,CONFIRMED). Serializamos array nesse formato.
+      const { status, ...rest } = params ?? {};
       const response = await api.get("/appointments/my-appointments", {
-        params,
+        params: {
+          ...rest,
+          ...(status && {
+            status: Array.isArray(status) ? status.join(",") : status,
+          }),
+        },
       });
       return response.data as AppointmentListResponse;
     } catch (error) {

--- a/apps/web/services/manager-service.ts
+++ b/apps/web/services/manager-service.ts
@@ -1,5 +1,6 @@
 import { api } from "../lib/api";
 import { AxiosError } from "axios";
+import { MAX_PAGE_SIZE, type Paginated } from "../lib/pagination";
 
 export type PatientApprovalStatus = "APPROVED" | "PENDING" | "REJECTED";
 
@@ -68,6 +69,31 @@ export interface ManagerPatientResponse {
     questionnaire?: QuestionnaireSummary | null;
   };
   questionnaire?: QuestionnaireSummary | null;
+}
+
+export interface ManagerProfessionalResponse {
+  id: string;
+  name: string;
+  email: string;
+  status: string;
+  professionalProfile?: {
+    id?: string;
+    specialty?: string;
+    professionalLicense?: string;
+    modality?: string;
+    bio?: string;
+    photoUrl?: string;
+    specialities?: { id: string; name: string }[];
+  } | null;
+  address?: {
+    zipCode?: string | null;
+    street?: string | null;
+    number?: string | null;
+    complement?: string | null;
+    district?: string | null;
+    city?: string | null;
+    state?: string | null;
+  } | null;
 }
 
 export interface CreateAppointmentDto {
@@ -172,9 +198,13 @@ export const managerService = {
 
   async listPatients(): Promise<ManagerPatientResponse[]> {
     try {
-      const response =
-        await api.get<ManagerPatientResponse[]>("/manager/patients");
-      return response.data;
+      const response = await api.get<Paginated<ManagerPatientResponse>>(
+        "/manager/patients",
+        { params: { limit: MAX_PAGE_SIZE } },
+      );
+      // A tela de pacientes (e a home do gestor) filtra/agrega a lista inteira
+      // no cliente, então desembrulhamos o envelope e devolvemos o array.
+      return response.data.data;
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         const message = error.response.data.message;
@@ -213,11 +243,15 @@ export const managerService = {
     params?: ListAppointmentsParams,
   ): Promise<ManagementAppointment[]> {
     try {
-      const response = await api.get<ManagementAppointment[]>(
+      const response = await api.get<Paginated<ManagementAppointment>>(
         "/manager/appointments",
-        { params },
+        // A view (ManagementAppointmentsView) filtra/ordena/agrega a lista
+        // inteira no cliente (busca, filtro por status, stat cards). O sort por
+        // vulnerabilidade é resolvido no servidor via `sortBy`/`order`. Pedimos
+        // o cap de 100 e desembrulhamos o envelope { data, meta }.
+        { params: { limit: MAX_PAGE_SIZE, ...params } },
       );
-      return response.data;
+      return response.data.data;
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         const message = error.response.data.message;
@@ -255,10 +289,17 @@ export const managerService = {
     }
   },
 
-  async listProfessionals() {
+  async listProfessionals(): Promise<ManagerProfessionalResponse[]> {
     try {
-      const response = await api.get("/professional");
-      return response.data;
+      // `/professional` agora é paginado ({ data, meta }). Esta tela filtra por
+      // busca/especialidade/localização no cliente (as opções de localização
+      // derivam do conjunto inteiro), então pedimos o cap de 100 e
+      // desembrulhamos, mantendo a paginação da grade no cliente.
+      const response = await api.get<Paginated<ManagerProfessionalResponse>>(
+        "/professional",
+        { params: { limit: MAX_PAGE_SIZE } },
+      );
+      return response.data.data;
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         const message = error.response.data.message;

--- a/apps/web/services/medical-records-service.ts
+++ b/apps/web/services/medical-records-service.ts
@@ -1,5 +1,6 @@
 import { api } from "../lib/api";
 import { AxiosError } from "axios";
+import { MAX_PAGE_SIZE, type Paginated } from "../lib/pagination";
 
 export interface MedicalRecordAuthor {
   id: string;
@@ -48,12 +49,8 @@ export interface MedicalRecordPatientResponse {
   updatedAt: string;
 }
 
-export interface PaginatedMedicalRecords<T> {
-  data: T[];
-  page: number;
-  limit: number;
-  total: number;
-}
+/** @deprecated Use `Paginated<T>` de `@/lib/pagination`. Mantido como alias. */
+export type PaginatedMedicalRecords<T> = Paginated<T>;
 
 export interface CreateMedicalRecordDto {
   appointmentId: string;
@@ -162,8 +159,13 @@ export const medicalRecordsService = {
 
   async findByPatient(patientId: string): Promise<MedicalRecordResponse[]> {
     try {
-      const response = await api.get(`/medical-records/patient/${patientId}`);
-      return response.data as MedicalRecordResponse[];
+      const response = await api.get(`/medical-records/patient/${patientId}`, {
+        params: { limit: MAX_PAGE_SIZE },
+      });
+      // A API agora responde com envelope { data, meta }. Esta chamada não expõe
+      // paginação na UI, então desembrulhamos e mantemos o array.
+      const payload = response.data as Paginated<MedicalRecordResponse>;
+      return payload.data;
     } catch (error) {
       extractErrorMessage(error, "Erro ao buscar prontuários do paciente.");
     }

--- a/apps/web/services/professional-service.ts
+++ b/apps/web/services/professional-service.ts
@@ -1,5 +1,6 @@
 import { api } from "../lib/api";
 import { AxiosError } from "axios";
+import { MAX_PAGE_SIZE, type Paginated } from "../lib/pagination";
 
 export interface UpdateSettingsPayload {
   modality: string;
@@ -104,8 +105,13 @@ export const professionalService = {
 
   async getPatients(): Promise<PatientProfile[]> {
     try {
-      const response = await api.get("/professional/patients");
-      return response.data;
+      const response = await api.get("/professional/patients", {
+        params: { limit: MAX_PAGE_SIZE },
+      });
+      // A tela filtra a lista inteira no cliente (busca por nome/CPF/telefone),
+      // então desembrulhamos o envelope e devolvemos o array. Cap de 100 na API.
+      const payload = response.data as Paginated<PatientProfile>;
+      return payload.data;
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         throw new Error(
@@ -118,8 +124,19 @@ export const professionalService = {
 
   async getPatientDetail(patientId: string): Promise<PatientDetail> {
     try {
-      const response = await api.get(`/professional/patients/${patientId}`);
-      return response.data;
+      const response = await api.get(`/professional/patients/${patientId}`, {
+        params: { limit: MAX_PAGE_SIZE },
+      });
+      // O `history` virou envelope { data, meta }. A tela de detalhe separa
+      // histórico em "próxima consulta" x "passadas" e conta o total no cliente,
+      // então normalizamos `history` de volta para um array simples aqui.
+      const raw = response.data as Omit<PatientDetail, "history"> & {
+        history: PatientDetail["history"] | Paginated<PatientDetail["history"][number]>;
+      };
+      const history = Array.isArray(raw.history)
+        ? raw.history
+        : raw.history.data;
+      return { ...raw, history };
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         throw new Error(

--- a/apps/web/services/professionals-service.ts
+++ b/apps/web/services/professionals-service.ts
@@ -1,6 +1,7 @@
 import { api } from "../lib/api";
 import { AxiosError } from "axios";
 import { API_ROUTES } from "../constants/api-routes";
+import { MAX_PAGE_SIZE, type Paginated } from "../lib/pagination";
 
 export interface ProfessionalUser {
   id: string;
@@ -29,8 +30,14 @@ export interface ProfessionalUser {
 export const professionalsService = {
   async listAll(): Promise<ProfessionalUser[]> {
     try {
-      const response = await api.get(API_ROUTES.PROFESSIONALS.LIST);
-      return response.data;
+      // `/professional` agora é paginado ({ data, meta }). A busca de médicos do
+      // paciente filtra por busca/especialidade/localização no cliente, então
+      // pedimos o cap de 100 e desembrulhamos o envelope.
+      const response = await api.get<Paginated<ProfessionalUser>>(
+        API_ROUTES.PROFESSIONALS.LIST,
+        { params: { limit: MAX_PAGE_SIZE } },
+      );
+      return response.data.data;
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         const message = error.response.data.message;


### PR DESCRIPTION
## Resumo
- `useServerPagination`: hook compartilhado para paginação server-side (com sincronização opcional via URL)
- `DataTable` dividido em `DataTablePageSizeSelector` (seletor "por página", no topo da tela) e `DataTablePagination` (contador + anterior/próxima, no rodapé)
- Telas migradas: usuários (admin), agendamentos e pacientes (gestor), prontuários (profissional e paciente), solicitações pendentes (profissional), listagem/busca de profissionais, consultas do paciente

Baseado em #220 (contrato de paginação do backend). Closes #219

## Test plan
- [x] `npx tsc --noEmit` limpo
- [x] `npm run build` limpo (todas as rotas afetadas compilam)