### PR TITLE
fix: sincronizar frontend de paginação com main (corrige PR #221 mergeado na branch errada)

### DIFF
--- a/apps/server/src/admin/dto/list-admin-users-query-dto.ts
+++ b/apps/server/src/admin/dto/list-admin-users-query-dto.ts
@@ -1,10 +1,11 @@
 import { IsEnum, IsOptional, IsString } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { UserRole, UserStatus } from '@prisma/client';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
 
 const toUpper = ({ value }: { value: string }): string => value?.toUpperCase();
 
-export class ListAdminUsersQueryDto {
+export class ListAdminUsersQueryDto extends PaginationQueryDto {
   @IsOptional()
   @Transform(toUpper)
   @IsEnum(UserRole)

--- a/apps/server/src/appointments/appointments.repository.ts
+++ b/apps/server/src/appointments/appointments.repository.ts
@@ -255,7 +255,7 @@ export class AppointmentsRepository {
 
     const where = {
       ...ownerFilter,
-      ...(query.status && { status: query.status }),
+      ...(query.status?.length && { status: { in: query.status } }),
       ...(query.startDate || query.endDate
         ? {
             dateTime: {

--- a/apps/server/src/appointments/appointments.service.spec.ts
+++ b/apps/server/src/appointments/appointments.service.spec.ts
@@ -51,7 +51,7 @@ describe('AppointmentsService', () => {
   const makeAppointment = (overrides: Record<string, unknown> = {}) => ({
     id: 'appt-1',
     dateTime: hoursFromNow(48),
-    status: AppointmentStatus.SCHEDULED,
+    status: AppointmentStatus.CONFIRMED,
     notes: null,
     modality: 'IN_PERSON',
     googleEventId: null,
@@ -123,7 +123,9 @@ describe('AppointmentsService', () => {
         'https://meet.google.com/abc-defg-hij',
         'event-1',
       );
-      expect(mailService.sendAppointmentCreatedPatientEmail).toHaveBeenCalledWith(
+      expect(
+        mailService.sendAppointmentCreatedPatientEmail,
+      ).toHaveBeenCalledWith(
         { name: appointment.patient.name, email: appointment.patient.email },
         expect.objectContaining({
           modality: 'VIRTUAL',
@@ -161,7 +163,9 @@ describe('AppointmentsService', () => {
 
       expect(meetService.createMeetEvent).not.toHaveBeenCalled();
       expect(repository.updateMeetData).not.toHaveBeenCalled();
-      expect(mailService.sendAppointmentCreatedPatientEmail).toHaveBeenCalledWith(
+      expect(
+        mailService.sendAppointmentCreatedPatientEmail,
+      ).toHaveBeenCalledWith(
         { name: appointment.patient.name, email: appointment.patient.email },
         expect.objectContaining({
           modality: 'CLINIC',
@@ -192,7 +196,9 @@ describe('AppointmentsService', () => {
       });
 
       expect(repository.updateMeetData).not.toHaveBeenCalled();
-      expect(mailService.sendAppointmentCreatedPatientEmail).toHaveBeenCalledWith(
+      expect(
+        mailService.sendAppointmentCreatedPatientEmail,
+      ).toHaveBeenCalledWith(
         { name: appointment.patient.name, email: appointment.patient.email },
         expect.objectContaining({
           modality: 'VIRTUAL',
@@ -247,7 +253,9 @@ describe('AppointmentsService', () => {
         'appt-1',
         'Imprevisto',
       );
-      expect(mailService.sendAppointmentCancelledEmail).toHaveBeenCalledTimes(2);
+      expect(mailService.sendAppointmentCancelledEmail).toHaveBeenCalledTimes(
+        2,
+      );
       expect(result.status).toBe(AppointmentStatus.CANCELLED);
     });
 

--- a/apps/server/src/appointments/appointments.service.ts
+++ b/apps/server/src/appointments/appointments.service.ts
@@ -7,6 +7,7 @@ import {
   Inject,
 } from '@nestjs/common';
 import { AppointmentsRepository } from './appointments.repository';
+import { buildMeta } from '../common/dto/paginated-response.dto';
 import { MailService } from '../mail/mail.service';
 import { MEET_SERVICE } from '../common/interfaces/MeetEventInterfaces';
 import type { MeetService } from '../common/interfaces/MeetEventInterfaces';
@@ -85,9 +86,7 @@ export class AppointmentsService {
 
     return {
       data: appointments.map((a) => this.mapToResponseDto(a)),
-      page,
-      limit,
-      total,
+      meta: buildMeta(total, page, limit),
     };
   }
 
@@ -100,9 +99,7 @@ export class AppointmentsService {
 
     return {
       data: appointments.map((a) => this.mapToResponseDto(a)),
-      page,
-      limit,
-      total,
+      meta: buildMeta(total, page, limit),
     };
   }
 

--- a/apps/server/src/appointments/dto/appointment-response.dto.ts
+++ b/apps/server/src/appointments/dto/appointment-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AppointmentModality } from '@prisma/client';
+import { PaginationMetaDto } from '../../common/dto/paginated-response.dto';
 
 export class ProfessionalResponseDto {
   @ApiProperty({
@@ -120,12 +121,6 @@ export class AppointmentListResponseDto {
   })
   data!: AppointmentResponseDto[];
 
-  @ApiProperty({ example: 1, description: 'Página atual' })
-  page!: number;
-
-  @ApiProperty({ example: 10, description: 'Registros por página' })
-  limit!: number;
-
-  @ApiProperty({ example: 5, description: 'Total de registros' })
-  total!: number;
+  @ApiProperty({ type: PaginationMetaDto, description: 'Metadados de paginação' })
+  meta!: PaginationMetaDto;
 }

--- a/apps/server/src/appointments/dto/list-appointments-query.dto.ts
+++ b/apps/server/src/appointments/dto/list-appointments-query.dto.ts
@@ -1,25 +1,33 @@
-import {
-  IsOptional,
-  IsEnum,
-  IsDateString,
-  IsNumber,
-  Min,
-  Max,
-} from 'class-validator';
+import { IsOptional, IsEnum, IsDateString, IsArray } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 import { AppointmentStatus } from '@prisma/client';
-import { Type } from 'class-transformer';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
 
-export class ListAppointmentsQueryDto {
+export class ListAppointmentsQueryDto extends PaginationQueryDto {
   @ApiProperty({
     enum: AppointmentStatus,
+    isArray: true,
     example: 'CONFIRMED',
-    description: 'Filtrar por status do agendamento',
+    description:
+      'Filtrar por status do agendamento. Aceita um único valor ' +
+      '(?status=CONFIRMED) ou vários separados por vírgula ' +
+      '(?status=PENDING,CONFIRMED).',
     required: false,
   })
-  @IsEnum(AppointmentStatus, { message: 'Status inválido' })
+  // Normaliza "PENDING,CONFIRMED" (ou repetição do param) em array; um único
+  // valor vira array de um elemento. Assim `status: { in: [...] }` no
+  // repositório cobre tanto filtro simples quanto por múltiplos status (aba
+  // "Próximas" do paciente = PENDING + CONFIRMED).
+  @Transform(({ value }) => {
+    if (value === undefined || value === null || value === '') return undefined;
+    const list = Array.isArray(value) ? value : String(value).split(',');
+    return list.map((item) => String(item).trim()).filter(Boolean);
+  })
+  @IsArray()
+  @IsEnum(AppointmentStatus, { each: true, message: 'Status inválido' })
   @IsOptional()
-  status?: AppointmentStatus;
+  status?: AppointmentStatus[];
 
   @ApiProperty({
     example: '2024-06-01',
@@ -38,28 +46,4 @@ export class ListAppointmentsQueryDto {
   @IsDateString({}, { message: 'Data final inválida' })
   @IsOptional()
   endDate?: string;
-
-  @ApiProperty({
-    example: 1,
-    description: 'Página da paginação (começa em 1, máximo 1000)',
-    required: false,
-  })
-  @Type(() => Number)
-  @IsNumber({}, { message: 'Página deve ser um número' })
-  @Min(1, { message: 'Página deve ser no mínimo 1' })
-  @Max(1000, { message: 'Página máxima é 1000' })
-  @IsOptional()
-  page?: number = 1;
-
-  @ApiProperty({
-    example: 10,
-    description: 'Quantidade de registros por página (1-100, padrão 10)',
-    required: false,
-  })
-  @Type(() => Number)
-  @IsNumber({}, { message: 'Limit deve ser um número' })
-  @Min(1, { message: 'Limit deve ser no mínimo 1' })
-  @Max(100, { message: 'Limit máximo é 100 registros' })
-  @IsOptional()
-  limit?: number = 10;
 }

--- a/apps/server/src/common/dto/paginated-response.dto.ts
+++ b/apps/server/src/common/dto/paginated-response.dto.ts
@@ -1,0 +1,98 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Metadados de paginação incluídos em toda resposta paginada.
+ */
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+/**
+ * Envelope padrão de resposta paginada da API.
+ *
+ * Contrato unificado usado por TODOS os endpoints paginados:
+ *   { data: T[], meta: { page, limit, total, totalPages } }
+ */
+export interface PaginatedResult<T> {
+  data: T[];
+  meta: PaginationMeta;
+}
+
+/**
+ * Classe de metadados para documentação Swagger.
+ */
+export class PaginationMetaDto implements PaginationMeta {
+  @ApiProperty({ example: 1, description: 'Página atual' })
+  page!: number;
+
+  @ApiProperty({ example: 10, description: 'Registros por página' })
+  limit!: number;
+
+  @ApiProperty({ example: 42, description: 'Total de registros' })
+  total!: number;
+
+  @ApiProperty({ example: 5, description: 'Total de páginas' })
+  totalPages!: number;
+}
+
+/**
+ * Monta os metadados de paginação a partir do total e dos parâmetros da query.
+ * `totalPages` é no mínimo 1 mesmo quando não há registros, para simplificar a UI.
+ */
+export function buildMeta(
+  total: number,
+  page: number,
+  limit: number,
+): PaginationMeta {
+  return {
+    page,
+    limit,
+    total,
+    totalPages: Math.max(1, Math.ceil(total / limit)),
+  };
+}
+
+/**
+ * Delegate mínimo de um model Prisma: expõe `findMany` e `count`.
+ * Genérico sobre o próprio delegate para preservar a inferência de tipos do
+ * Prisma (args e retorno de `findMany`).
+ */
+interface PrismaModelDelegate {
+  findMany(args: unknown): Promise<unknown>;
+  count(args: unknown): Promise<number>;
+}
+
+type FindManyArgs<D extends PrismaModelDelegate> = Parameters<D['findMany']>[0];
+type FindManyRow<D extends PrismaModelDelegate> =
+  Awaited<ReturnType<D['findMany']>> extends (infer R)[] ? R : never;
+
+/**
+ * Executa `findMany` + `count` em paralelo aplicando skip/take e retorna o
+ * envelope paginado padrão. Elimina a duplicação de `Promise.all([findMany, count])`
+ * espalhada pelos repositories.
+ *
+ * @example
+ *   return paginate(this.prisma.user, { where, include, orderBy }, page, limit);
+ */
+export async function paginate<D extends PrismaModelDelegate>(
+  delegate: D,
+  args: FindManyArgs<D>,
+  page: number,
+  limit: number,
+): Promise<PaginatedResult<FindManyRow<D>>> {
+  const findArgs = args as { where?: unknown };
+
+  const [data, total] = await Promise.all([
+    delegate.findMany({
+      ...findArgs,
+      skip: (page - 1) * limit,
+      take: limit,
+    }) as Promise<FindManyRow<D>[]>,
+    delegate.count({ where: findArgs.where }),
+  ]);
+
+  return { data, meta: buildMeta(total, page, limit) };
+}

--- a/apps/server/src/common/dto/pagination-query.dto.ts
+++ b/apps/server/src/common/dto/pagination-query.dto.ts
@@ -1,0 +1,36 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+/**
+ * Base DTO de paginação (offset-based).
+ *
+ * DTOs de listagem devem estender esta classe e adicionar apenas seus próprios
+ * filtros (search, status, datas, etc). Assim `page`/`limit` ficam centralizados
+ * em um único lugar, com validação e defaults consistentes em toda a API.
+ */
+export class PaginationQueryDto {
+  @ApiPropertyOptional({
+    example: 1,
+    default: 1,
+    description: 'Página da paginação (começa em 1, máximo 1000)',
+  })
+  @Type(() => Number)
+  @IsInt({ message: 'Página deve ser um número inteiro' })
+  @Min(1, { message: 'Página deve ser no mínimo 1' })
+  @Max(1000, { message: 'Página máxima é 1000' })
+  @IsOptional()
+  page: number = 1;
+
+  @ApiPropertyOptional({
+    example: 10,
+    default: 10,
+    description: 'Quantidade de registros por página (1-100, padrão 10)',
+  })
+  @Type(() => Number)
+  @IsInt({ message: 'Limit deve ser um número inteiro' })
+  @Min(1, { message: 'Limit deve ser no mínimo 1' })
+  @Max(100, { message: 'Limit máximo é 100 registros' })
+  @IsOptional()
+  limit: number = 10;
+}

--- a/apps/server/src/manager/dtos/list-manager-appointments-query.dto.ts
+++ b/apps/server/src/manager/dtos/list-manager-appointments-query.dto.ts
@@ -1,7 +1,8 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional } from 'class-validator';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
 
-export class ListManagerAppointmentsQueryDto {
+export class ListManagerAppointmentsQueryDto extends PaginationQueryDto {
   @ApiPropertyOptional({
     enum: ['vulnerabilityScore'],
     description: 'Campo usado para ordenar os agendamentos',

--- a/apps/server/src/manager/manager.controller.ts
+++ b/apps/server/src/manager/manager.controller.ts
@@ -28,6 +28,7 @@ import { UpdatePatientDto } from '../patients/dto/update-patient.dto';
 import { UpdatePatientApprovalStatusDto } from '../patients/dto/update-patient-approval-status.dto';
 import { CancelAppointmentDto } from '../appointments/dto/cancel-appointment-patient.dto';
 import { ListManagerAppointmentsQueryDto } from './dtos/list-manager-appointments-query.dto';
+import { ListPatientsQueryDto } from '../patients/dto/list-patients-query.dto';
 
 @ApiTags('Manager')
 @ApiBearerAuth('access-token')
@@ -106,8 +107,8 @@ export class ManagerController {
   @ApiResponse({ status: 200, description: 'Lista de pacientes.' })
   @ApiResponse({ status: 401, description: 'Não autenticado.' })
   @ApiResponse({ status: 403, description: 'Acesso negado — somente MANAGER.' })
-  async listPatients(@Query('search') search?: string) {
-    return this.patientsService.listPatients(search);
+  async listPatients(@Query() query: ListPatientsQueryDto) {
+    return this.patientsService.listPatients(query);
   }
 
   @Get('patients/:patientId')

--- a/apps/server/src/manager/manager.repository.ts
+++ b/apps/server/src/manager/manager.repository.ts
@@ -1,6 +1,59 @@
 import { Injectable } from '@nestjs/common';
-import { AppointmentStatus } from '@prisma/client';
+import { AppointmentStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { ListManagerAppointmentsQueryDto } from './dtos/list-manager-appointments-query.dto';
+import {
+  buildMeta,
+  PaginatedResult,
+} from '../common/dto/paginated-response.dto';
+
+const MANAGER_APPOINTMENT_SELECT = {
+  id: true,
+  dateTime: true,
+  status: true,
+  notes: true,
+  modality: true,
+  meetLink: true,
+  createdAt: true,
+  patient: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      patientProfile: {
+        select: {
+          questionnaire: {
+            select: {
+              totalScore: true,
+              isVulnerable: true,
+            },
+          },
+        },
+      },
+    },
+  },
+  professional: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+  scheduledByManager: {
+    select: {
+      user: { select: { name: true } },
+    },
+  },
+  cancelledByManager: {
+    select: {
+      user: { select: { name: true } },
+    },
+  },
+} satisfies Prisma.AppointmentSelect;
+
+export type ManagerAppointmentRow = Prisma.AppointmentGetPayload<{
+  select: typeof MANAGER_APPOINTMENT_SELECT;
+}>;
 
 @Injectable()
 export class ManagerRepository {
@@ -36,53 +89,56 @@ export class ManagerRepository {
     });
   }
 
-  findAllAppointmentsForManagerAndAdmin() {
-    return this.prisma.appointment.findMany({
-      select: {
-        id: true,
-        dateTime: true,
-        status: true,
-        notes: true,
-        modality: true,
-        meetLink: true,
-        createdAt: true,
+  async findAllAppointmentsForManagerAndAdmin(
+    query: ListManagerAppointmentsQueryDto,
+  ): Promise<PaginatedResult<ManagerAppointmentRow>> {
+    const { page, limit } = query;
+    const orderBy = this.buildAppointmentsOrderBy(query);
+
+    const [data, total] = await Promise.all([
+      this.prisma.appointment.findMany({
+        select: MANAGER_APPOINTMENT_SELECT,
+        orderBy,
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.appointment.count(),
+    ]);
+
+    return { data, meta: buildMeta(total, page, limit) };
+  }
+
+  /**
+   * Ordenação por vulnerabilidade resolvida no banco (não em memória), para
+   * funcionar corretamente através de todas as páginas.
+   *
+   * Ordena pela nota do questionário do paciente (relação to-one) e usa
+   * `dateTime desc` como critério de desempate — o mesmo comportamento do antigo
+   * sort em memória. Pacientes sem questionário (totalScore NULL) seguem a
+   * colocação padrão do PostgreSQL (NULLs por último em asc), preservando a
+   * ordenação consistente entre páginas.
+   */
+  private buildAppointmentsOrderBy(
+    query: ListManagerAppointmentsQueryDto,
+  ): Prisma.AppointmentOrderByWithRelationInput[] {
+    if (query.sortBy !== 'vulnerabilityScore') {
+      return [{ dateTime: 'desc' }];
+    }
+
+    const direction: Prisma.SortOrder = query.order === 'desc' ? 'desc' : 'asc';
+
+    return [
+      {
         patient: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            patientProfile: {
-              select: {
-                questionnaire: {
-                  select: {
-                    totalScore: true,
-                    isVulnerable: true,
-                  },
-                },
-              },
+          patientProfile: {
+            questionnaire: {
+              totalScore: direction,
             },
           },
         },
-        professional: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-          },
-        },
-        scheduledByManager: {
-          select: {
-            user: { select: { name: true } },
-          },
-        },
-        cancelledByManager: {
-          select: {
-            user: { select: { name: true } },
-          },
-        },
       },
-      orderBy: { dateTime: 'desc' },
-    });
+      { dateTime: 'desc' },
+    ];
   }
 
   findProfessionalWithSpecialities(id: string) {

--- a/apps/server/src/manager/manager.service.spec.ts
+++ b/apps/server/src/manager/manager.service.spec.ts
@@ -83,7 +83,7 @@ describe('ManagerService', () => {
     });
   });
 
-  describe('listAppointments vulnerability sorting', () => {
+  describe('listAppointments', () => {
     const makeAppt = (
       id: string,
       dateTime: Date,
@@ -110,45 +110,46 @@ describe('ManagerService', () => {
       cancelledByManager: null,
     });
 
-    it('keeps insertion order when not sorting by vulnerability', async () => {
-      repository.findAllAppointmentsForManagerAndAdmin.mockResolvedValue([
-        makeAppt('a', new Date('2026-01-01'), 2),
-        makeAppt('b', new Date('2026-02-01'), 8),
-      ]);
+    const meta = { page: 1, limit: 10, total: 2, totalPages: 1 };
 
-      const result = await service.listAppointments({} as any);
-
-      expect(result.map((r) => r.id)).toEqual(['a', 'b']);
-      expect(result[1].isVulnerable).toBe(true);
-    });
-
-    it('sorts by score descending and pushes null scores to the end', async () => {
-      repository.findAllAppointmentsForManagerAndAdmin.mockResolvedValue([
-        makeAppt('low', new Date('2026-01-01'), 2),
-        makeAppt('none', new Date('2026-01-01'), null),
-        makeAppt('high', new Date('2026-01-01'), 9),
-      ]);
+    it('returns the { data, meta } envelope and maps rows', async () => {
+      repository.findAllAppointmentsForManagerAndAdmin.mockResolvedValue({
+        data: [
+          makeAppt('a', new Date('2026-01-01'), 2),
+          makeAppt('b', new Date('2026-02-01'), 8),
+        ],
+        meta,
+      });
 
       const result = await service.listAppointments({
-        sortBy: 'vulnerabilityScore',
-        order: 'desc',
+        page: 1,
+        limit: 10,
       } as any);
 
-      expect(result.map((r) => r.id)).toEqual(['high', 'low', 'none']);
+      expect(result.data.map((r) => r.id)).toEqual(['a', 'b']);
+      expect(result.data[1].isVulnerable).toBe(true);
+      expect(result.meta).toEqual(meta);
     });
 
-    it('sorts ascending when order is asc', async () => {
-      repository.findAllAppointmentsForManagerAndAdmin.mockResolvedValue([
-        makeAppt('high', new Date('2026-01-01'), 9),
-        makeAppt('low', new Date('2026-01-01'), 2),
-      ]);
+    it('preserves the DB ordering (sorting now happens in the repository)', async () => {
+      // A ordenação por vulnerabilityScore é feita no Prisma orderBy; o service
+      // apenas repassa a ordem já resolvida pelo banco através de todas as páginas.
+      repository.findAllAppointmentsForManagerAndAdmin.mockResolvedValue({
+        data: [
+          makeAppt('high', new Date('2026-01-01'), 9),
+          makeAppt('low', new Date('2026-01-01'), 2),
+          makeAppt('none', new Date('2026-01-01'), null),
+        ],
+        meta: { ...meta, total: 3 },
+      });
 
-      const result = await service.listAppointments({
-        sortBy: 'vulnerabilityScore',
-        order: 'asc',
-      } as any);
+      const query = { sortBy: 'vulnerabilityScore', order: 'desc' } as any;
+      const result = await service.listAppointments(query);
 
-      expect(result.map((r) => r.id)).toEqual(['low', 'high']);
+      expect(result.data.map((r) => r.id)).toEqual(['high', 'low', 'none']);
+      expect(
+        repository.findAllAppointmentsForManagerAndAdmin,
+      ).toHaveBeenCalledWith(query);
     });
   });
 

--- a/apps/server/src/manager/manager.service.ts
+++ b/apps/server/src/manager/manager.service.ts
@@ -1,10 +1,6 @@
-import {
-  Injectable,
-  BadRequestException,
-  NotFoundException,
-} from '@nestjs/common';
-import { ManagerRepository } from './manager.repository';
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
 import { AppointmentStatus, UserRole } from '@prisma/client';
+import { ManagerRepository } from './manager.repository';
 import { ListManagerAppointmentsQueryDto } from './dtos/list-manager-appointments-query.dto';
 
 @Injectable()
@@ -16,8 +12,7 @@ export class ManagerService {
     appointmentId: string,
     reason?: string,
   ) {
-    const appointment =
-      await this.repository.findAppointmentById(appointmentId);
+    const appointment = await this.repository.findAppointmentById(appointmentId);
 
     if (!appointment) {
       throw new NotFoundException('Consulta não encontrada');
@@ -27,8 +22,9 @@ export class ManagerService {
       throw new BadRequestException('Consulta já está cancelada');
     }
 
-    const manager =
-      await this.repository.findManagerProfileByUserId(managerUserId);
+    const manager = await this.repository.findManagerProfileByUserId(
+      managerUserId,
+    );
 
     if (!manager) {
       throw new NotFoundException('Perfil de gestor não encontrado');
@@ -46,49 +42,39 @@ export class ManagerService {
   }
 
   async listAppointments(query: ListManagerAppointmentsQueryDto) {
-    const appointments =
-      await this.repository.findAllAppointmentsForManagerAndAdmin();
+    const { data, meta } =
+      await this.repository.findAllAppointmentsForManagerAndAdmin(query);
 
-    const response = appointments.map((appointment) => ({
-      id: appointment.id,
-      dateTime: appointment.dateTime,
-      status: appointment.status,
-      notes: appointment.notes,
-      modality: appointment.modality,
-      meetLink: appointment.meetLink,
-      createdAt: appointment.createdAt,
-      patient: {
-        id: appointment.patient.id,
-        name: appointment.patient.name,
-        email: appointment.patient.email,
-      },
-      professional: appointment.professional,
-      scheduledByManager: appointment.scheduledByManager,
-      cancelledByManager: appointment.cancelledByManager,
-      totalScore:
-        appointment.patient.patientProfile?.questionnaire?.totalScore ?? null,
-      isVulnerable:
-        appointment.patient.patientProfile?.questionnaire?.isVulnerable ?? null,
-    }));
+    return {
+      data: data.map((appt) => {
+        const questionnaire = appt.patient.patientProfile?.questionnaire;
 
-    if (query.sortBy !== 'vulnerabilityScore') {
-      return response;
-    }
-
-    const direction = query.order === 'desc' ? -1 : 1;
-
-    return response.sort((left, right) => {
-      if (left.totalScore === null && right.totalScore === null) {
-        return right.dateTime.getTime() - left.dateTime.getTime();
-      }
-      if (left.totalScore === null) return 1;
-      if (right.totalScore === null) return -1;
-
-      const scoreDifference = (left.totalScore - right.totalScore) * direction;
-      return (
-        scoreDifference || right.dateTime.getTime() - left.dateTime.getTime()
-      );
-    });
+        return {
+          id: appt.id,
+          dateTime: appt.dateTime,
+          status: appt.status,
+          notes: appt.notes,
+          modality: appt.modality,
+          meetLink: appt.meetLink,
+          createdAt: appt.createdAt,
+          patient: {
+            id: appt.patient.id,
+            name: appt.patient.name,
+            email: appt.patient.email,
+          },
+          professional: {
+            id: appt.professional.id,
+            name: appt.professional.name,
+            email: appt.professional.email,
+          },
+          scheduledByManagerName: appt.scheduledByManager?.user.name ?? null,
+          cancelledByManagerName: appt.cancelledByManager?.user.name ?? null,
+          vulnerabilityScore: questionnaire?.totalScore ?? null,
+          isVulnerable: questionnaire?.isVulnerable ?? false,
+        };
+      }),
+      meta,
+    };
   }
 
   async getProfessionalAvailability(professionalId: string) {

--- a/apps/server/src/medical-records/dto/list-medical-records-query.dto.ts
+++ b/apps/server/src/medical-records/dto/list-medical-records-query.dto.ts
@@ -1,16 +1,8 @@
-import {
-  IsOptional,
-  IsUUID,
-  IsDateString,
-  IsNumber,
-  IsString,
-  Min,
-  Max,
-} from 'class-validator';
+import { IsOptional, IsUUID, IsDateString, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
 
-export class ListMedicalRecordsQueryDto {
+export class ListMedicalRecordsQueryDto extends PaginationQueryDto {
   @ApiProperty({
     description: 'Filtrar pelo ID do paciente',
     required: false,
@@ -54,20 +46,4 @@ export class ListMedicalRecordsQueryDto {
   @IsDateString({}, { message: 'Data final inválida' })
   @IsOptional()
   endDate?: string;
-
-  @ApiProperty({ example: 1, required: false })
-  @Type(() => Number)
-  @IsNumber({}, { message: 'Página deve ser um número' })
-  @Min(1, { message: 'Página deve ser no mínimo 1' })
-  @Max(1000, { message: 'Página máxima é 1000' })
-  @IsOptional()
-  page?: number = 1;
-
-  @ApiProperty({ example: 10, required: false })
-  @Type(() => Number)
-  @IsNumber({}, { message: 'Limit deve ser um número' })
-  @Min(1, { message: 'Limit deve ser no mínimo 1' })
-  @Max(100, { message: 'Limit máximo é 100 registros' })
-  @IsOptional()
-  limit?: number = 10;
 }

--- a/apps/server/src/medical-records/dto/medical-record-response.dto.ts
+++ b/apps/server/src/medical-records/dto/medical-record-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { PaginationMetaDto } from '../../common/dto/paginated-response.dto';
 
 export class MedicalRecordAuthorDto {
   @ApiProperty() id!: string;
@@ -55,15 +56,13 @@ export class MedicalRecordPatientResponseDto {
 export class MedicalRecordListResponseDto {
   @ApiProperty({ type: [MedicalRecordResponseDto] })
   data!: MedicalRecordResponseDto[];
-  @ApiProperty({ example: 1 }) page!: number;
-  @ApiProperty({ example: 10 }) limit!: number;
-  @ApiProperty({ example: 0 }) total!: number;
+  @ApiProperty({ type: PaginationMetaDto })
+  meta!: PaginationMetaDto;
 }
 
 export class MedicalRecordPatientListResponseDto {
   @ApiProperty({ type: [MedicalRecordPatientResponseDto] })
   data!: MedicalRecordPatientResponseDto[];
-  @ApiProperty({ example: 1 }) page!: number;
-  @ApiProperty({ example: 10 }) limit!: number;
-  @ApiProperty({ example: 0 }) total!: number;
+  @ApiProperty({ type: PaginationMetaDto })
+  meta!: PaginationMetaDto;
 }

--- a/apps/server/src/medical-records/medical-records.controller.ts
+++ b/apps/server/src/medical-records/medical-records.controller.ts
@@ -134,13 +134,14 @@ export class MedicalRecordsController {
     description: 'Requer vínculo de consulta com o paciente.',
   })
   @ApiParam({ name: 'patientId', description: 'ID do paciente' })
-  @ApiResponse({ status: 200, type: [MedicalRecordResponseDto] })
+  @ApiResponse({ status: 200, type: MedicalRecordListResponseDto })
   @ApiResponse({ status: 403, description: 'Sem vínculo com este paciente.' })
   findByPatient(
     @Request() req: { user: { userId: string } },
     @Param('patientId') patientId: string,
+    @Query() query: ListMedicalRecordsQueryDto,
   ) {
-    return this.service.findByPatient(patientId, req.user.userId);
+    return this.service.findByPatient(patientId, req.user.userId, query);
   }
 
   @Get('appointment/:appointmentId/pdf')

--- a/apps/server/src/medical-records/medical-records.repository.ts
+++ b/apps/server/src/medical-records/medical-records.repository.ts
@@ -77,12 +77,21 @@ export class MedicalRecordsRepository {
     return { records, total, page, limit };
   }
 
-  findByPatient(patientId: string) {
-    return this.prisma.medicalRecord.findMany({
-      where: { patientId },
-      include: RECORD_INCLUDE,
-      orderBy: { createdAt: 'desc' },
-    });
+  async findByPatient(patientId: string, page: number, limit: number) {
+    const where: Prisma.MedicalRecordWhereInput = { patientId };
+
+    const [records, total] = await Promise.all([
+      this.prisma.medicalRecord.findMany({
+        where,
+        include: RECORD_INCLUDE,
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.medicalRecord.count({ where }),
+    ]);
+
+    return { records, total, page, limit };
   }
 
   async listSharedForProfessional(

--- a/apps/server/src/medical-records/medical-records.service.spec.ts
+++ b/apps/server/src/medical-records/medical-records.service.spec.ts
@@ -207,7 +207,10 @@ describe('MedicalRecordsService', () => {
       repository.hasValidPriorAppointment.mockResolvedValue(false);
 
       await expect(
-        service.findByPatient('patient-1', 'prof-1'),
+        service.findByPatient('patient-1', 'prof-1', {
+          page: 1,
+          limit: 10,
+        } as any),
       ).rejects.toBeInstanceOf(ForbiddenException);
 
       expect(repository.hasValidPriorAppointment).toHaveBeenCalledWith(

--- a/apps/server/src/medical-records/medical-records.service.ts
+++ b/apps/server/src/medical-records/medical-records.service.ts
@@ -19,6 +19,7 @@ import {
   MedicalRecordPdfService,
   PatientMedicalRecordPdfInput,
 } from './medical-record-pdf.service';
+import { buildMeta } from '../common/dto/paginated-response.dto';
 
 type MedicalRecordWithRelations = Prisma.MedicalRecordGetPayload<{
   include: {
@@ -148,17 +149,13 @@ export class MedicalRecordsService {
     if (requesterRole === UserRole.PATIENT) {
       return {
         data: records.map((r) => this.toPatientResponseDto(r)),
-        page,
-        limit,
-        total,
+        meta: buildMeta(total, page, limit),
       };
     }
 
     return {
       data: records.map((r) => this.toResponseDto(r)),
-      page,
-      limit,
-      total,
+      meta: buildMeta(total, page, limit),
     };
   }
 
@@ -171,16 +168,15 @@ export class MedicalRecordsService {
 
     return {
       data: records.map((r) => this.toResponseDto(r)),
-      page,
-      limit,
-      total,
+      meta: buildMeta(total, page, limit),
     };
   }
 
   async findByPatient(
     patientId: string,
     requesterId: string,
-  ): Promise<MedicalRecordResponseDto[]> {
+    query: ListMedicalRecordsQueryDto,
+  ): Promise<MedicalRecordListResponseDto> {
     const hasLink = await this.hasPriorAppointment(requesterId, patientId);
 
     if (!hasLink) {
@@ -189,9 +185,13 @@ export class MedicalRecordsService {
       );
     }
 
-    const records = await this.repository.findByPatient(patientId);
+    const { records, total, page, limit } =
+      await this.repository.findByPatient(patientId, query.page, query.limit);
 
-    return records.map((r) => this.toResponseDto(r));
+    return {
+      data: records.map((r) => this.toResponseDto(r)),
+      meta: buildMeta(total, page, limit),
+    };
   }
 
   async update(

--- a/apps/server/src/patients/dto/list-patients-query.dto.ts
+++ b/apps/server/src/patients/dto/list-patients-query.dto.ts
@@ -1,0 +1,12 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+
+export class ListPatientsQueryDto extends PaginationQueryDto {
+  @ApiPropertyOptional({
+    description: 'Busca textual por nome ou CPF do paciente',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+}

--- a/apps/server/src/patients/patients.repository.ts
+++ b/apps/server/src/patients/patients.repository.ts
@@ -8,8 +8,10 @@ import {
 } from '@prisma/client';
 import { CreatePatientDto } from './dto/create-patient.dto';
 import { ExportAppointmentsQueryDto } from './dto/export-appointments-query.dto';
+import { ListPatientsQueryDto } from './dto/list-patients-query.dto';
 import { UpdatePatientDto } from './dto/update-patient.dto';
 import { PrismaService } from '../prisma/prisma.service';
+import { paginate } from '../common/dto/paginated-response.dto';
 
 @Injectable()
 export class PatientsRepository {
@@ -156,30 +158,39 @@ export class PatientsRepository {
     });
   }
 
-  listPatients(search?: string) {
-    return this.prisma.user.findMany({
-      where: {
-        role: UserRole.PATIENT,
-        ...(search && {
-          OR: [
-            { name: { contains: search, mode: 'insensitive' } },
-            { cpf: { contains: search } },
-          ],
-        }),
-      },
-      include: {
-        patientProfile: {
-          include: {
-            questionnaire: {
-              include: {
-                answers: { include: { question: true, option: true } },
+  listPatients(query: ListPatientsQueryDto) {
+    const { search, page, limit } = query;
+
+    const where: Prisma.UserWhereInput = {
+      role: UserRole.PATIENT,
+      ...(search && {
+        OR: [
+          { name: { contains: search, mode: 'insensitive' } },
+          { cpf: { contains: search } },
+        ],
+      }),
+    };
+
+    return paginate(
+      this.prisma.user,
+      {
+        where,
+        include: {
+          patientProfile: {
+            include: {
+              questionnaire: {
+                include: {
+                  answers: { include: { question: true, option: true } },
+                },
               },
             },
           },
         },
+        orderBy: { createdAt: 'desc' },
       },
-      orderBy: { createdAt: 'desc' },
-    });
+      page,
+      limit,
+    );
   }
 
   findPatientWithQuestionnaire(patientId: string) {

--- a/apps/server/src/patients/patients.service.ts
+++ b/apps/server/src/patients/patients.service.ts
@@ -17,6 +17,7 @@ import { AppointmentReportItemDto } from '../reports/dto/appointment-made.dto';
 import { ExportAppointmentsQueryDto } from './dto/export-appointments-query.dto';
 import { CreatePatientDto } from './dto/create-patient.dto';
 import { UpdatePatientDto } from './dto/update-patient.dto';
+import { ListPatientsQueryDto } from './dto/list-patients-query.dto';
 import PDFKit from 'pdfkit';
 
 type PDFDocumentType = PDFKit.PDFDocument;
@@ -210,8 +211,8 @@ export class PatientsService {
     };
   }
 
-  async listPatients(search?: string) {
-    return this.repository.listPatients(search);
+  async listPatients(query: ListPatientsQueryDto) {
+    return this.repository.listPatients(query);
   }
 
   async getPatient(patientId: string) {

--- a/apps/server/src/professional/professional.controller.ts
+++ b/apps/server/src/professional/professional.controller.ts
@@ -25,6 +25,7 @@ import { CreateScheduleBlockDto } from './dto/schedule-block.dto';
 import { ProfessionalRoleGuard } from './guards/professional-role.guard';
 import { EmailVerifiedGuard } from '../auth/guards/email-verified.guard';
 import { QuestionnaireCompletionGuard } from '../questionnaire/questionnaire-completion.guard';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 
 @ApiTags('Professional')
 @ApiBearerAuth('access-token')
@@ -35,11 +36,11 @@ export class ProfessionalController {
 
   @Get()
   @UseGuards(AuthGuard('jwt'), EmailVerifiedGuard)
-  @ApiOperation({ summary: 'Listar todos os profissionais' })
+  @ApiOperation({ summary: 'Listar todos os profissionais (paginado)' })
   @ApiResponse({ status: 200, description: 'Lista de profissionais.' })
   @ApiResponse({ status: 401, description: 'Não autenticado.' })
-  listAll() {
-    return this.professionalService.listAll();
+  listAll(@Query() query: PaginationQueryDto) {
+    return this.professionalService.listAll(query);
   }
 
   @Get('settings')
@@ -124,8 +125,8 @@ export class ProfessionalController {
     status: 403,
     description: 'Acesso negado — somente PROFESSIONAL.',
   })
-  getPatients(@Req() req) {
-    return this.professionalService.getPatients(req.user.id as string);
+  getPatients(@Req() req, @Query() query: PaginationQueryDto) {
+    return this.professionalService.getPatients(req.user.id as string, query);
   }
 
   @Get('patients/:id')
@@ -137,10 +138,15 @@ export class ProfessionalController {
   })
   @ApiResponse({ status: 200, description: 'Detalhes e histórico.' })
   @ApiResponse({ status: 404, description: 'Paciente não encontrado.' })
-  getPatientDetail(@Req() req, @Param('id') patientId: string) {
+  getPatientDetail(
+    @Req() req,
+    @Param('id') patientId: string,
+    @Query() query: PaginationQueryDto,
+  ) {
     return this.professionalService.getPatientDetail(
       req.user.id as string,
       patientId,
+      query,
     );
   }
 

--- a/apps/server/src/professional/professional.repository.ts
+++ b/apps/server/src/professional/professional.repository.ts
@@ -98,24 +98,53 @@ export class ProfessionalRepository {
     });
   }
 
-  findAppointmentsWithPatients(userId: string) {
+  /**
+   * Página de pacientes distintos que já tiveram consulta com este profissional,
+   * ordenados por nome. A paginação é feita sobre a lista de pacientes (não de
+   * consultas), garantindo `total`/`totalPages` corretos por paciente.
+   */
+  async findAttendedPatientsPage(
+    professionalId: string,
+    page: number,
+    limit: number,
+  ) {
+    const where: Prisma.UserWhereInput = {
+      role: 'PATIENT',
+      appointmentsAsPatient: { some: { professionalId } },
+    };
+
+    const [patients, total] = await Promise.all([
+      this.prisma.user.findMany({
+        where,
+        orderBy: { name: 'asc' },
+        skip: (page - 1) * limit,
+        take: limit,
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          cpf: true,
+          patientProfile: { select: { phone: true } },
+        },
+      }),
+      this.prisma.user.count({ where }),
+    ]);
+
+    return { patients, total };
+  }
+
+  /**
+   * Consultas (dateTime/status) de um conjunto de pacientes com este profissional,
+   * usadas para calcular última/próxima visita da página atual.
+   */
+  findAppointmentsForPatients(professionalId: string, patientIds: string[]) {
     return this.prisma.appointment.findMany({
-      where: { professionalId: userId },
+      where: { professionalId, patientId: { in: patientIds } },
       orderBy: { dateTime: 'desc' },
       select: {
         dateTime: true,
         status: true,
-        patient: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            cpf: true,
-            patientProfile: {
-              select: { phone: true },
-            },
-          },
-        },
+        patientId: true,
       },
     });
   }
@@ -135,27 +164,52 @@ export class ProfessionalRepository {
     });
   }
 
-  findPatientAppointments(professionalId: string, patientId: string) {
-    return this.prisma.appointment.findMany({
-      where: { professionalId, patientId },
-      orderBy: { dateTime: 'desc' },
-    });
+  async findPatientAppointments(
+    professionalId: string,
+    patientId: string,
+    page: number,
+    limit: number,
+  ) {
+    const where: Prisma.AppointmentWhereInput = { professionalId, patientId };
+
+    const [appointments, total] = await Promise.all([
+      this.prisma.appointment.findMany({
+        where,
+        orderBy: { dateTime: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.appointment.count({ where }),
+    ]);
+
+    return { appointments, total };
   }
 
-  listAllProfessionals() {
-    return this.prisma.user.findMany({
-      where: { role: 'PROFESSIONAL' },
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        status: true,
-        professionalProfile: {
-          include: { specialities: true },
-        },
-        address: true,
+  async listAllProfessionals(page: number, limit: number) {
+    const where = { role: 'PROFESSIONAL' as const };
+    const select = {
+      id: true,
+      name: true,
+      email: true,
+      status: true,
+      professionalProfile: {
+        include: { specialities: true },
       },
-    });
+      address: true,
+    };
+
+    const [data, total] = await Promise.all([
+      this.prisma.user.findMany({
+        where,
+        select,
+        orderBy: { name: 'asc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.user.count({ where }),
+    ]);
+
+    return { data, total };
   }
 
   updateSettings(userId: string, dto: UpdateProfessionalSettingsDto) {

--- a/apps/server/src/professional/professional.service.spec.ts
+++ b/apps/server/src/professional/professional.service.spec.ts
@@ -12,7 +12,8 @@ describe('ProfessionalService', () => {
     findDailyAppointments: jest.fn(),
     findScheduleBlocksByDate: jest.fn(),
     countDistinctAttendedPatients: jest.fn(),
-    findAppointmentsWithPatients: jest.fn(),
+    findAttendedPatientsPage: jest.fn(),
+    findAppointmentsForPatients: jest.fn(),
     updateSettings: jest.fn(),
     findScheduleBlockById: jest.fn(),
     deleteScheduleBlock: jest.fn(),
@@ -99,62 +100,92 @@ describe('ProfessionalService', () => {
   });
 
   describe('getPatients aggregation', () => {
-    it('dedups patients and computes last/next visit correctly', async () => {
+    const pageQuery = { page: 1, limit: 10 } as any;
+
+    it('computes last/next visit per patient and returns { data, meta }', async () => {
       const now = Date.now();
       const past = new Date(now - 86400000); // ontem
       const future = new Date(now + 86400000); // amanhã
 
-      repository.findAppointmentsWithPatients.mockResolvedValue([
-        {
-          dateTime: past,
-          status: AppointmentStatus.COMPLETED,
-          patient: {
+      repository.findAttendedPatientsPage.mockResolvedValue({
+        patients: [
+          {
             id: 'pat-1',
             name: 'João',
             email: 'joao@x.com',
             cpf: null,
             patientProfile: { phone: '111' },
           },
-        },
+        ],
+        total: 1,
+      });
+      repository.findAppointmentsForPatients.mockResolvedValue([
         {
           dateTime: future,
           status: AppointmentStatus.CONFIRMED,
-          patient: {
-            id: 'pat-1',
-            name: 'João',
-            email: 'joao@x.com',
-            cpf: null,
-            patientProfile: { phone: '111' },
-          },
+          patientId: 'pat-1',
+        },
+        {
+          dateTime: past,
+          status: AppointmentStatus.COMPLETED,
+          patientId: 'pat-1',
         },
       ]);
 
-      const result = await service.getPatients('u-1');
+      const result = await service.getPatients('u-1', pageQuery);
 
-      expect(result).toHaveLength(1);
-      expect(result[0].lastVisit).toBe(past.toISOString());
-      expect(result[0].nextVisit).toBe(future.toISOString());
-      expect(result[0].phone).toBe('111');
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].lastVisit).toBe(past.toISOString());
+      expect(result.data[0].nextVisit).toBe(future.toISOString());
+      expect(result.data[0].phone).toBe('111');
+      expect(result.meta).toEqual({
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+      });
+      expect(repository.findAppointmentsForPatients).toHaveBeenCalledWith('u-1', [
+        'pat-1',
+      ]);
     });
 
     it('falls back to "Não informado" when phone is missing', async () => {
-      repository.findAppointmentsWithPatients.mockResolvedValue([
-        {
-          dateTime: new Date(Date.now() - 1000),
-          status: AppointmentStatus.COMPLETED,
-          patient: {
+      repository.findAttendedPatientsPage.mockResolvedValue({
+        patients: [
+          {
             id: 'pat-2',
             name: 'Maria',
             email: 'maria@x.com',
             cpf: null,
             patientProfile: null,
           },
+        ],
+        total: 1,
+      });
+      repository.findAppointmentsForPatients.mockResolvedValue([
+        {
+          dateTime: new Date(Date.now() - 1000),
+          status: AppointmentStatus.COMPLETED,
+          patientId: 'pat-2',
         },
       ]);
 
-      const result = await service.getPatients('u-1');
+      const result = await service.getPatients('u-1', pageQuery);
 
-      expect(result[0].phone).toBe('Não informado');
+      expect(result.data[0].phone).toBe('Não informado');
+    });
+
+    it('returns an empty page without querying appointments', async () => {
+      repository.findAttendedPatientsPage.mockResolvedValue({
+        patients: [],
+        total: 0,
+      });
+
+      const result = await service.getPatients('u-1', pageQuery);
+
+      expect(result.data).toEqual([]);
+      expect(result.meta.total).toBe(0);
+      expect(repository.findAppointmentsForPatients).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/professional/professional.service.ts
+++ b/apps/server/src/professional/professional.service.ts
@@ -12,6 +12,8 @@ import { MailService } from '../mail/mail.service';
 import { MEET_SERVICE } from '../common/interfaces/MeetEventInterfaces';
 import type { MeetService } from '../common/interfaces/MeetEventInterfaces';
 import { APPOINTMENT_DURATION_MINUTES } from '../appointments/appointment.constants';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { buildMeta } from '../common/dto/paginated-response.dto';
 
 @Injectable()
 export class ProfessionalService {
@@ -93,31 +95,30 @@ export class ProfessionalService {
     };
   }
 
-  async getPatients(userId: string) {
-    const appointments =
-      await this.repository.findAppointmentsWithPatients(userId);
+  async getPatients(userId: string, query: PaginationQueryDto) {
+    const { page, limit } = query;
+
+    const { patients, total } =
+      await this.repository.findAttendedPatientsPage(userId, page, limit);
+
+    if (patients.length === 0) {
+      return { data: [], meta: buildMeta(total, page, limit) };
+    }
+
+    const patientIds = patients.map((p) => p.id);
+    const appointments = await this.repository.findAppointmentsForPatients(
+      userId,
+      patientIds,
+    );
 
     const now = new Date();
-    const uniquePatients = new Map<
+    const visits = new Map<
       string,
-      {
-        id: string;
-        name: string;
-        email: string;
-        cpf: string | null;
-        phone: string;
-        lastVisit: string | null;
-        nextVisit: string | null;
-      }
+      { lastVisit: string | null; nextVisit: string | null }
     >();
 
     for (const appt of appointments) {
-      const existing = uniquePatients.get(appt.patient.id) ?? {
-        id: appt.patient.id,
-        name: appt.patient.name,
-        email: appt.patient.email,
-        cpf: appt.patient.cpf ?? null,
-        phone: appt.patient.patientProfile?.phone || 'Não informado',
+      const existing = visits.get(appt.patientId) ?? {
         lastVisit: null as string | null,
         nextVisit: null as string | null,
       };
@@ -143,23 +144,48 @@ export class ProfessionalService {
         }
       }
 
-      uniquePatients.set(appt.patient.id, existing);
+      visits.set(appt.patientId, existing);
     }
 
-    return Array.from(uniquePatients.values());
+    const data = patients.map((patient) => {
+      const patientVisits = visits.get(patient.id) ?? {
+        lastVisit: null,
+        nextVisit: null,
+      };
+
+      return {
+        id: patient.id,
+        name: patient.name,
+        email: patient.email,
+        cpf: patient.cpf ?? null,
+        phone: patient.patientProfile?.phone || 'Não informado',
+        lastVisit: patientVisits.lastVisit,
+        nextVisit: patientVisits.nextVisit,
+      };
+    });
+
+    return { data, meta: buildMeta(total, page, limit) };
   }
 
-  async getPatientDetail(professionalId: string, patientId: string) {
+  async getPatientDetail(
+    professionalId: string,
+    patientId: string,
+    query: PaginationQueryDto,
+  ) {
     const patient = await this.repository.findPatientSummary(patientId);
 
     if (!patient) {
       throw new NotFoundException('Paciente não encontrado');
     }
 
-    const appointments = await this.repository.findPatientAppointments(
-      professionalId,
-      patientId,
-    );
+    const { page, limit } = query;
+    const { appointments, total } =
+      await this.repository.findPatientAppointments(
+        professionalId,
+        patientId,
+        page,
+        limit,
+      );
 
     return {
       id: patient.id,
@@ -167,18 +193,26 @@ export class ProfessionalService {
       email: patient.email,
       cpf: patient.cpf ?? null,
       phone: patient.patientProfile?.phone || 'Não informado',
-      history: appointments.map((apt) => ({
-        id: apt.id,
-        dateTime: apt.dateTime,
-        status: apt.status,
-        modality: apt.modality,
-        notes: apt.notes,
-      })),
+      history: {
+        data: appointments.map((apt) => ({
+          id: apt.id,
+          dateTime: apt.dateTime,
+          status: apt.status,
+          modality: apt.modality,
+          notes: apt.notes,
+        })),
+        meta: buildMeta(total, page, limit),
+      },
     };
   }
 
-  async listAll() {
-    return this.repository.listAllProfessionals();
+  async listAll(query: PaginationQueryDto) {
+    const { page, limit } = query;
+    const { data, total } = await this.repository.listAllProfessionals(
+      page,
+      limit,
+    );
+    return { data, meta: buildMeta(total, page, limit) };
   }
 
   async updateSettings(userId: string, dto: UpdateProfessionalSettingsDto) {

--- a/apps/server/src/users/users.repository.ts
+++ b/apps/server/src/users/users.repository.ts
@@ -3,6 +3,7 @@ import { Prisma, UserRole } from '@prisma/client';
 import { ListAdminUsersQueryDto } from 'src/admin/dto/list-admin-users-query-dto';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { paginate } from '../common/dto/paginated-response.dto';
 
 @Injectable()
 export class UsersRepository {
@@ -137,23 +138,31 @@ export class UsersRepository {
   }
 
   findAllUsers(query: ListAdminUsersQueryDto) {
-    return this.prisma.user.findMany({
-      where: {
-        role: query.role ?? { in: ['PATIENT', 'PROFESSIONAL', 'MANAGER'] },
-        ...(query.status && { status: query.status }),
-        ...(query.search && {
-          OR: [
-            { name: { contains: query.search, mode: 'insensitive' } },
-            { email: { contains: query.search, mode: 'insensitive' } },
-          ],
-        }),
+    const where: Prisma.UserWhereInput = {
+      role: query.role ?? { in: ['PATIENT', 'PROFESSIONAL', 'MANAGER'] },
+      ...(query.status && { status: query.status }),
+      ...(query.search && {
+        OR: [
+          { name: { contains: query.search, mode: 'insensitive' } },
+          { email: { contains: query.search, mode: 'insensitive' } },
+        ],
+      }),
+    };
+
+    return paginate(
+      this.prisma.user,
+      {
+        where,
+        omit: { password: true },
+        include: {
+          patientProfile: true,
+          professionalProfile: { include: { specialities: true } },
+        },
+        orderBy: { [query.sortBy ?? 'name']: query.sortOrder ?? 'asc' },
       },
-      include: {
-        patientProfile: true,
-        professionalProfile: { include: { specialities: true } },
-      },
-      orderBy: { [query.sortBy ?? 'name']: query.sortOrder ?? 'asc' },
-    });
+      query.page,
+      query.limit,
+    );
   }
 
   findAllProfessionals() {

--- a/apps/web/app/dashboard/admin/components/UsersTable.tsx
+++ b/apps/web/app/dashboard/admin/components/UsersTable.tsx
@@ -15,12 +15,15 @@ import {
   DataTableHeader,
   DataTableMobileItem,
   DataTableMobileList,
+  DataTablePageSizeSelector,
+  DataTablePagination,
   DataTableRow,
   DataTableToolbar,
   SortableHeader,
 } from "@/components/ui/data-table";
 import { AdminUser } from "../../../../services/admin-service";
 import { useAdminUsersTable, TypeFilter } from "@/queries/useAdminUsersTable";
+import { usePagination } from "@/hooks/usePagination";
 import { useIsMobile, useMounted } from "@/hooks/useIsMobile";
 import { TableSkeleton } from "@/components/ui/skeletons";
 import { Eye, Check, Ban, Pencil, Users } from "lucide-react";
@@ -149,6 +152,11 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
     });
   }, [users, sortField, sortDir]);
 
+  const pagination = usePagination(sortedUsers, {
+    initialPageSize: 10,
+    resetKeys: [search, typeFilter, sortField, sortDir],
+  });
+
   const stopClick = (e: React.MouseEvent) => e.stopPropagation();
 
   return (
@@ -186,6 +194,13 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
             className="h-9 text-sm"
           />
         </div>
+        {sortedUsers.length > 0 && (
+          <DataTablePageSizeSelector
+            pageSize={pagination.pageSize}
+            onPageSizeChange={pagination.setPageSize}
+            className="ml-auto"
+          />
+        )}
       </DataTableToolbar>
       </div>
 
@@ -203,7 +218,7 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
         />
       ) : isMobile ? (
         <DataTableMobileList>
-          {sortedUsers.map((user) => {
+          {pagination.pageItems.map((user) => {
             const badge = TYPE_BADGE[user.role];
             const speciality = getSpeciality(user);
             return (
@@ -404,8 +419,7 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
             <DataTableHeadCell align="center">Ações</DataTableHeadCell>
           </DataTableHead>
           <DataTableBody>
-            {sortedUsers.map((user) => {
-              const badge = TYPE_BADGE[user.role];
+            {pagination.pageItems.map((user) => {
               const speciality = getSpeciality(user);
               return (
                 <DataTableRow
@@ -531,6 +545,20 @@ function UsersTableInner({ onStatusChange, actions }: Props) {
             })}
           </DataTableBody>
         </DataTable>
+      )}
+
+      {mounted && !isLoading && sortedUsers.length > 0 && (
+        <DataTablePagination
+          page={pagination.page}
+          totalPages={pagination.totalPages}
+          from={pagination.from}
+          to={pagination.to}
+          totalItems={pagination.totalItems}
+          hasPrev={pagination.hasPrev}
+          hasNext={pagination.hasNext}
+          onPageChange={pagination.setPage}
+          itemLabel="usuários"
+        />
       )}
       </div>
     </DataTableCard>

--- a/apps/web/app/dashboard/manager/appointments/new/page.tsx
+++ b/apps/web/app/dashboard/manager/appointments/new/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Spinner } from "@/components/ui/spinner";
-import { managerService } from "../../../../../services/manager-service";
-import { toast } from "sonner";
+import {
+  DataTablePageSizeSelector,
+  DataTablePagination,
+} from "@/components/ui/data-table";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { usePagination } from "@/hooks/usePagination";
 import { PageShell, PageHeader } from "../../../../ui/dashboard/page-shell";
 import { TourButton } from "@/components/tour/TourButton";
 import { SearchBar } from "../../../patient/search/components/SearchBar";
@@ -13,6 +16,7 @@ import { EmptySearch } from "../../../patient/search/components/EmptySearch";
 import { ProfessionalData, SeeProfileModal } from "../../../patient/search/components/SeeProfileModal";
 import { ManagerBookingModal } from "./components/ManagerBookingModal";
 import { useListPatientsQuery } from "@/queries/useListPatientsQuery";
+import { useProfessionalsQuery } from "@/queries/useProfessionalsQuery";
 import { AddressData } from "../../../patient/search/components/addressMaps";
 import {
   getAvailableLocations,
@@ -39,7 +43,7 @@ type Professional = {
 const NewApointmentPage = () => {
   const isMobile = useIsMobile();
   const { data: patients = [] } = useListPatientsQuery();
-  const [professionals, setProfessionals] = useState<Professional[]>([]);
+  const { data: professionals = [], isLoading } = useProfessionalsQuery();
   const [search, setSearch] = useState("");
   const [selectedSpecialty, setSelectedSpecialty] = useState("Todas");
   const [selectedLocation, setSelectedLocation] = useState("Todas");
@@ -47,22 +51,6 @@ const NewApointmentPage = () => {
     useState<Professional | null>(null);
   const [bookingProfessional, setBookingProfessional] =
     useState<Professional | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    const load = async () => {
-      try {
-        setIsLoading(true);
-        const data = await managerService.listProfessionals();
-        setProfessionals(data);
-      } catch {
-        toast.error("Erro ao carregar profissionais.");
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    load();
-  }, []);
 
   const visibleProfessionals = professionals.filter(
     (p) => p.status !== "PENDING" && p.status !== "BLOCKED",
@@ -72,30 +60,36 @@ const NewApointmentPage = () => {
     [professionals],
   );
 
-  const filtered = visibleProfessionals
-    .filter((p) => {
-      const term = search.toLowerCase();
-      const matchesSearch =
-        p.name.toLowerCase().includes(term) ||
-        (p.professionalProfile?.specialities?.[0]?.name || "").toLowerCase().includes(term);
+  const filtered = visibleProfessionals.filter((p) => {
+    const term = search.toLowerCase();
+    const matchesSearch =
+      p.name.toLowerCase().includes(term) ||
+      (p.professionalProfile?.specialities?.[0]?.name || "")
+        .toLowerCase()
+        .includes(term);
 
-      const matchesSpecialty =
-        selectedSpecialty === "Todas" ||
-        (p.professionalProfile?.specialities?.[0]?.name || "")
-          .toLowerCase()
-          .includes(selectedSpecialty.toLowerCase());
+    const matchesSpecialty =
+      selectedSpecialty === "Todas" ||
+      (p.professionalProfile?.specialities?.[0]?.name || "")
+        .toLowerCase()
+        .includes(selectedSpecialty.toLowerCase());
 
-      const matchesLocation =
-        selectedLocation === "Todas" ||
-        (p.address?.city && p.address?.state
-          ? getLocationValue({
-              city: p.address.city.trim(),
-              state: p.address.state.trim(),
-            }) === selectedLocation
-          : false);
+    const matchesLocation =
+      selectedLocation === "Todas" ||
+      (p.address?.city && p.address?.state
+        ? getLocationValue({
+            city: p.address.city.trim(),
+            state: p.address.state.trim(),
+          }) === selectedLocation
+        : false);
 
-      return matchesSearch && matchesSpecialty && matchesLocation;
-    });
+    return matchesSearch && matchesSpecialty && matchesLocation;
+  });
+
+  const pagination = usePagination(filtered, {
+    initialPageSize: 10,
+    resetKeys: [search, selectedSpecialty, selectedLocation],
+  });
 
   return (
     <PageShell>
@@ -126,18 +120,39 @@ const NewApointmentPage = () => {
       ) : filtered.length === 0 ? (
         <EmptySearch />
       ) : (
-        <div
-          className={`grid gap-4 ${isMobile ? "grid-cols-1" : "grid-cols-1 lg:grid-cols-2"}`}
-        >
-          {filtered.map((prof) => (
-            <DoctorCard
-              key={prof.id}
-              professional={prof}
-              onViewProfile={() => setSelectedProfessional(prof)}
-              onBook={() => setBookingProfessional(prof)}
+        <>
+          <div className="mb-4 flex justify-end">
+            <DataTablePageSizeSelector
+              pageSize={pagination.pageSize}
+              onPageSizeChange={pagination.setPageSize}
             />
-          ))}
-        </div>
+          </div>
+          <div
+            className={`grid gap-4 ${isMobile ? "grid-cols-1" : "grid-cols-1 lg:grid-cols-2"}`}
+          >
+            {pagination.pageItems.map((prof) => (
+              <DoctorCard
+                key={prof.id}
+                professional={prof}
+                onViewProfile={() => setSelectedProfessional(prof)}
+                onBook={() => setBookingProfessional(prof)}
+              />
+            ))}
+          </div>
+          <div className="mt-4 overflow-hidden rounded-xl border border-border bg-card">
+            <DataTablePagination
+              page={pagination.page}
+              totalPages={pagination.totalPages}
+              from={pagination.from}
+              to={pagination.to}
+              totalItems={pagination.totalItems}
+              hasPrev={pagination.hasPrev}
+              hasNext={pagination.hasNext}
+              onPageChange={pagination.setPage}
+              itemLabel="profissionais"
+            />
+          </div>
+        </>
       )}
       </div>
 

--- a/apps/web/app/dashboard/manager/patients/page.tsx
+++ b/apps/web/app/dashboard/manager/patients/page.tsx
@@ -25,6 +25,7 @@ import {
   DataTableHeadCell,
   DataTableMobileItem,
   DataTableMobileList,
+  DataTablePageSizeSelector,
   DataTablePagination,
   DataTableRow,
   SortableHeader,
@@ -242,6 +243,12 @@ export default function PatientsPage() {
             </span>
           </p>
         )}
+        <div className="mt-3 flex justify-end">
+          <DataTablePageSizeSelector
+            pageSize={pagination.pageSize}
+            onPageSizeChange={pagination.setPageSize}
+          />
+        </div>
       </div>
 
       <div id="tour-mgr-patients-table">
@@ -331,8 +338,6 @@ export default function PatientsPage() {
               hasPrev={pagination.hasPrev}
               hasNext={pagination.hasNext}
               onPageChange={pagination.setPage}
-              pageSize={pagination.pageSize}
-              onPageSizeChange={pagination.setPageSize}
               itemLabel="pacientes"
             />
           </DataTableCard>
@@ -463,8 +468,6 @@ export default function PatientsPage() {
               hasPrev={pagination.hasPrev}
               hasNext={pagination.hasNext}
               onPageChange={pagination.setPage}
-              pageSize={pagination.pageSize}
-              onPageSizeChange={pagination.setPageSize}
               itemLabel="pacientes"
             />
           </DataTableCard>

--- a/apps/web/app/dashboard/patient/appointments/components/AppointmentTabs.tsx
+++ b/apps/web/app/dashboard/patient/appointments/components/AppointmentTabs.tsx
@@ -1,27 +1,15 @@
-import { TABS, TabKey, Appointment } from "../appointments.types";
+import { TABS, TabKey } from "../appointments.types";
 
 type AppointmentTabsProps = {
   activeTab: TabKey;
-  appointments: Appointment[];
+  /** Total de consultas por aba (vindo do `meta.total` do servidor). */
+  counts: Record<TabKey, number>;
   onTabChange: (tab: TabKey) => void;
-};
-
-const getTabCount = (appointments: Appointment[], tab: TabKey) => {
-  switch (tab) {
-    case "upcoming":
-      return appointments.filter(
-        (a) => a.status === "CONFIRMED" || a.status === "PENDING",
-      ).length;
-    case "past":
-      return appointments.filter((a) => a.status === "COMPLETED").length;
-    case "cancelled":
-      return appointments.filter((a) => a.status === "CANCELLED").length;
-  }
 };
 
 export function AppointmentTabs({
   activeTab,
-  appointments,
+  counts,
   onTabChange,
 }: AppointmentTabsProps) {
   return (
@@ -45,7 +33,7 @@ export function AppointmentTabs({
                 : "ml-1.5 px-2 py-0.5 rounded-full bg-gray-100 text-xs font-semibold"
             }
           >
-            {getTabCount(appointments, tab.key)}
+            {counts[tab.key]}
           </span>
         </button>
       ))}

--- a/apps/web/app/dashboard/patient/appointments/page.tsx
+++ b/apps/web/app/dashboard/patient/appointments/page.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  DataTablePageSizeSelector,
+  DataTablePagination,
+} from "@/components/ui/data-table";
 import { CardGridSkeleton } from "@/components/ui/skeletons";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useServerPagination } from "@/hooks/useServerPagination";
 import { SearchIcon } from "../../../utils/icons";
 import { Appointment, TabKey } from "./appointments.types";
 import { AppointmentTabs } from "./components/AppointmentTabs";
@@ -14,10 +19,12 @@ import { EmptyAppointments } from "./components/EmptyAppointments";
 import { AppointmentDetailsModal } from "./components/AppointmentDetailsModal";
 import { patientsService } from "@/services/patients-service";
 import { CancelConfirmDialog } from "./components/CancelConfirmDialog";
+import { AppointmentResponse } from "@/services/appointments-service";
 import {
-  appointmentsService,
-  AppointmentResponse,
-} from "@/services/appointments-service";
+  useMyAppointmentsQuery,
+  useMyAppointmentsCounts,
+} from "@/queries/useMyAppointmentsQuery";
+import { useCancelAppointmentMutation } from "@/queries/useCancelAppointmentMutation";
 import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 import { TourButton } from "@/components/tour/TourButton";
 
@@ -37,57 +44,46 @@ function mapApiToAppointment(appt: AppointmentResponse): Appointment {
   };
 }
 
-const getFilteredAppointments = (appointments: Appointment[], tab: TabKey) => {
-  switch (tab) {
-    case "upcoming":
-      return appointments.filter(
-        (a) => a.status === "CONFIRMED" || a.status === "PENDING",
-      );
-    case "past":
-      return appointments.filter((a) => a.status === "COMPLETED");
-    case "cancelled":
-      return appointments.filter((a) => a.status === "CANCELLED");
-  }
+// Cada aba mapeia para os status que a compõem no servidor. "Próximas" combina
+// PENDING + CONFIRMED, por isso o backend aceita múltiplos status por vírgula.
+const TAB_STATUSES: Record<TabKey, string[]> = {
+  upcoming: ["PENDING", "CONFIRMED"],
+  past: ["COMPLETED"],
+  cancelled: ["CANCELLED"],
 };
 
 const AppointmentsPage = () => {
   const router = useRouter();
   const isMobile = useIsMobile();
   const [activeTab, setActiveTab] = useState<TabKey>("upcoming");
-  const [appointments, setAppointments] = useState<Appointment[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [isDownloadingReport, setIsDownloadingReport] = useState(false);
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
   const [appointmentToCancel, setAppointmentToCancel] = useState<string | null>(
     null,
   );
-  const [isCancelling, setIsCancelling] = useState(false);
   const [selectedAppointment, setSelectedAppointment] =
     useState<Appointment | null>(null);
   const [isDetailsModalOpen, setIsDetailsModalOpen] = useState(false);
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        setIsLoading(true);
-        const result = await appointmentsService.listMyAppointments({
-          limit: 100,
-        });
-        if (result) {
-          setAppointments(result.data.map(mapApiToAppointment));
-        }
-      } catch (error) {
-        const msg =
-          error instanceof Error
-            ? error.message
-            : "Erro ao carregar consultas.";
-        toast.error(msg);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    load();
-  }, []);
+  const { page, pageSize, resetToFirstPage, getPaginationProps } =
+    useServerPagination();
+
+  const { data, isLoading, isFetching } = useMyAppointmentsQuery({
+    status: TAB_STATUSES[activeTab],
+    page,
+    limit: pageSize,
+  });
+
+  const tabCounts = useMyAppointmentsCounts(TAB_STATUSES);
+
+  const cancelMutation = useCancelAppointmentMutation();
+  const isCancelling = cancelMutation.isPending;
+
+  function handleTabChange(tab: TabKey) {
+    setActiveTab(tab);
+    // A paginação é por aba (server-side), então voltamos à página 1 ao trocar.
+    resetToFirstPage();
+  }
 
   const handleCancelClick = (id: string) => {
     setAppointmentToCancel(id);
@@ -99,40 +95,32 @@ const AppointmentsPage = () => {
     setIsDetailsModalOpen(true);
   };
 
-  const confirmCancel = async (reason?: string) => {
+  const confirmCancel = (reason?: string) => {
     if (!appointmentToCancel) return;
 
-    try {
-      setIsCancelling(true);
-      await appointmentsService.cancel(appointmentToCancel, { reason });
-      setAppointments((prev) =>
-        prev.map((a) =>
-          a.id === appointmentToCancel
-            ? { ...a, status: "CANCELLED" as const }
-            : a,
-        ),
-      );
-      toast.success("Consulta cancelada com sucesso.");
-      setIsCancelModalOpen(false);
-    } catch (error) {
-      const msg =
-        error instanceof Error ? error.message : "Erro ao cancelar consulta.";
-      toast.error(msg);
-    } finally {
-      setIsCancelling(false);
-      setAppointmentToCancel(null);
-    }
+    cancelMutation.mutate(
+      { id: appointmentToCancel, data: { reason } },
+      {
+        onSuccess: () => {
+          toast.success("Consulta cancelada com sucesso.");
+          setIsCancelModalOpen(false);
+        },
+        onError: (error) => {
+          const msg =
+            error instanceof Error
+              ? error.message
+              : "Erro ao cancelar consulta.";
+          toast.error(msg);
+        },
+        onSettled: () => setAppointmentToCancel(null),
+      },
+    );
   };
 
-  const filtered = getFilteredAppointments(appointments, activeTab).sort(
-    (a, b) => {
-      const dateA = new Date(a.dateTime).getTime();
-      const dateB = new Date(b.dateTime).getTime();
-      return activeTab === "past" ? dateB - dateA : dateA - dateB;
-    },
-  );
+  const filtered = (data?.data ?? []).map(mapApiToAppointment);
+  const totalForTab = data?.meta.total ?? 0;
 
-  const hasReportData = filtered.length > 0;
+  const hasReportData = totalForTab > 0;
 
   const handleDownloadReport = async () => {
     try {
@@ -198,8 +186,8 @@ const AppointmentsPage = () => {
       <div id="tour-appt-tabs">
         <AppointmentTabs
           activeTab={activeTab}
-          appointments={appointments}
-          onTabChange={setActiveTab}
+          counts={tabCounts}
+          onTabChange={handleTabChange}
         />
       </div>
 
@@ -214,6 +202,12 @@ const AppointmentsPage = () => {
           >
             {isDownloadingReport ? "Gerando relatório..." : reportButtonLabel}
           </Button>
+        </div>
+      )}
+
+      {!isLoading && totalForTab > 0 && (
+        <div className="mb-4 flex justify-end">
+          <DataTablePageSizeSelector {...getPaginationProps(data?.meta)} />
         </div>
       )}
 
@@ -240,6 +234,16 @@ const AppointmentsPage = () => {
           </div>
         )}
       </div>
+
+      {!isLoading && totalForTab > 0 && (
+        <div className="mt-4 overflow-hidden rounded-xl border border-border bg-card">
+          <DataTablePagination
+            {...getPaginationProps(data?.meta)}
+            itemLabel="consultas"
+            busy={isFetching}
+          />
+        </div>
+      )}
 
       {isMobile && (
         <div className="mt-6">

--- a/apps/web/app/dashboard/patient/medical-records/page.tsx
+++ b/apps/web/app/dashboard/patient/medical-records/page.tsx
@@ -4,14 +4,12 @@ import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { CardGridSkeleton } from "@/components/ui/skeletons";
+import { Spinner } from "@/components/ui/spinner";
 import { Badge } from "@/components/ui/badge";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { useMedicalRecordsListForPatientQuery } from "@/queries/useMedicalRecords";
 import { CalendarIcon, EyeIcon } from "../../../utils/icons";
-import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 import { SearchInput } from "@/components/ui/search-input";
-import { TourButton } from "@/components/tour/TourButton";
-import { useIsMobile } from "@/hooks/useIsMobile";
 
 const PAGE_SIZE = 10;
 
@@ -50,7 +48,7 @@ const PatientMedicalRecordsPage = () => {
     useMedicalRecordsListForPatientQuery(params);
 
   const records = data?.data ?? [];
-  const total = data?.total ?? 0;
+  const total = data?.meta.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const handleSearch = (e: React.FormEvent) => {
@@ -62,17 +60,24 @@ const PatientMedicalRecordsPage = () => {
   const hasFilters = Boolean(search);
 
   return (
-    <PageShell>
-      <PageHeader
-        title="Meus Prontuários"
-        description={`Histórico dos prontuários das suas consultas.${total > 0 ? ` ${total} no total.` : ""}`}
-        help={<TourButton tour="patient-records" iconOnly={isMobile} />}
-      />
+    <section
+      className={`w-full min-h-screen mx-auto bg-[#f8fafc] ${isMobile ? "px-4 py-5" : "px-16 py-8"}`}
+    >
+      <div className="mb-8">
+        <h1
+          className={`font-bold text-gray-900 tracking-tight ${isMobile ? "text-2xl" : "text-4xl"}`}
+        >
+          Meus Prontuários
+        </h1>
+        <p
+          className={`mt-1 text-gray-500 ${isMobile ? "text-sm" : "text-base"}`}
+        >
+          Histórico dos prontuários das suas consultas.
+          {total > 0 && ` ${total} no total.`}
+        </p>
+      </div>
 
-      <Card
-        id="tour-records-search"
-        className="mb-6 border border-gray-200 rounded-xl bg-white"
-      >
+      <Card className="mb-6 border border-gray-200 rounded-xl bg-white">
         <CardContent className="p-4 sm:p-5">
           <form
             onSubmit={handleSearch}
@@ -109,9 +114,10 @@ const PatientMedicalRecordsPage = () => {
         </CardContent>
       </Card>
 
-      <div id="tour-records-list">
       {isLoading ? (
-        <CardGridSkeleton count={4} minWidth={400} />
+        <div className="py-16 flex justify-center">
+          <Spinner size="lg" />
+        </div>
       ) : records.length === 0 ? (
         <Card className="border border-dashed border-gray-300 rounded-xl bg-white">
           <CardContent className="py-16 text-center flex flex-col items-center gap-3">
@@ -184,7 +190,6 @@ const PatientMedicalRecordsPage = () => {
           ))}
         </div>
       )}
-      </div>
 
       {totalPages > 1 && (
         <div className="mt-6 flex items-center justify-between gap-3">
@@ -211,7 +216,7 @@ const PatientMedicalRecordsPage = () => {
           </div>
         </div>
       )}
-    </PageShell>
+    </section>
   );
 };
 

--- a/apps/web/app/dashboard/professional/medical-records/page.tsx
+++ b/apps/web/app/dashboard/professional/medical-records/page.tsx
@@ -5,19 +5,22 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  DataTablePageSizeSelector,
+  DataTablePagination,
+} from "@/components/ui/data-table";
 import { CardGridSkeleton } from "@/components/ui/skeletons";
 import { Badge } from "@/components/ui/badge";
 import {
   useMedicalRecordsListQuery,
   useSharedMedicalRecordsQuery,
 } from "@/queries/useMedicalRecords";
+import { useServerPagination } from "@/hooks/useServerPagination";
 import { SearchInput } from "@/components/ui/search-input";
 import { CalendarIcon, EyeIcon, UsersIcon } from "../../../utils/icons";
 import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 import { TourButton } from "@/components/tour/TourButton";
 import type { MedicalRecordResponse } from "@/services/medical-records-service";
-
-const PAGE_SIZE = 10;
 
 type ViewMode = "mine" | "shared";
 
@@ -46,29 +49,27 @@ function MyRecordsView() {
   const [searchInput, setSearchInput] = useState(initialSearch);
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
-  const [page, setPage] = useState(1);
+  const { queryParams, resetToFirstPage, getPaginationProps } =
+    useServerPagination({ syncUrl: true, paramPrefix: "mine_" });
 
   const params = useMemo(
     () => ({
-      page,
-      limit: PAGE_SIZE,
+      ...queryParams,
       ...(search && { search }),
       ...(startDate && { startDate }),
       ...(endDate && { endDate }),
     }),
-    [page, search, startDate, endDate],
+    [queryParams, search, startDate, endDate],
   );
 
   const { data, isLoading, isFetching } = useMedicalRecordsListQuery(params);
 
   const records = data?.data ?? [];
-  const total = data?.total ?? 0;
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     setSearch(searchInput.trim());
-    setPage(1);
+    resetToFirstPage();
   };
 
   const handleClearFilters = () => {
@@ -76,7 +77,7 @@ function MyRecordsView() {
     setSearch("");
     setStartDate("");
     setEndDate("");
-    setPage(1);
+    resetToFirstPage();
   };
 
   const hasFilters = Boolean(search || startDate || endDate);
@@ -101,7 +102,7 @@ function MyRecordsView() {
               <Input
                 type="date"
                 value={startDate}
-                onChange={(e) => { setStartDate(e.target.value); setPage(1); }}
+                onChange={(e) => { setStartDate(e.target.value); resetToFirstPage(); }}
                 className="w-full sm:w-44"
               />
             </div>
@@ -110,7 +111,7 @@ function MyRecordsView() {
               <Input
                 type="date"
                 value={endDate}
-                onChange={(e) => { setEndDate(e.target.value); setPage(1); }}
+                onChange={(e) => { setEndDate(e.target.value); resetToFirstPage(); }}
                 className="w-full sm:w-44"
               />
             </div>
@@ -125,6 +126,12 @@ function MyRecordsView() {
           </form>
         </CardContent>
       </Card>
+
+      {!isLoading && records.length > 0 && (
+        <div className="mb-4 flex justify-end">
+          <DataTablePageSizeSelector {...getPaginationProps(data?.meta)} />
+        </div>
+      )}
 
       {isLoading ? (
         <CardGridSkeleton count={4} minWidth={400} />
@@ -142,15 +149,13 @@ function MyRecordsView() {
         </div>
       )}
 
-      {totalPages > 1 && (
-        <div className="mt-6 flex items-center justify-between gap-3">
-          <p className="text-xs text-slate-500">Página {page} de {totalPages}</p>
-          <div className="flex gap-2">
-            <Button variant="outline" size="sm" disabled={page <= 1 || isFetching}
-              onClick={() => setPage((p) => Math.max(1, p - 1))}>Anterior</Button>
-            <Button variant="outline" size="sm" disabled={page >= totalPages || isFetching}
-              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}>Próxima</Button>
-          </div>
+      {records.length > 0 && (
+        <div className="mt-4 overflow-hidden rounded-xl border border-border bg-card">
+          <DataTablePagination
+            {...getPaginationProps(data?.meta)}
+            itemLabel="prontuários"
+            busy={isFetching}
+          />
         </div>
       )}
     </>
@@ -161,22 +166,21 @@ function MyRecordsView() {
 function SharedRecordsView() {
   const router = useRouter();
   const [search, setSearch] = useState("");
-  const [page, setPage] = useState(1);
+  const { queryParams, resetToFirstPage, getPaginationProps } =
+    useServerPagination({ syncUrl: true, paramPrefix: "shared_" });
 
   const params = useMemo(
-    () => ({ page, limit: PAGE_SIZE, ...(search && { search }) }),
-    [page, search],
+    () => ({ ...queryParams, ...(search && { search }) }),
+    [queryParams, search],
   );
 
   const { data, isLoading, isFetching } = useSharedMedicalRecordsQuery(params);
 
   const records = (data?.data ?? []) as MedicalRecordResponse[];
-  const total = data?.total ?? 0;
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    setPage(1);
+    resetToFirstPage();
   };
 
   return (
@@ -186,13 +190,19 @@ function SharedRecordsView() {
           <form onSubmit={handleSearch} className="flex gap-3">
             <SearchInput
               value={search}
-              onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+              onChange={(e) => { setSearch(e.target.value); resetToFirstPage(); }}
               placeholder="Buscar por paciente, profissional, queixa ou diagnóstico…"
               className="flex-1"
             />
           </form>
         </CardContent>
       </Card>
+
+      {!isLoading && records.length > 0 && (
+        <div className="mb-4 flex justify-end">
+          <DataTablePageSizeSelector {...getPaginationProps(data?.meta)} />
+        </div>
+      )}
 
       {isLoading ? (
         <CardGridSkeleton count={4} minWidth={400} />
@@ -213,15 +223,13 @@ function SharedRecordsView() {
         </div>
       )}
 
-      {totalPages > 1 && (
-        <div className="mt-6 flex items-center justify-between gap-3">
-          <p className="text-xs text-slate-500">Página {page} de {totalPages}</p>
-          <div className="flex gap-2">
-            <Button variant="outline" size="sm" disabled={page <= 1 || isFetching}
-              onClick={() => setPage((p) => Math.max(1, p - 1))}>Anterior</Button>
-            <Button variant="outline" size="sm" disabled={page >= totalPages || isFetching}
-              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}>Próxima</Button>
-          </div>
+      {records.length > 0 && (
+        <div className="mt-4 overflow-hidden rounded-xl border border-border bg-card">
+          <DataTablePagination
+            {...getPaginationProps(data?.meta)}
+            itemLabel="prontuários"
+            busy={isFetching}
+          />
         </div>
       )}
     </>

--- a/apps/web/app/dashboard/professional/page.tsx
+++ b/apps/web/app/dashboard/professional/page.tsx
@@ -15,6 +15,8 @@ import {
   UsersIcon,
   XIcon,
   VideoIcon,
+  HouseIcon,
+  BuildingsIcon,
   UserCheckIcon,
   XCircleIcon,
 } from "../../utils/icons";
@@ -28,14 +30,70 @@ import {
 import { ConfirmModal } from "./schedule/components/ConfirmModal";
 import { PageShell, PageHeader } from "../../ui/dashboard/page-shell";
 import { TourButton } from "@/components/tour/TourButton";
-import { ModalityBadge } from "./components/ModalityBadge";
-import { STATUS_META } from "./components/appointment-meta";
-import type {
-  AppointmentResponse,
-  AppointmentStatus,
-} from "@/services/appointments-service";
 
-type Appointment = AppointmentResponse;
+type AppointmentStatus =
+  | "PENDING"
+  | "CONFIRMED"
+  | "CANCELLED"
+  | "COMPLETED"
+  | "NO_SHOW";
+
+type Modality = "VIRTUAL" | "HOME_VISIT" | "CLINIC";
+
+type Appointment = {
+  id: string;
+  dateTime: string;
+  status: AppointmentStatus;
+  modality?: Modality;
+  notes?: string;
+  meetLink?: string | null;
+  patient: { id: string; name: string; email?: string; phone?: string | null };
+};
+
+const STATUS_META: Record<
+  AppointmentStatus,
+  { label: string; className: string }
+> = {
+  PENDING: {
+    label: "Pendente",
+    className: "bg-amber-50 text-amber-700 border border-amber-200",
+  },
+  CONFIRMED: {
+    label: "Confirmado",
+    className: "bg-blue-50 text-blue-700 border border-blue-200",
+  },
+  COMPLETED: {
+    label: "Atendido",
+    className: "bg-emerald-50 text-emerald-700 border border-emerald-200",
+  },
+  NO_SHOW: {
+    label: "Faltou",
+    className: "bg-orange-50 text-orange-700 border border-orange-200",
+  },
+  CANCELLED: {
+    label: "Cancelado",
+    className: "bg-red-50 text-red-600 border border-red-200",
+  },
+};
+
+const MODALITY_META: Record<
+  Modality,
+  { label: string; icon: React.ReactNode }
+> = {
+  VIRTUAL: { label: "Online", icon: <VideoIcon size={14} /> },
+  HOME_VISIT: { label: "Domiciliar", icon: <HouseIcon size={14} /> },
+  CLINIC: { label: "Presencial", icon: <BuildingsIcon size={14} /> },
+};
+
+function ModalityBadge({ modality }: { modality?: Modality }) {
+  const meta = modality ? MODALITY_META[modality] : MODALITY_META.VIRTUAL;
+  return (
+    <Badge className="flex items-center gap-1 px-2 py-0.5 rounded text-xs font-semibold bg-slate-100 text-slate-600 border border-slate-200">
+      {meta.icon}
+      {meta.label}
+    </Badge>
+  );
+}
 
 const ProfessionalDashboard = () => {
   const router = useRouter();
@@ -93,7 +151,7 @@ const ProfessionalDashboard = () => {
     }, [scheduleData]);
 
   const pendingRequests = (pendingData?.data || []) as Appointment[];
-  const pendingTotal = pendingData?.total ?? 0;
+  const pendingTotal = pendingData?.meta.total ?? 0;
 
   const formatTime = (isoString: string) =>
     new Date(isoString).toLocaleTimeString("pt-BR", {
@@ -318,7 +376,7 @@ const ProfessionalDashboard = () => {
                         </div>
                         <div className="flex items-center gap-2 shrink-0">
                           <Badge
-                            className={`px-2 py-1 rounded-3xl text-xs font-semibold ${meta.badgeClassName}`}
+                            className={`px-2 py-1 rounded-3xl text-xs font-semibold ${meta.className}`}
                           >
                             {meta.label}
                           </Badge>
@@ -366,23 +424,14 @@ const ProfessionalDashboard = () => {
 
         {/* Solicitações */}
         <div id="tour-prof-requests" className="flex flex-col gap-4">
-          <div className="mb-2 flex justify-between items-center gap-2">
-            <h2 className="flex items-center gap-2 text-lg font-semibold text-gray-700 min-w-0">
-              <span className="truncate">Solicitações</span>
-              {pendingTotal > 0 && (
-                <Badge className="px-2 py-1 rounded-3xl text-xs font-semibold bg-yellow-100 text-yellow-700 shrink-0">
-                  {pendingTotal} Novas
-                </Badge>
-              )}
+          <div className="mb-2 flex justify-between items-center">
+            <h2 className="flex items-center gap-2 text-lg font-semibold text-gray-700">
+              Solicitações
             </h2>
-            {pendingTotal > pendingRequests.length && (
-              <Link
-                href="/dashboard/professional/requests"
-                title="Ver todas as solicitações pendentes"
-                className="text-xs font-medium text-[#006fee] hover:text-[#0058c2] shrink-0 whitespace-nowrap"
-              >
-                Ver todas
-              </Link>
+            {pendingTotal > 0 && (
+              <Badge className="px-2 py-1 rounded-3xl text-xs font-semibold bg-yellow-100 text-yellow-700">
+                {pendingTotal} Novas
+              </Badge>
             )}
           </div>
           <div className="flex flex-col gap-3">
@@ -440,6 +489,15 @@ const ProfessionalDashboard = () => {
               ))
             )}
           </div>
+          {pendingTotal > pendingRequests.length && (
+            <Link
+              href="/dashboard/professional/requests"
+              title="Ver todas as solicitações pendentes"
+              className="text-sm font-medium text-[#006fee] hover:underline self-end"
+            >
+              Ver todas
+            </Link>
+          )}
           <Card className="mt-4 border border-[#cce7ff] rounded-lg bg-[#f0f9ff]">
             <CardContent>
               <h4 className="text-lg font-semibold text-gray-700">

--- a/apps/web/app/dashboard/professional/requests/page.tsx
+++ b/apps/web/app/dashboard/professional/requests/page.tsx
@@ -3,6 +3,10 @@
 import React, { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  DataTablePageSizeSelector,
+  DataTablePagination,
+} from "@/components/ui/data-table";
 import { Spinner } from "@/components/ui/spinner";
 import { toast } from "sonner";
 import { format } from "date-fns";
@@ -11,6 +15,7 @@ import {
   useProfessionalAppointmentsQuery,
   useUpdateAppointmentStatusMutation,
 } from "@/queries/useProfessionalAppointments";
+import { useServerPagination } from "@/hooks/useServerPagination";
 import { ConfirmModal } from "../schedule/components/ConfirmModal";
 import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 import { ModalityBadge } from "../components/ModalityBadge";
@@ -21,21 +26,22 @@ import type {
 
 type PendingAppointment = AppointmentResponse & { status: "PENDING" };
 
-const PAGE_SIZE = 20;
-
 const PendingRequestsPage = () => {
-  const [page, setPage] = useState(1);
+  const { queryParams, getPaginationProps } = useServerPagination({
+    initialPageSize: 20,
+    syncUrl: true,
+  });
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState<{
     id: string;
     status: AppointmentStatus;
   } | null>(null);
 
-  const { data, isLoading, isError } = useProfessionalAppointmentsQuery({
-    status: "PENDING",
-    page,
-    limit: PAGE_SIZE,
-  });
+  const { data, isLoading, isError, isFetching } =
+    useProfessionalAppointmentsQuery({
+      status: "PENDING",
+      ...queryParams,
+    });
 
   const { mutate: updateStatus, isPending: isUpdating } =
     useUpdateAppointmentStatusMutation();
@@ -45,8 +51,6 @@ const PendingRequestsPage = () => {
   }, [isError]);
 
   const requests = (data?.data || []) as PendingAppointment[];
-  const total = data?.total ?? 0;
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const formatFullDateTime = (isoString: string) =>
     format(new Date(isoString), "dd/MM 'às' HH:mm");
@@ -75,6 +79,12 @@ const PendingRequestsPage = () => {
         title="Solicitações Pendentes"
         description="Todas as consultas aguardando sua confirmação, ordenadas por data."
       />
+
+      {!isLoading && requests.length > 0 && (
+        <div className="mb-4 flex justify-end">
+          <DataTablePageSizeSelector {...getPaginationProps(data?.meta)} />
+        </div>
+      )}
 
       {isLoading ? (
         <div className="flex justify-center py-16">
@@ -135,29 +145,13 @@ const PendingRequestsPage = () => {
         </div>
       )}
 
-      {totalPages > 1 && (
-        <div className="mt-6 flex items-center justify-between gap-3">
-          <p className="text-xs text-slate-500">
-            Página {page} de {totalPages}
-          </p>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page <= 1}
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-            >
-              Anterior
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page >= totalPages}
-              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-            >
-              Próxima
-            </Button>
-          </div>
+      {requests.length > 0 && (
+        <div className="mt-4 overflow-hidden rounded-xl border border-border bg-card">
+          <DataTablePagination
+            {...getPaginationProps(data?.meta)}
+            itemLabel="solicitações"
+            busy={isFetching}
+          />
         </div>
       )}
 

--- a/apps/web/components/appointments/ManagementAppointmentsView.tsx
+++ b/apps/web/components/appointments/ManagementAppointmentsView.tsx
@@ -29,6 +29,7 @@ import {
   DataTableHeadCell,
   DataTableMobileItem,
   DataTableMobileList,
+  DataTablePageSizeSelector,
   DataTablePagination,
   DataTableRow,
   SortableHeader,
@@ -155,8 +156,6 @@ export function ManagementAppointmentsView({
       hasPrev={pagination.hasPrev}
       hasNext={pagination.hasNext}
       onPageChange={pagination.setPage}
-      pageSize={pagination.pageSize}
-      onPageSizeChange={pagination.setPageSize}
       itemLabel="consultas"
     />
   );
@@ -327,6 +326,11 @@ export function ManagementAppointmentsView({
                   {scoreSortIcon}
                 </button>
               )}
+              <DataTablePageSizeSelector
+                pageSize={pagination.pageSize}
+                onPageSizeChange={pagination.setPageSize}
+                className="h-10 sm:ml-1"
+              />
             </div>
           </div>
 

--- a/apps/web/components/ui/data-table.tsx
+++ b/apps/web/components/ui/data-table.tsx
@@ -284,21 +284,13 @@ export function DataTableMobileItem({
 
 const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 
-export function DataTablePagination({
-  page,
-  totalPages,
-  from,
-  to,
-  totalItems,
-  hasPrev,
-  hasNext,
-  onPageChange,
-  pageSize,
-  onPageSizeChange,
-  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
-  itemLabel = "itens",
-  className,
-}: {
+/**
+ * Props compartilhadas entre o seletor "Por página" (topo) e o rodapé de
+ * paginação. Vêm do mesmo lugar — `getPaginationProps(meta)` do
+ * `useServerPagination` ou do `usePagination` — então cada peça pega o que
+ * precisa e ignora o resto (o spread `{...props}` funciona nos dois).
+ */
+type PaginationCoreProps = {
   page: number;
   totalPages: number;
   from: number;
@@ -312,12 +304,81 @@ export function DataTablePagination({
   pageSizeOptions?: number[];
   itemLabel?: string;
   className?: string;
-}) {
-  const showPageSize =
-    typeof pageSize === "number" && typeof onPageSizeChange === "function";
+};
 
-  // Nada para mostrar: sem múltiplas páginas e sem seletor de tamanho.
-  if (totalPages <= 1 && !showPageSize) return null;
+/**
+ * Seletor "Por página", pensado para ficar no TOPO da tela (perto do título /
+ * busca / filtros), separado do rodapé. Renderiza `null` quando não há como
+ * trocar o tamanho da página (sem `onPageSizeChange`). Aceita o mesmo objeto de
+ * props do rodapé — os campos extras são ignorados.
+ */
+export function DataTablePageSizeSelector({
+  pageSize,
+  onPageSizeChange,
+  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
+  className,
+}: Pick<
+  PaginationCoreProps,
+  "pageSize" | "onPageSizeChange" | "pageSizeOptions" | "className"
+>) {
+  if (typeof pageSize !== "number" || typeof onPageSizeChange !== "function") {
+    return null;
+  }
+
+  return (
+    <label
+      className={cn(
+        "flex items-center gap-2 text-xs text-muted-foreground",
+        className,
+      )}
+    >
+      <span className="whitespace-nowrap">Por página</span>
+      <select
+        value={pageSize}
+        onChange={(event) => onPageSizeChange(Number(event.target.value))}
+        aria-label="Itens por página"
+        className="h-9 rounded-lg border border-border bg-card px-2 text-xs font-medium text-foreground transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-sky-500"
+      >
+        {pageSizeOptions.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+/**
+ * Rodapé de paginação: contador "Mostrando X–Y de N" + botões Anterior/Próxima.
+ * O seletor "Por página" foi movido para `DataTablePageSizeSelector` (topo da
+ * tela) — este componente NÃO renderiza mais o seletor.
+ */
+export function DataTablePagination({
+  page,
+  totalPages,
+  from,
+  to,
+  totalItems,
+  hasPrev,
+  hasNext,
+  onPageChange,
+  itemLabel = "itens",
+  busy = false,
+  className,
+}: Omit<
+  PaginationCoreProps,
+  "pageSize" | "onPageSizeChange" | "pageSizeOptions"
+> & {
+  /**
+   * Fetch em andamento (paginação server-side). Desabilita prev/próxima para
+   * evitar cliques duplos disparando requests sobrepostos. Sem efeito na
+   * paginação client-side, onde a troca de página é síncrona.
+   */
+  busy?: boolean;
+}) {
+  // Sem múltiplas páginas não há nada para mostrar no rodapé.
+  if (totalPages <= 1) return null;
 
   return (
     <div
@@ -326,67 +387,45 @@ export function DataTablePagination({
         className,
       )}
     >
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
-        <p className="text-xs text-muted-foreground">
-          Mostrando{" "}
-          <span className="font-medium text-foreground">
-            {from}–{to}
-          </span>{" "}
-          de <span className="font-medium text-foreground">{totalItems}</span>{" "}
-          {itemLabel}
-        </p>
+      <p className="text-xs text-muted-foreground">
+        Mostrando{" "}
+        <span className="font-medium text-foreground">
+          {from}–{to}
+        </span>{" "}
+        de <span className="font-medium text-foreground">{totalItems}</span>{" "}
+        {itemLabel}
+      </p>
 
-        {showPageSize && (
-          <label className="flex items-center gap-2 text-xs text-muted-foreground">
-            <span>Por página</span>
-            <select
-              value={pageSize}
-              onChange={(event) => onPageSizeChange(Number(event.target.value))}
-              aria-label="Itens por página"
-              className="h-8 rounded-lg border border-border bg-card px-2 text-xs font-medium text-foreground transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-sky-500"
-            >
-              {pageSizeOptions.map((option) => (
-                <option key={option} value={option}>
-                  {option}
-                </option>
-              ))}
-            </select>
-          </label>
-        )}
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={() => onPageChange(page - 1)}
+          disabled={!hasPrev || busy}
+          title="Página anterior"
+          aria-label="Página anterior"
+          className="inline-flex h-8 items-center gap-1 rounded-lg border border-border bg-card px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          <span className="hidden sm:inline">Anterior</span>
+        </button>
+
+        <span className="px-3 text-xs text-muted-foreground">
+          Página <span className="font-medium text-foreground">{page}</span> de{" "}
+          <span className="font-medium text-foreground">{totalPages}</span>
+        </span>
+
+        <button
+          type="button"
+          onClick={() => onPageChange(page + 1)}
+          disabled={!hasNext || busy}
+          title="Próxima página"
+          aria-label="Próxima página"
+          className="inline-flex h-8 items-center gap-1 rounded-lg border border-border bg-card px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <span className="hidden sm:inline">Próxima</span>
+          <ChevronRight className="h-4 w-4" />
+        </button>
       </div>
-
-      {totalPages > 1 && (
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => onPageChange(page - 1)}
-            disabled={!hasPrev}
-            title="Página anterior"
-            aria-label="Página anterior"
-            className="inline-flex h-8 items-center gap-1 rounded-lg border border-border bg-card px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            <ChevronLeft className="h-4 w-4" />
-            <span className="hidden sm:inline">Anterior</span>
-          </button>
-
-          <span className="px-3 text-xs text-muted-foreground">
-            Página <span className="font-medium text-foreground">{page}</span> de{" "}
-            <span className="font-medium text-foreground">{totalPages}</span>
-          </span>
-
-          <button
-            type="button"
-            onClick={() => onPageChange(page + 1)}
-            disabled={!hasNext}
-            title="Próxima página"
-            aria-label="Próxima página"
-            className="inline-flex h-8 items-center gap-1 rounded-lg border border-border bg-card px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            <span className="hidden sm:inline">Próxima</span>
-            <ChevronRight className="h-4 w-4" />
-          </button>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/hooks/useServerPagination.ts
+++ b/apps/web/hooks/useServerPagination.ts
@@ -1,0 +1,125 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import {
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  type PaginationMeta,
+} from "@/lib/pagination";
+
+type UseServerPaginationOptions = {
+  initialPageSize?: number;
+  /**
+   * Sincroniza `page`/`limit` na URL (?page=&limit=). Use em telas de listagem
+   * cheias, para que a página sobreviva a refresh/voltar. Deixe `false` em
+   * abas/toggles internos que já disputam a query string.
+   */
+  syncUrl?: boolean;
+  /** Prefixo dos params na URL, para telas com mais de uma lista paginada. */
+  paramPrefix?: string;
+};
+
+/**
+ * Estado de paginação server-side: controla `page`/`limit` e, junto com o
+ * `meta` devolvido pela API, entrega exatamente as props que
+ * `DataTablePagination` espera (from/to/hasPrev/hasNext). Não faz fetch — o
+ * `page`/`limit` alimentam a query (TanStack) e o `meta` da resposta volta pra
+ * `getPaginationProps`.
+ */
+export function useServerPagination({
+  initialPageSize = DEFAULT_PAGE_SIZE,
+  syncUrl = false,
+  paramPrefix = "",
+}: UseServerPaginationOptions = {}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const pageKey = `${paramPrefix}page`;
+  const limitKey = `${paramPrefix}limit`;
+
+  const urlPage = Number(searchParams.get(pageKey));
+  const urlLimit = Number(searchParams.get(limitKey));
+
+  const [localPage, setLocalPage] = useState(1);
+  const [localPageSize, setLocalPageSize] = useState(initialPageSize);
+
+  const page = syncUrl && urlPage >= 1 ? urlPage : localPage;
+  const rawLimit = syncUrl && urlLimit >= 1 ? urlLimit : localPageSize;
+  const pageSize = Math.min(rawLimit, MAX_PAGE_SIZE);
+
+  function writeUrl(next: { page?: number; limit?: number }) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next.page !== undefined) params.set(pageKey, String(next.page));
+    if (next.limit !== undefined) params.set(limitKey, String(next.limit));
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  }
+
+  function setPage(nextPage: number) {
+    if (syncUrl) {
+      writeUrl({ page: nextPage });
+    } else {
+      setLocalPage(nextPage);
+    }
+  }
+
+  function setPageSize(nextSize: number) {
+    // Trocar o tamanho da página sempre volta para a primeira página, senão o
+    // usuário pode cair numa página inexistente.
+    if (syncUrl) {
+      writeUrl({ page: 1, limit: nextSize });
+    } else {
+      setLocalPageSize(nextSize);
+      setLocalPage(1);
+    }
+  }
+
+  /**
+   * Reinicia para a página 1. Chame quando um filtro/busca muda (o número de
+   * páginas encolhe e a página atual pode deixar de existir).
+   */
+  function resetToFirstPage() {
+    setPage(1);
+  }
+
+  /**
+   * Traduz o `meta` da API nas props do componente `DataTablePagination`.
+   * Passe direto: `<DataTablePagination {...getPaginationProps(data?.meta)} />`.
+   */
+  function getPaginationProps(meta: PaginationMeta | undefined) {
+    const total = meta?.total ?? 0;
+    const totalPages = meta?.totalPages ?? 1;
+    const from = total === 0 ? 0 : (page - 1) * pageSize + 1;
+    const to = Math.min(page * pageSize, total);
+
+    return {
+      page,
+      totalPages,
+      from,
+      to,
+      totalItems: total,
+      hasPrev: page > 1,
+      hasNext: page < totalPages,
+      onPageChange: setPage,
+      pageSize,
+      onPageSizeChange: setPageSize,
+    };
+  }
+
+  const queryParams = useMemo(
+    () => ({ page, limit: pageSize }),
+    [page, pageSize],
+  );
+
+  return {
+    page,
+    pageSize,
+    setPage,
+    setPageSize,
+    resetToFirstPage,
+    /** `{ page, limit }` pronto para espalhar nos params da query. */
+    queryParams,
+    getPaginationProps,
+  };
+}

--- a/apps/web/lib/pagination.ts
+++ b/apps/web/lib/pagination.ts
@@ -1,0 +1,43 @@
+/**
+ * Contrato padrão de paginação server-side.
+ *
+ * Todo endpoint paginado da API responde com este envelope:
+ *
+ *   { data: T[], meta: { page, limit, total, totalPages } }
+ *
+ * `totalPages` é sempre >= 1 (mesmo com `total = 0`), então nunca precisamos
+ * recalcular `Math.ceil(total / limit)` no front — basta ler de `meta`.
+ */
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface Paginated<T> {
+  data: T[];
+  meta: PaginationMeta;
+}
+
+export interface PaginationParams {
+  page?: number;
+  limit?: number;
+}
+
+/** Opções de tamanho de página padrão em toda a aplicação (máx. 100 na API). */
+export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
+
+export const DEFAULT_PAGE_SIZE = 10;
+
+/**
+ * Limite máximo aceito pela API (ver list-*-query.dto.ts no server). Usado por
+ * telas que ainda filtram/ordenam a lista inteira no cliente e precisam puxar o
+ * máximo de registros de uma vez, sem paginação real.
+ */
+export const MAX_PAGE_SIZE = 100;
+
+/** Envelope vazio, útil como fallback enquanto a query carrega. */
+export function emptyPage<T>(limit: number = DEFAULT_PAGE_SIZE): Paginated<T> {
+  return { data: [], meta: { page: 1, limit, total: 0, totalPages: 1 } };
+}

--- a/apps/web/queries/useCancelAppointmentMutation.ts
+++ b/apps/web/queries/useCancelAppointmentMutation.ts
@@ -1,8 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   appointmentsService,
-  AppointmentListResponse,
-  AppointmentResponse,
   CancelAppointmentDto,
 } from "../services/appointments-service";
 
@@ -16,16 +14,11 @@ export function useCancelAppointmentMutation() {
     onSuccess: (updated) => {
       if (!updated) return;
 
-      queryClient.setQueryData<AppointmentListResponse>(["my-appointments"], (old) => {
-        if (!old) return old;
-        return {
-          ...old,
-          data: old.data.map((a: AppointmentResponse) =>
-            a.id === updated.id ? updated : a,
-          ),
-        };
-      });
-
+      // A lista "Minhas consultas" agora é paginada e filtrada por aba/status
+      // (cache com chave variável), então invalidamos o prefixo em vez de
+      // remendar uma entrada específica. Cancelar move o item entre abas, o que
+      // muda os totais — reconsultar é o caminho correto.
+      void queryClient.invalidateQueries({ queryKey: ["my-appointments"] });
       void queryClient.invalidateQueries({ queryKey: ["appointments"] });
     },
   });

--- a/apps/web/queries/useMedicalRecords.ts
+++ b/apps/web/queries/useMedicalRecords.ts
@@ -11,6 +11,7 @@ export function useSharedMedicalRecordsQuery(params: ListMedicalRecordsParams) {
   return useQuery({
     queryKey: KEYS.shared(params),
     queryFn: () => medicalRecordsService.listShared(params),
+    placeholderData: (previousData) => previousData,
   });
 }
 
@@ -32,6 +33,7 @@ export function useMedicalRecordsListQuery(params: ListMedicalRecordsParams) {
   return useQuery({
     queryKey: KEYS.list(params),
     queryFn: () => medicalRecordsService.list(params),
+    placeholderData: (previousData) => previousData,
   });
 }
 
@@ -41,6 +43,7 @@ export function useMedicalRecordsListForPatientQuery(
   return useQuery({
     queryKey: KEYS.listForPatient(params),
     queryFn: () => medicalRecordsService.listForPatient(params),
+    placeholderData: (previousData) => previousData,
   });
 }
 

--- a/apps/web/queries/useMyAppointmentsQuery.ts
+++ b/apps/web/queries/useMyAppointmentsQuery.ts
@@ -1,15 +1,48 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery } from "@tanstack/react-query";
 import { appointmentsService } from "../services/appointments-service";
 
-export function useMyAppointmentsQuery(params?: {
-  status?: string;
+type MyAppointmentsParams = {
+  status?: string | string[];
   startDate?: string;
   endDate?: string;
   page?: number;
   limit?: number;
-}) {
+};
+
+export function useMyAppointmentsQuery(params?: MyAppointmentsParams) {
   return useQuery({
-    queryKey: ["my-appointments"],
+    queryKey: ["my-appointments", params ?? {}],
     queryFn: () => appointmentsService.listMyAppointments(params),
+    placeholderData: (previousData) => previousData,
   });
+}
+
+/**
+ * Totais por conjunto de status, para os badges das abas. Cada consulta pede
+ * `limit: 1` e lê apenas `meta.total` — barato e cacheado pelo TanStack. Recebe
+ * um mapa `chave -> status[]` e devolve `chave -> total`.
+ */
+export function useMyAppointmentsCounts<K extends string>(
+  statusByKey: Record<K, string[]>,
+) {
+  const entries = Object.entries(statusByKey) as [K, string[]][];
+
+  const results = useQueries({
+    queries: entries.map(([key, status]) => ({
+      queryKey: ["my-appointments-count", key, status],
+      queryFn: () =>
+        appointmentsService.listMyAppointments({ status, page: 1, limit: 1 }),
+      placeholderData: (previous: Awaited<
+        ReturnType<typeof appointmentsService.listMyAppointments>
+      > | undefined) => previous,
+    })),
+  });
+
+  return entries.reduce(
+    (acc, [key], index) => {
+      acc[key] = results[index]?.data?.meta.total ?? 0;
+      return acc;
+    },
+    {} as Record<K, number>,
+  );
 }

--- a/apps/web/services/admin-service.ts
+++ b/apps/web/services/admin-service.ts
@@ -1,6 +1,7 @@
 import { api } from "../lib/api";
 import { AxiosError } from "axios";
 import { API_ROUTES } from "../constants/api-routes";
+import { MAX_PAGE_SIZE, type Paginated } from "../lib/pagination";
 
 export type PatientApprovalStatus = "APPROVED" | "PENDING" | "REJECTED";
 
@@ -49,8 +50,13 @@ const handleError = (error: unknown, fallback: string): never => {
 export const adminService = {
   async listUsers(params?: AdminUsersParams): Promise<AdminUser[]> {
     try {
-      const response = await api.get(API_ROUTES.ADMIN.USERS, { params });
-      return response.data;
+      const response = await api.get(API_ROUTES.ADMIN.USERS, {
+        params: { limit: MAX_PAGE_SIZE, ...params },
+      });
+      // A tabela de usuários filtra/ordena tudo no cliente (busca fuzzy, abas
+      // por role). Desembrulhamos o envelope { data, meta } e devolvemos o array.
+      const payload = response.data as Paginated<AdminUser>;
+      return payload.data;
     } catch (error) {
       return handleError(error, "Erro ao listar usuários.");
     }
@@ -59,9 +65,10 @@ export const adminService = {
   async listProfessionals(): Promise<AdminUser[]> {
     try {
       const response = await api.get(API_ROUTES.ADMIN.USERS, {
-        params: { role: "PROFESSIONAL" },
+        params: { role: "PROFESSIONAL", limit: MAX_PAGE_SIZE },
       });
-      return response.data;
+      const payload = response.data as Paginated<AdminUser>;
+      return payload.data;
     } catch (error) {
       return handleError(error, "Erro ao listar profissionais.");
     }

--- a/apps/web/services/appointments-service.ts
+++ b/apps/web/services/appointments-service.ts
@@ -1,5 +1,6 @@
 import { api } from "../lib/api";
 import { AxiosError } from "axios";
+import type { Paginated } from "../lib/pagination";
 
 export interface CreateAppointmentPatientDto {
   professionalId: string;
@@ -57,12 +58,7 @@ export interface AppointmentResponse {
   };
 }
 
-export interface AppointmentListResponse {
-  data: AppointmentResponse[];
-  page: number;
-  limit: number;
-  total: number;
-}
+export type AppointmentListResponse = Paginated<AppointmentResponse>;
 
 function extractErrorMessage(error: unknown, fallback: string): never {
   if (error instanceof AxiosError && error.response) {
@@ -96,15 +92,23 @@ export const appointmentsService = {
   },
 
   async listMyAppointments(params?: {
-    status?: string;
+    status?: string | string[];
     startDate?: string;
     endDate?: string;
     page?: number;
     limit?: number;
   }) {
     try {
+      // O backend aceita `status` único ou múltiplos separados por vírgula
+      // (?status=PENDING,CONFIRMED). Serializamos array nesse formato.
+      const { status, ...rest } = params ?? {};
       const response = await api.get("/appointments/my-appointments", {
-        params,
+        params: {
+          ...rest,
+          ...(status && {
+            status: Array.isArray(status) ? status.join(",") : status,
+          }),
+        },
       });
       return response.data as AppointmentListResponse;
     } catch (error) {

--- a/apps/web/services/manager-service.ts
+++ b/apps/web/services/manager-service.ts
@@ -1,5 +1,6 @@
 import { api } from "../lib/api";
 import { AxiosError } from "axios";
+import { MAX_PAGE_SIZE, type Paginated } from "../lib/pagination";
 
 export type PatientApprovalStatus = "APPROVED" | "PENDING" | "REJECTED";
 
@@ -68,6 +69,31 @@ export interface ManagerPatientResponse {
     questionnaire?: QuestionnaireSummary | null;
   };
   questionnaire?: QuestionnaireSummary | null;
+}
+
+export interface ManagerProfessionalResponse {
+  id: string;
+  name: string;
+  email: string;
+  status: string;
+  professionalProfile?: {
+    id?: string;
+    specialty?: string;
+    professionalLicense?: string;
+    modality?: string;
+    bio?: string;
+    photoUrl?: string;
+    specialities?: { id: string; name: string }[];
+  } | null;
+  address?: {
+    zipCode?: string | null;
+    street?: string | null;
+    number?: string | null;
+    complement?: string | null;
+    district?: string | null;
+    city?: string | null;
+    state?: string | null;
+  } | null;
 }
 
 export interface CreateAppointmentDto {
@@ -172,9 +198,13 @@ export const managerService = {
 
   async listPatients(): Promise<ManagerPatientResponse[]> {
     try {
-      const response =
-        await api.get<ManagerPatientResponse[]>("/manager/patients");
-      return response.data;
+      const response = await api.get<Paginated<ManagerPatientResponse>>(
+        "/manager/patients",
+        { params: { limit: MAX_PAGE_SIZE } },
+      );
+      // A tela de pacientes (e a home do gestor) filtra/agrega a lista inteira
+      // no cliente, então desembrulhamos o envelope e devolvemos o array.
+      return response.data.data;
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         const message = error.response.data.message;
@@ -213,11 +243,15 @@ export const managerService = {
     params?: ListAppointmentsParams,
   ): Promise<ManagementAppointment[]> {
     try {
-      const response = await api.get<ManagementAppointment[]>(
+      const response = await api.get<Paginated<ManagementAppointment>>(
         "/manager/appointments",
-        { params },
+        // A view (ManagementAppointmentsView) filtra/ordena/agrega a lista
+        // inteira no cliente (busca, filtro por status, stat cards). O sort por
+        // vulnerabilidade é resolvido no servidor via `sortBy`/`order`. Pedimos
+        // o cap de 100 e desembrulhamos o envelope { data, meta }.
+        { params: { limit: MAX_PAGE_SIZE, ...params } },
       );
-      return response.data;
+      return response.data.data;
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         const message = error.response.data.message;
@@ -255,10 +289,17 @@ export const managerService = {
     }
   },
 
-  async listProfessionals() {
+  async listProfessionals(): Promise<ManagerProfessionalResponse[]> {
     try {
-      const response = await api.get("/professional");
-      return response.data;
+      // `/professional` agora é paginado ({ data, meta }). Esta tela filtra por
+      // busca/especialidade/localização no cliente (as opções de localização
+      // derivam do conjunto inteiro), então pedimos o cap de 100 e
+      // desembrulhamos, mantendo a paginação da grade no cliente.
+      const response = await api.get<Paginated<ManagerProfessionalResponse>>(
+        "/professional",
+        { params: { limit: MAX_PAGE_SIZE } },
+      );
+      return response.data.data;
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         const message = error.response.data.message;

--- a/apps/web/services/medical-records-service.ts
+++ b/apps/web/services/medical-records-service.ts
@@ -1,5 +1,6 @@
 import { api } from "../lib/api";
 import { AxiosError } from "axios";
+import { MAX_PAGE_SIZE, type Paginated } from "../lib/pagination";
 
 export interface MedicalRecordAuthor {
   id: string;
@@ -48,12 +49,8 @@ export interface MedicalRecordPatientResponse {
   updatedAt: string;
 }
 
-export interface PaginatedMedicalRecords<T> {
-  data: T[];
-  page: number;
-  limit: number;
-  total: number;
-}
+/** @deprecated Use `Paginated<T>` de `@/lib/pagination`. Mantido como alias. */
+export type PaginatedMedicalRecords<T> = Paginated<T>;
 
 export interface CreateMedicalRecordDto {
   appointmentId: string;
@@ -162,8 +159,13 @@ export const medicalRecordsService = {
 
   async findByPatient(patientId: string): Promise<MedicalRecordResponse[]> {
     try {
-      const response = await api.get(`/medical-records/patient/${patientId}`);
-      return response.data as MedicalRecordResponse[];
+      const response = await api.get(`/medical-records/patient/${patientId}`, {
+        params: { limit: MAX_PAGE_SIZE },
+      });
+      // A API agora responde com envelope { data, meta }. Esta chamada não expõe
+      // paginação na UI, então desembrulhamos e mantemos o array.
+      const payload = response.data as Paginated<MedicalRecordResponse>;
+      return payload.data;
     } catch (error) {
       extractErrorMessage(error, "Erro ao buscar prontuários do paciente.");
     }

--- a/apps/web/services/professional-service.ts
+++ b/apps/web/services/professional-service.ts
@@ -1,5 +1,6 @@
 import { api } from "../lib/api";
 import { AxiosError } from "axios";
+import { MAX_PAGE_SIZE, type Paginated } from "../lib/pagination";
 
 export interface UpdateSettingsPayload {
   modality: string;
@@ -104,8 +105,13 @@ export const professionalService = {
 
   async getPatients(): Promise<PatientProfile[]> {
     try {
-      const response = await api.get("/professional/patients");
-      return response.data;
+      const response = await api.get("/professional/patients", {
+        params: { limit: MAX_PAGE_SIZE },
+      });
+      // A tela filtra a lista inteira no cliente (busca por nome/CPF/telefone),
+      // então desembrulhamos o envelope e devolvemos o array. Cap de 100 na API.
+      const payload = response.data as Paginated<PatientProfile>;
+      return payload.data;
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         throw new Error(
@@ -118,8 +124,19 @@ export const professionalService = {
 
   async getPatientDetail(patientId: string): Promise<PatientDetail> {
     try {
-      const response = await api.get(`/professional/patients/${patientId}`);
-      return response.data;
+      const response = await api.get(`/professional/patients/${patientId}`, {
+        params: { limit: MAX_PAGE_SIZE },
+      });
+      // O `history` virou envelope { data, meta }. A tela de detalhe separa
+      // histórico em "próxima consulta" x "passadas" e conta o total no cliente,
+      // então normalizamos `history` de volta para um array simples aqui.
+      const raw = response.data as Omit<PatientDetail, "history"> & {
+        history: PatientDetail["history"] | Paginated<PatientDetail["history"][number]>;
+      };
+      const history = Array.isArray(raw.history)
+        ? raw.history
+        : raw.history.data;
+      return { ...raw, history };
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         throw new Error(

--- a/apps/web/services/professionals-service.ts
+++ b/apps/web/services/professionals-service.ts
@@ -1,6 +1,7 @@
 import { api } from "../lib/api";
 import { AxiosError } from "axios";
 import { API_ROUTES } from "../constants/api-routes";
+import { MAX_PAGE_SIZE, type Paginated } from "../lib/pagination";
 
 export interface ProfessionalUser {
   id: string;
@@ -29,8 +30,14 @@ export interface ProfessionalUser {
 export const professionalsService = {
   async listAll(): Promise<ProfessionalUser[]> {
     try {
-      const response = await api.get(API_ROUTES.PROFESSIONALS.LIST);
-      return response.data;
+      // `/professional` agora é paginado ({ data, meta }). A busca de médicos do
+      // paciente filtra por busca/especialidade/localização no cliente, então
+      // pedimos o cap de 100 e desembrulhamos o envelope.
+      const response = await api.get<Paginated<ProfessionalUser>>(
+        API_ROUTES.PROFESSIONALS.LIST,
+        { params: { limit: MAX_PAGE_SIZE } },
+      );
+      return response.data.data;
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         const message = error.response.data.message;


### PR DESCRIPTION
## Problema

O PR #221 (frontend de paginação) foi mergeado por engano em `feat/pagination-backend` ao invés de `main`. Como `feat/pagination-backend` já havia sido mergeado em `main` via PR #220 (backend paginado), o frontend correspondente nunca chegou à produção.

Resultado: o backend em produção passou a responder listagens com o envelope `{ data, meta }`, mas o frontend em produção (build anterior a #221) ainda esperava arrays crus — causando `TypeError: X.filter is not a function` e falhas de spread em todas as roles (paciente, profissional, gestor, admin).

## Fix

Este PR traz para `main` exatamente o conteúdo do PR #221 (frontend). O diff de backend entre `main` e `feat/pagination-backend` é vazio — apenas os arquivos de frontend estão inclusos.

## Test plan

- [x] Confirmado `git diff origin/main origin/feat/pagination-backend -- apps/server/` vazio (sem drift de backend)
- [ ] Validar localmente que as telas afetadas (usuários admin, agendamentos/pacientes gestor, prontuários paciente/profissional, solicitações pendentes, busca de profissionais, consultas do paciente) carregam corretamente com o backend paginado
- [ ] Após merge, verificar deploy Vercel e testar as 4 roles em produção