### PR TITLE
feat(patient): paginação server-side na busca de médicos

### DIFF
--- a/apps/server/src/professional/dto/list-professionals-query.dto.ts
+++ b/apps/server/src/professional/dto/list-professionals-query.dto.ts
@@ -1,0 +1,29 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+
+export class ListProfessionalsQueryDto extends PaginationQueryDto {
+  @ApiPropertyOptional({
+    description: 'Busca textual por nome do profissional ou especialidade',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filtrar por nome de especialidade (match exato)',
+  })
+  @IsOptional()
+  @IsString()
+  speciality?: string;
+
+  @ApiPropertyOptional({ description: 'Filtrar por cidade (match exato)' })
+  @IsOptional()
+  @IsString()
+  city?: string;
+
+  @ApiPropertyOptional({ description: 'Filtrar por estado/UF (match exato)' })
+  @IsOptional()
+  @IsString()
+  state?: string;
+}

--- a/apps/server/src/professional/professional.controller.ts
+++ b/apps/server/src/professional/professional.controller.ts
@@ -26,6 +26,7 @@ import { ProfessionalRoleGuard } from './guards/professional-role.guard';
 import { EmailVerifiedGuard } from '../auth/guards/email-verified.guard';
 import { QuestionnaireCompletionGuard } from '../questionnaire/questionnaire-completion.guard';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { ListProfessionalsQueryDto } from './dto/list-professionals-query.dto';
 
 @ApiTags('Professional')
 @ApiBearerAuth('access-token')
@@ -39,8 +40,20 @@ export class ProfessionalController {
   @ApiOperation({ summary: 'Listar todos os profissionais (paginado)' })
   @ApiResponse({ status: 200, description: 'Lista de profissionais.' })
   @ApiResponse({ status: 401, description: 'Não autenticado.' })
-  listAll(@Query() query: PaginationQueryDto) {
+  listAll(@Query() query: ListProfessionalsQueryDto) {
     return this.professionalService.listAll(query);
+  }
+
+  @Get('locations')
+  @UseGuards(AuthGuard('jwt'), EmailVerifiedGuard)
+  @ApiOperation({
+    summary: 'Listar cidades/estados distintos entre os profissionais visíveis',
+    description:
+      'Usado para popular o filtro de localização na busca de profissionais.',
+  })
+  @ApiResponse({ status: 200, description: 'Lista de cidade/estado.' })
+  listLocations() {
+    return this.professionalService.listLocations();
   }
 
   @Get('settings')

--- a/apps/server/src/professional/professional.repository.ts
+++ b/apps/server/src/professional/professional.repository.ts
@@ -1,8 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { AppointmentStatus, Prisma } from '@prisma/client';
+import { AppointmentStatus, Prisma, UserRole, UserStatus } from '@prisma/client';
 import { CreateScheduleBlockDto } from './dto/schedule-block.dto';
 import { UpdateProfessionalSettingsDto } from './dto/update-setting.dto';
+import { ListProfessionalsQueryDto } from './dto/list-professionals-query.dto';
 import { PrismaService } from '../prisma/prisma.service';
+import { paginate } from '../common/dto/paginated-response.dto';
 
 @Injectable()
 export class ProfessionalRepository {
@@ -185,31 +187,80 @@ export class ProfessionalRepository {
     return { appointments, total };
   }
 
-  async listAllProfessionals(page: number, limit: number) {
-    const where = { role: 'PROFESSIONAL' as const };
-    const select = {
-      id: true,
-      name: true,
-      email: true,
-      status: true,
-      professionalProfile: {
-        include: { specialities: true },
-      },
-      address: true,
+  /**
+   * Lista profissionais visíveis para pacientes (exclui PENDING/BLOCKED, que
+   * ainda não foram aprovados ou foram bloqueados) com busca/filtros
+   * server-side, evitando trazer a base inteira para filtrar no cliente.
+   */
+  listAllProfessionals(query: ListProfessionalsQueryDto) {
+    const { page, limit, search, speciality, city, state } = query;
+
+    const where: Prisma.UserWhereInput = {
+      role: UserRole.PROFESSIONAL,
+      status: { notIn: [UserStatus.PENDING, UserStatus.BLOCKED] },
+      ...(search && {
+        OR: [
+          { name: { contains: search, mode: 'insensitive' } },
+          {
+            professionalProfile: {
+              specialities: {
+                some: { name: { contains: search, mode: 'insensitive' } },
+              },
+            },
+          },
+        ],
+      }),
+      ...(speciality && {
+        professionalProfile: {
+          specialities: { some: { name: { equals: speciality, mode: 'insensitive' } } },
+        },
+      }),
+      ...((city || state) && {
+        address: {
+          is: {
+            ...(city && { city: { equals: city, mode: 'insensitive' } }),
+            ...(state && { state: { equals: state, mode: 'insensitive' } }),
+          },
+        },
+      }),
     };
 
-    const [data, total] = await Promise.all([
-      this.prisma.user.findMany({
+    return paginate(
+      this.prisma.user,
+      {
         where,
-        select,
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          status: true,
+          professionalProfile: {
+            include: { specialities: true },
+          },
+          address: true,
+        },
         orderBy: { name: 'asc' },
-        skip: (page - 1) * limit,
-        take: limit,
-      }),
-      this.prisma.user.count({ where }),
-    ]);
+      },
+      page,
+      limit,
+    );
+  }
 
-    return { data, total };
+  /** Combinações distintas de cidade/estado entre profissionais visíveis, para o filtro de localização. */
+  async listDistinctProfessionalLocations() {
+    const rows = await this.prisma.address.findMany({
+      where: {
+        user: {
+          role: UserRole.PROFESSIONAL,
+          status: { notIn: [UserStatus.PENDING, UserStatus.BLOCKED] },
+        },
+      },
+      select: { city: true, state: true },
+      distinct: ['city', 'state'],
+      orderBy: [{ state: 'asc' }, { city: 'asc' }],
+    });
+
+    return rows;
   }
 
   updateSettings(userId: string, dto: UpdateProfessionalSettingsDto) {

--- a/apps/server/src/professional/professional.service.ts
+++ b/apps/server/src/professional/professional.service.ts
@@ -13,6 +13,7 @@ import { MEET_SERVICE } from '../common/interfaces/MeetEventInterfaces';
 import type { MeetService } from '../common/interfaces/MeetEventInterfaces';
 import { APPOINTMENT_DURATION_MINUTES } from '../appointments/appointment.constants';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { ListProfessionalsQueryDto } from './dto/list-professionals-query.dto';
 import { buildMeta } from '../common/dto/paginated-response.dto';
 
 @Injectable()
@@ -206,13 +207,13 @@ export class ProfessionalService {
     };
   }
 
-  async listAll(query: PaginationQueryDto) {
-    const { page, limit } = query;
-    const { data, total } = await this.repository.listAllProfessionals(
-      page,
-      limit,
-    );
-    return { data, meta: buildMeta(total, page, limit) };
+  listAll(query: ListProfessionalsQueryDto) {
+    return this.repository.listAllProfessionals(query);
+  }
+
+  async listLocations() {
+    const rows = await this.repository.listDistinctProfessionalLocations();
+    return rows.map((row) => ({ city: row.city, state: row.state }));
   }
 
   async updateSettings(userId: string, dto: UpdateProfessionalSettingsDto) {

--- a/apps/web/app/dashboard/patient/search/components/locationFilters.ts
+++ b/apps/web/app/dashboard/patient/search/components/locationFilters.ts
@@ -13,15 +13,36 @@ export type LocationOption = {
 export const getLocationValue = (location: LocationOption) =>
   `${location.city} - ${location.state}`;
 
+export const parseLocationValue = (value: string): LocationOption | null => {
+  const [city, state] = value.split(" - ");
+  if (!city || !state) return null;
+  return { city, state };
+};
+
+export const sortLocations = (locations: LocationOption[]) =>
+  [...locations].sort((a, b) => {
+    const stateComparison = a.state.localeCompare(b.state, "pt-BR");
+    if (stateComparison !== 0) return stateComparison;
+    return a.city.localeCompare(b.city, "pt-BR");
+  });
+
+/**
+ * Deriva as combinações distintas de cidade/estado a partir de uma lista de
+ * profissionais já carregada no cliente. Usado por telas que ainda buscam o
+ * array completo (ex.: novo agendamento do gestor). A busca de médicos do
+ * paciente usa `professionalsService.listLocations()` (server-side) em vez
+ * desta função.
+ */
 export const getAvailableLocations = (
   professionals: ProfessionalWithLocation[],
 ) => {
   const locationsByKey = new Map<string, LocationOption>();
 
   professionals
-    .filter((professional) => (
-      professional.status !== "PENDING" && professional.status !== "BLOCKED"
-    ))
+    .filter(
+      (professional) =>
+        professional.status !== "PENDING" && professional.status !== "BLOCKED",
+    )
     .forEach((professional) => {
       const city = professional.address?.city?.trim();
       const state = professional.address?.state?.trim();
@@ -32,11 +53,5 @@ export const getAvailableLocations = (
       locationsByKey.set(key, { city, state });
     });
 
-  return Array.from(locationsByKey.values()).sort((a, b) => {
-    const stateComparison = a.state.localeCompare(b.state, "pt-BR");
-
-    if (stateComparison !== 0) return stateComparison;
-
-    return a.city.localeCompare(b.city, "pt-BR");
-  });
+  return sortLocations(Array.from(locationsByKey.values()));
 };

--- a/apps/web/app/dashboard/patient/search/page.tsx
+++ b/apps/web/app/dashboard/patient/search/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import { CardGridSkeleton } from "@/components/ui/skeletons";
-import { professionalsService } from "../../../../services/professionals-service";
-import { toast } from "sonner";
+import { DataTablePageSizeSelector, DataTablePagination } from "@/components/ui/data-table";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useServerPagination } from "@/hooks/useServerPagination";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import {
+  usePatientSearchProfessionalsQuery,
+  useProfessionalLocationsQuery,
+} from "@/queries/usePatientSearchProfessionalsQuery";
 import { SearchBar } from "./components/SearchBar";
 import { DoctorCard } from "./components/DoctorCard";
 import { EmptySearch } from "./components/EmptySearch";
@@ -14,7 +19,7 @@ import {
 } from "./components/SeeProfileModal";
 import { BookingModal } from "./components/BookingModal";
 import { AddressData } from "./components/addressMaps";
-import { getAvailableLocations, getLocationValue } from "./components/locationFilters";
+import { parseLocationValue } from "./components/locationFilters";
 import { PageShell, PageHeader } from "../../../ui/dashboard/page-shell";
 import { TourButton } from "@/components/tour/TourButton";
 
@@ -36,8 +41,7 @@ type Professional = {
 
 const SearchDoctorsPage = () => {
   const isMobile = useIsMobile();
-  const [professionals, setProfessionals] = useState<Professional[]>([]);
-  const [search, setSearch] = useState("");
+  const [searchInput, setSearchInput] = useState("");
   const [selectedSpecialty, setSelectedSpecialty] = useState("Todas");
   const [selectedLocation, setSelectedLocation] = useState("Todas");
 
@@ -45,57 +49,44 @@ const SearchDoctorsPage = () => {
     useState<Professional | null>(null);
   const [bookingProfessional, setBookingProfessional] =
     useState<Professional | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        setIsLoading(true);
-        const data = await professionalsService.listAll();
-        setProfessionals(data);
-      } catch {
-        toast.error("Erro ao carregar profissionais.");
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    load();
-  }, []);
+  const search = useDebouncedValue(searchInput, 400);
+  const { page, pageSize, setPage, setPageSize, getPaginationProps } =
+    useServerPagination({ initialPageSize: 10 });
 
-  const visibleProfessionals = professionals.filter(
-    (p) => p.status !== "PENDING" && p.status !== "BLOCKED",
-  );
-  const locations = useMemo(
-    () => getAvailableLocations(professionals),
-    [professionals],
-  );
+  const selectedLocationOption =
+    selectedLocation === "Todas" ? null : parseLocationValue(selectedLocation);
 
-  const filtered = visibleProfessionals
-    .filter((p) => {
-      const term = search.toLowerCase();
-      const matchesSearch =
-        p.name.toLowerCase().includes(term) ||
-        (p.professionalProfile?.specialities?.[0]?.name || "")
-          .toLowerCase()
-          .includes(term);
+  const { data, isLoading, isFetching } = usePatientSearchProfessionalsQuery({
+    page,
+    limit: pageSize,
+    ...(search && { search }),
+    ...(selectedSpecialty !== "Todas" && { speciality: selectedSpecialty }),
+    ...(selectedLocationOption && {
+      city: selectedLocationOption.city,
+      state: selectedLocationOption.state,
+    }),
+  });
 
-      const matchesSpecialty =
-        selectedSpecialty === "Todas" ||
-        (p.professionalProfile?.specialities?.[0]?.name || "")
-          .toLowerCase()
-          .includes(selectedSpecialty.toLowerCase());
+  const { data: locations = [] } = useProfessionalLocationsQuery();
 
-      const matchesLocation =
-        selectedLocation === "Todas" ||
-        (p.address?.city && p.address?.state
-          ? getLocationValue({
-              city: p.address.city.trim(),
-              state: p.address.state.trim(),
-            }) === selectedLocation
-          : false);
+  const professionals = data?.data ?? [];
+  const total = data?.meta.total ?? 0;
 
-      return matchesSearch && matchesSpecialty && matchesLocation;
-    });
+  function handleSearchChange(value: string) {
+    setSearchInput(value);
+    setPage(1);
+  }
+
+  function handleSpecialtyChange(value: string) {
+    setSelectedSpecialty(value);
+    setPage(1);
+  }
+
+  function handleLocationChange(value: string) {
+    setSelectedLocation(value);
+    setPage(1);
+  }
 
   return (
     <PageShell>
@@ -110,28 +101,34 @@ const SearchDoctorsPage = () => {
         title="Pesquisar e filtrar médicos por nome, especialidade ou localização"
       >
         <SearchBar
-          search={search}
+          search={searchInput}
           selectedSpecialty={selectedSpecialty}
           selectedLocation={selectedLocation}
           locations={locations}
-          resultsCount={filtered.length}
+          resultsCount={total}
           isLoading={isLoading}
-          onSearchChange={setSearch}
-          onSpecialtyChange={setSelectedSpecialty}
-          onLocationChange={setSelectedLocation}
+          onSearchChange={handleSearchChange}
+          onSpecialtyChange={handleSpecialtyChange}
+          onLocationChange={handleLocationChange}
         />
+        <div className="mb-4 flex justify-end">
+          <DataTablePageSizeSelector
+            pageSize={pageSize}
+            onPageSizeChange={setPageSize}
+          />
+        </div>
       </div>
 
       <div id="tour-search-results">
         {isLoading ? (
           <CardGridSkeleton count={6} minWidth={360} />
-        ) : filtered.length === 0 ? (
+        ) : professionals.length === 0 ? (
           <EmptySearch />
         ) : (
           <div
             className={`grid gap-4 ${isMobile ? "grid-cols-1" : "grid-cols-1 lg:grid-cols-2"}`}
           >
-            {filtered.map((prof) => (
+            {professionals.map((prof) => (
               <div
                 key={prof.id}
                 title={`Visualizar perfil ou agendar com ${prof.name}`}
@@ -145,6 +142,12 @@ const SearchDoctorsPage = () => {
             ))}
           </div>
         )}
+
+        <DataTablePagination
+          {...getPaginationProps(data?.meta)}
+          busy={isFetching}
+          itemLabel="profissionais"
+        />
       </div>
 
       <SeeProfileModal

--- a/apps/web/constants/api-routes.ts
+++ b/apps/web/constants/api-routes.ts
@@ -25,6 +25,7 @@ export const API_ROUTES = {
   },
   PROFESSIONALS: {
     LIST: "/professional",
+    LOCATIONS: "/professional/locations",
     SETTINGS: "/professional/settings",
     SCHEDULE: "/professional/schedule",
   },

--- a/apps/web/hooks/useDebouncedValue.ts
+++ b/apps/web/hooks/useDebouncedValue.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "react";
+
+/** Atrasa a propagação de `value` em `delayMs`, reiniciando o timer a cada mudança. */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/apps/web/queries/usePatientSearchProfessionalsQuery.ts
+++ b/apps/web/queries/usePatientSearchProfessionalsQuery.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  professionalsService,
+  ListProfessionalsParams,
+} from "@/services/professionals-service";
+
+export function usePatientSearchProfessionalsQuery(
+  params: ListProfessionalsParams,
+) {
+  return useQuery({
+    queryKey: ["patient-search-professionals", params],
+    queryFn: () => professionalsService.list(params),
+    placeholderData: (previousData) => previousData,
+  });
+}
+
+export function useProfessionalLocationsQuery() {
+  return useQuery({
+    queryKey: ["professional-locations"],
+    queryFn: () => professionalsService.listLocations(),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/apps/web/services/professionals-service.ts
+++ b/apps/web/services/professionals-service.ts
@@ -27,25 +27,67 @@ export interface ProfessionalUser {
   } | null;
 }
 
+export interface ProfessionalLocation {
+  city: string;
+  state: string;
+}
+
+export interface ListProfessionalsParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+  speciality?: string;
+  city?: string;
+  state?: string;
+}
+
+function extractErrorMessage(error: unknown, fallback: string): never {
+  if (error instanceof AxiosError && error.response) {
+    const message = error.response.data.message;
+    throw new Error(
+      Array.isArray(message) ? message.join(", ") : message || fallback,
+    );
+  }
+  throw new Error("Erro de conexão com o servidor.");
+}
+
 export const professionalsService = {
+  /** Lista paginada de profissionais visíveis (exclui PENDING/BLOCKED), com busca/filtros server-side. */
+  async list(
+    params: ListProfessionalsParams = {},
+  ): Promise<Paginated<ProfessionalUser>> {
+    try {
+      const response = await api.get<Paginated<ProfessionalUser>>(
+        API_ROUTES.PROFESSIONALS.LIST,
+        { params },
+      );
+      return response.data;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao listar profissionais.");
+    }
+  },
+
+  /** @deprecated Use `list()` com paginação. Mantido para telas que ainda precisam do array completo. */
   async listAll(): Promise<ProfessionalUser[]> {
     try {
-      // `/professional` agora é paginado ({ data, meta }). A busca de médicos do
-      // paciente filtra por busca/especialidade/localização no cliente, então
-      // pedimos o cap de 100 e desembrulhamos o envelope.
       const response = await api.get<Paginated<ProfessionalUser>>(
         API_ROUTES.PROFESSIONALS.LIST,
         { params: { limit: MAX_PAGE_SIZE } },
       );
       return response.data.data;
     } catch (error) {
-      if (error instanceof AxiosError && error.response) {
-        const message = error.response.data.message;
-        throw new Error(
-          Array.isArray(message) ? message.join(", ") : message || "Erro ao listar profissionais.",
-        );
-      }
-      throw new Error("Erro de conexão com o servidor.");
+      extractErrorMessage(error, "Erro ao listar profissionais.");
+    }
+  },
+
+  async listLocations(): Promise<ProfessionalLocation[]> {
+    try {
+      const response = await api.get<ProfessionalLocation[]>(
+        API_ROUTES.PROFESSIONALS.LOCATIONS,
+      );
+      return response.data;
+    } catch (error) {
+      extractErrorMessage(error, "Erro ao listar localizações.");
     }
   },
 };


### PR DESCRIPTION
## Resumo

- A busca de médicos do paciente (`/dashboard/patient/search`) carregava até 100 profissionais de uma vez e filtrava tudo (nome, especialidade, localização) no cliente, sem paginação — ficava extenso com muitos médicos cadastrados
- `GET /professional` passa a aceitar `search`, `speciality`, `city`, `state` além de `page`/`limit`, filtrando via Prisma no backend
- Novo endpoint `GET /professional/locations` retorna as combinações distintas de cidade/UF entre profissionais visíveis, para popular o filtro de localização sem precisar da lista completa
- Frontend reescrito para usar `useServerPagination` + `DataTablePagination` (mesmo padrão das telas já migradas em #221), com debounce de 400ms na busca textual

Closes #223

## Test plan

- [x] `tsc --noEmit` limpo (server e web)
- [x] `npx jest professional` — 13 testes passando
- [x] `next build` completo sem erros
- [ ] Validar manualmente: busca por nome/especialidade, filtro de localização, paginação (anterior/próxima, itens por página) na tela `/dashboard/patient/search`
- [ ] Confirmar que profissionais PENDING/BLOCKED continuam ocultos da busca do paciente